### PR TITLE
fix: implement /api/providers endpoints for settings persistence

### DIFF
--- a/src/server/routes/provider-routes.ts
+++ b/src/server/routes/provider-routes.ts
@@ -1,0 +1,100 @@
+/**
+ * Provider REST API routes: read/write custom LLM providers (~/.pi/agent/providers.json).
+ */
+import type { FastifyInstance } from "fastify";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+import { localhostGuard } from "../localhost-guard.js";
+
+const REDACTED = "***";
+const CONFIG_PATH = join(homedir(), ".pi", "agent", "providers.json");
+
+interface ProviderEntry {
+  baseUrl: string;
+  apiKey: string;
+  api?: string;
+}
+
+function readProvidersRaw(): Record<string, ProviderEntry> {
+  if (!existsSync(CONFIG_PATH)) return {};
+  try {
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    return raw.providers ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function redactProviders(
+  providers: Record<string, ProviderEntry>,
+): Record<string, ProviderEntry> {
+  const redacted: Record<string, ProviderEntry> = {};
+  for (const [name, entry] of Object.entries(providers)) {
+    redacted[name] = {
+      ...entry,
+      apiKey:
+        entry.apiKey && entry.apiKey.startsWith("$")
+          ? entry.apiKey
+          : entry.apiKey
+            ? REDACTED
+            : "",
+    };
+  }
+  return redacted;
+}
+
+export function registerProviderRoutes(fastify: FastifyInstance): void {
+  fastify.get(
+    "/api/providers",
+    { preHandler: localhostGuard },
+    async () => {
+      const providers = readProvidersRaw();
+      return { success: true, providers: redactProviders(providers) };
+    },
+  );
+
+  fastify.put(
+    "/api/providers",
+    { preHandler: localhostGuard },
+    async (request, reply) => {
+      const body = request.body as Record<string, any> | null;
+      if (!body || typeof body !== "object" || !body.providers || typeof body.providers !== "object") {
+        return reply.code(400).send({ success: false, error: "Invalid body" });
+      }
+
+      const incoming = body.providers as Record<string, ProviderEntry>;
+      const existing = readProvidersRaw();
+
+      // Merge: preserve redacted apiKey values from existing file
+      const merged: Record<string, ProviderEntry> = {};
+      for (const [name, entry] of Object.entries(incoming)) {
+        merged[name] = {
+          baseUrl: entry.baseUrl,
+          apiKey:
+            entry.apiKey === REDACTED && existing[name]
+              ? existing[name].apiKey
+              : entry.apiKey,
+          api: entry.api,
+        };
+      }
+
+      // Read raw file to preserve any non-providers fields
+      let fileData: Record<string, any> = {};
+      if (existsSync(CONFIG_PATH)) {
+        try {
+          fileData = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+        } catch {
+          // start fresh
+        }
+      }
+      fileData.providers = merged;
+
+      const dir = dirname(CONFIG_PATH);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(CONFIG_PATH, JSON.stringify(fileData, null, 2) + "\n", "utf-8");
+
+      return { success: true };
+    },
+  );
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -36,6 +36,7 @@ import { registerOpenSpecRoutes } from "./routes/openspec-routes.js";
 import { registerSystemRoutes } from "./routes/system-routes.js";
 import { registerProviderAuthRoutes } from "./routes/provider-auth-routes.js";
 import { registerPackageRoutes } from "./routes/package-routes.js";
+import { registerProviderRoutes } from "./routes/provider-routes.js";
 import { PackageManagerWrapper } from "./package-manager-wrapper.js";
 import { createEditorManager, type EditorManager } from "./editor-manager.js";
 import { registerEditorRoutes } from "./routes/editor-routes.js";
@@ -271,6 +272,7 @@ export async function createServer(config: ServerConfig): Promise<DashboardServe
   registerEditorProxy(fastify, editorManager);
 
   registerProviderAuthRoutes(fastify, { piGateway });
+  registerProviderRoutes(fastify);
 
   // Serve static files / SPA fallback
   const __dirname = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
The Settings UI already has a working LLM Providers section that calls GET/PUT /api/providers, but no server routes handled these requests. The GET silently 404'd and the PUT failed on save, so any provider added through the UI was lost on reload.