### PR TITLE
fix settings tab pointer cursor

### DIFF
--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -332,7 +332,7 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
           <button
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
-            className={`px-4 py-2 text-sm font-medium transition-colors relative ${
+            className={`px-4 py-2 text-sm font-medium transition-colors relative cursor-pointer ${
               activeTab === tab.id
                 ? "text-[var(--text-primary)]"
                 : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"

--- a/packages/client/src/components/__tests__/SettingsPanel.test.tsx
+++ b/packages/client/src/components/__tests__/SettingsPanel.test.tsx
@@ -111,6 +111,21 @@ describe("SettingsPanel", () => {
     expect(screen.getByText("Server")).toBeTruthy();
   });
 
+  it("should show pointer cursor on settings tabs", async () => {
+    global.fetch = mockFetchConfig();
+
+    render(<SettingsPanel />);
+
+    await waitFor(() => screen.getByText("Settings"));
+
+    expect(screen.getByRole("button", { name: "General" }).className).toContain("cursor-pointer");
+    expect(screen.getByRole("button", { name: "Servers" }).className).toContain("cursor-pointer");
+    expect(screen.getByRole("button", { name: "Packages" }).className).toContain("cursor-pointer");
+    expect(screen.getByRole("button", { name: "Providers" }).className).toContain("cursor-pointer");
+    expect(screen.getByRole("button", { name: "Security" }).className).toContain("cursor-pointer");
+    expect(screen.getByRole("button", { name: "Advanced" }).className).toContain("cursor-pointer");
+  });
+
   it("should show loading state initially", () => {
     global.fetch = vi.fn().mockReturnValue(new Promise(() => {})); // never resolves
     render(<SettingsPanel />);


### PR DESCRIPTION
## Summary
- add pointer cursor styling to Settings tab buttons
- add regression coverage for all Settings tabs

## Validation
- npm test -- SettingsPanel