### PR TITLE
docs(specs): document configurable ask_user prompt timeout

### DIFF
--- a/openspec/specs/ask-user-tool/spec.md
+++ b/openspec/specs/ask-user-tool/spec.md
@@ -234,6 +234,40 @@ This aligns with the pi 0.69.0+ TypeBox 1.x migration. pi-coding-agent still ali
 - **AND** schema validation SHALL continue to flow through pi's tool-argument validator
 
 
+### Requirement: Configurable PromptBus timeout for ask_user
+The bridge's PromptBus SHALL accept a `timeoutMs` option that controls how long a `request(...)` waits before auto-cancelling. The bridge extension's `session_start` handler SHALL pass `timeoutMs = config.askUserPromptTimeoutSeconds * 1000` when `askUserPromptTimeoutSeconds > 0`, and SHALL pass a value `<= 0` when `askUserPromptTimeoutSeconds <= 0` so the bus skips the cancellation timer entirely. With no timer scheduled, the request SHALL remain pending until either the user answers, the session ends, or another adapter explicitly responds.
+
+The PromptBus implementation SHALL NOT call `setTimeout(...)` when the resolved `timeoutMs <= 0`. Equivalently, the per-request `timer` field SHALL be `null` (or otherwise non-firing) for infinite-wait requests, and any cleanup paths that `clearTimeout(...)` SHALL tolerate the null-timer case.
+
+This applies uniformly to every PromptBus-routed prompt method (`select`, `input`, `confirm`, `multiselect`, `editor`), not just `ask_user`. The `ask_user` tool itself does not branch on the config — it simply calls the bridge-patched `ctx.ui.*` wrappers, which inherit the bus-level timeout configured at `session_start`.
+
+#### Scenario: Default timeout fires after 300 s
+- **GIVEN** `config.askUserPromptTimeoutSeconds` is 300 (default) and an `ask_user` prompt is dispatched
+- **WHEN** 300 s elapse without any adapter responding
+- **THEN** the PromptBus SHALL invoke its cancellation path, every adapter's `dismiss(id)` SHALL be called, and the awaiting `request(...)` promise SHALL resolve with `{ cancelled: true }`
+
+#### Scenario: Custom positive timeout is honored
+- **GIVEN** `config.askUserPromptTimeoutSeconds = 60` at session start
+- **WHEN** an `ask_user` prompt is dispatched
+- **THEN** the PromptBus SHALL schedule the cancellation timer for 60_000 ms (= `60 * 1000`)
+
+#### Scenario: -1 disables the cancellation timer (infinite wait)
+- **GIVEN** `config.askUserPromptTimeoutSeconds = -1`
+- **WHEN** an `ask_user` prompt is dispatched
+- **THEN** the PromptBus SHALL NOT call `setTimeout(...)` for cancellation
+- **AND** the request SHALL remain pending indefinitely until a user response, session end, or explicit cross-adapter dismissal arrives
+
+#### Scenario: 0 also disables the cancellation timer
+- **GIVEN** `config.askUserPromptTimeoutSeconds = 0`
+- **WHEN** an `ask_user` prompt is dispatched
+- **THEN** the PromptBus SHALL behave identically to the `-1` case (no `setTimeout`, infinite wait)
+
+#### Scenario: Timeout applies to all PromptBus methods, not just ask_user
+- **GIVEN** `config.askUserPromptTimeoutSeconds = 60`
+- **WHEN** the bridge invokes any of `ctx.ui.select`, `ctx.ui.input`, `ctx.ui.confirm`, `ctx.ui.multiselect`, or `ctx.ui.editor` (each of which is patched at `session_start` to route through PromptBus)
+- **THEN** the underlying PromptBus `request(...)` SHALL inherit the same 60_000 ms timeout
+- **AND** an in-flight request from any of these methods SHALL auto-cancel after 60 s with `{ cancelled: true }` if no adapter responds first
+
 ### Requirement: prepareArguments preserves empty-args rejection
 The `ask_user` tool's `prepareArguments` rescue layer SHALL NOT synthesize a `method`, `title`, or `questions` field when the input is an empty object `{}`. The framework's runtime schema validator MUST continue to reject empty-args invocations so the model is forced to retry with valid arguments. The rescue layer's existing transformations (unwrap `params`, rename `question` → `title`, parse stringified `options`, synthesize `method: "batch"` from a non-empty `questions` array, normalize `[{label,value}]` → `[label]`, etc.) all require at least one input field to fire and SHALL remain no-ops on `{}`.
 

--- a/openspec/specs/settings-panel/spec.md
+++ b/openspec/specs/settings-panel/spec.md
@@ -15,7 +15,7 @@ The sidebar header SHALL include a gear icon button positioned at the end of the
 The settings panel SHALL render as a full-page view in the main content area when the route is `/settings`. It SHALL display a fixed header (back button, title, Restart and Save buttons), a tab bar, and a scrollable content area for the active tab. The header and tab bar SHALL remain visible at all times regardless of scroll position.
 
 The panel SHALL provide 4 tabs:
-- **General**: Server (`port`, `piPort`, `autoShutdown`, `shutdownIdleSeconds`), Sessions (`spawnStrategy`), Tunnel (`tunnel.enabled`), Developer (`devBuildOnReload`)
+- **General**: Server (`port`, `piPort`, `autoShutdown`, `shutdownIdleSeconds`), Sessions (`spawnStrategy`, `reattachPlacement`, `askUserPromptTimeoutSeconds`, `defaultModel`), Tunnel (`tunnel.enabled`), Developer (`devBuildOnReload`)
 - **Providers**: Provider Authentication (ProviderAuthSection) and LLM Providers (custom OpenAI-compatible endpoints)
 - **Security**: OAuth dashboard access (`auth.providers` per-provider config, `auth.allowedUsers`, `auth.bypassUrls`), and **Trusted Networks** (the combined trusted-host/network bypass control that writes to `auth.bypassHosts`)
 - **Advanced**: Memory Limits (`memoryLimits.maxEventsPerSession`, `memoryLimits.maxStringFieldSize`, `memoryLimits.maxWsBufferBytes`)
@@ -215,6 +215,39 @@ When LLM providers are saved via the Settings panel, the server SHALL broadcast 
 - **WHEN** the user saves provider changes and opens the Default Model selector
 - **THEN** models from all configured providers are listed
 - **AND** no server restart is required
+
+### Requirement: ask_user prompt timeout field in Sessions section
+The Settings panel's General → Sessions section SHALL include a numeric input bound to `config.askUserPromptTimeoutSeconds`. The field SHALL accept negative integers so users can enter `-1` to disable the timeout. The control SHALL display a hint text immediately below it explaining: (a) the value is in seconds, (b) `-1` (or `0`) means “wait forever”, and (c) the default is 300 (5 minutes).
+
+When the user changes this field, the Settings panel SHALL include `askUserPromptTimeoutSeconds` in the partial sent to `PUT /api/config`. If the user clears the field (the resulting input value is undefined / NaN), the partial SHALL fall back to the default `300` rather than silently writing `0`.
+
+The server's `writeConfigPartial` SHALL persist the value verbatim through its existing top-level scalar merge (`{ ...existing, ...partial }`); no auth-section-style special handling is required. A subsequent `GET /api/config` SHALL return the persisted value with no redaction.
+
+Changing this field SHALL NOT mark the save as restart-requiring — the bridge re-reads `config.askUserPromptTimeoutSeconds` on every `session_start`, so the new timeout takes effect on the next pi session reload (`/reload`) without a server restart.
+
+#### Scenario: Field is rendered with current value
+- **WHEN** the user opens `/settings` with `askUserPromptTimeoutSeconds: 600` on disk
+- **THEN** the General → Sessions section SHALL show a numeric input populated with `600`
+- **AND** the hint text below SHALL mention the `-1` / `0` infinite-wait semantics and the 300 s default
+
+#### Scenario: User saves a custom positive value
+- **WHEN** the user changes the field from `300` to `120` and clicks Save
+- **THEN** the panel SHALL `PUT /api/config` with `{ "askUserPromptTimeoutSeconds": 120 }` in the partial
+- **AND** the persisted `~/.pi/dashboard/config.json` SHALL contain `askUserPromptTimeoutSeconds: 120`
+
+#### Scenario: User saves -1 for infinite wait
+- **WHEN** the user enters `-1` and clicks Save
+- **THEN** the panel SHALL `PUT /api/config` with `{ "askUserPromptTimeoutSeconds": -1 }`
+- **AND** the persisted config SHALL contain `askUserPromptTimeoutSeconds: -1` (the negative value MUST NOT be coerced or rejected by the client-side diff)
+
+#### Scenario: Empty-field fallback
+- **WHEN** the user clears the input (browser yields NaN/undefined) and clicks Save
+- **THEN** the partial SHALL contain `askUserPromptTimeoutSeconds: 300` (the default), not `0`
+
+#### Scenario: Save does not require restart
+- **WHEN** only `askUserPromptTimeoutSeconds` changes and the user clicks Save
+- **THEN** the `PUT /api/config` response SHALL have `restartRequired: false`
+- **AND** the panel SHALL NOT show the “Restart needed” banner
 
 ### Requirement: Config write persists auth.bypassHosts and auth.bypassUrls
 The `PUT /api/config` endpoint SHALL persist `auth.bypassHosts` and `auth.bypassUrls` from the incoming partial to `~/.pi/dashboard/config.json`. The auth-section merge in `writeConfigPartial` SHALL propagate these fields using the same conditional-copy pattern already used for `allowedUsers`: when `partial.auth.bypassHosts !== undefined`, the persisted `auth.bypassHosts` SHALL equal the incoming value (including the empty array, which SHALL clear all entries); when `partial.auth.bypassHosts` is absent, the existing persisted value SHALL be preserved. The same behaviour SHALL apply to `auth.bypassUrls`.

--- a/openspec/specs/shared-config/spec.md
+++ b/openspec/specs/shared-config/spec.md
@@ -128,3 +128,40 @@ Invalid values (anything outside the union) SHALL fall back to the default `"alw
 #### Scenario: ensureConfig excludes reattachPlacement
 - **WHEN** `ensureConfig()` creates a new config file
 - **THEN** it SHALL NOT include `reattachPlacement` in the written defaults
+
+### Requirement: ask_user prompt timeout config field
+The shared config module SHALL include a configurable timeout that governs how long the bridge's PromptBus waits for a response to an interactive `ask_user` (or any other PromptBus-routed) prompt before auto-cancelling:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `askUserPromptTimeoutSeconds` | number | 300 | Seconds to wait for an answer before auto-cancelling. Any value `<= 0` (canonically `-1`) SHALL disable the timeout entirely so prompts wait indefinitely. |
+
+The shared config module SHALL also export a `DEFAULT_ASK_USER_PROMPT_TIMEOUT_SECONDS` constant equal to `300` so consumers (CLI, electron, tests) reference the same value rather than re-hard-coding it.
+
+Non-numeric values (string, boolean, null, arrays, objects) SHALL fall back to the default `300`.
+
+`ensureConfig()` SHALL NOT include `askUserPromptTimeoutSeconds` in the written defaults — the loader's default-coalescing handles missing values, keeping the on-disk file minimal.
+
+#### Scenario: Config with default timeout
+- **WHEN** `~/.pi/dashboard/config.json` does not include `askUserPromptTimeoutSeconds`
+- **THEN** `loadConfig()` SHALL return `askUserPromptTimeoutSeconds: 300`
+
+#### Scenario: Config with custom positive timeout
+- **WHEN** `~/.pi/dashboard/config.json` contains `{ "askUserPromptTimeoutSeconds": 60 }`
+- **THEN** `loadConfig()` SHALL return `askUserPromptTimeoutSeconds: 60`
+
+#### Scenario: Config with infinite timeout via -1
+- **WHEN** `~/.pi/dashboard/config.json` contains `{ "askUserPromptTimeoutSeconds": -1 }`
+- **THEN** `loadConfig()` SHALL return `askUserPromptTimeoutSeconds: -1` (not coerced to the default — the negative value is preserved as the disable-timeout signal)
+
+#### Scenario: Config with infinite timeout via 0
+- **WHEN** `~/.pi/dashboard/config.json` contains `{ "askUserPromptTimeoutSeconds": 0 }`
+- **THEN** `loadConfig()` SHALL return `askUserPromptTimeoutSeconds: 0`
+
+#### Scenario: Non-numeric value falls back to default
+- **WHEN** `~/.pi/dashboard/config.json` contains `{ "askUserPromptTimeoutSeconds": "forever" }` (or `null`, or an object/array)
+- **THEN** `loadConfig()` SHALL return `askUserPromptTimeoutSeconds: 300`
+
+#### Scenario: ensureConfig excludes askUserPromptTimeoutSeconds
+- **WHEN** `ensureConfig()` creates a new config file
+- **THEN** it SHALL NOT include `askUserPromptTimeoutSeconds` in the written defaults


### PR DESCRIPTION
Follow-up to #16 (merged).

Adds three new requirements covering the ask_user prompt timeout feature:

- **shared-config** — `askUserPromptTimeoutSeconds` config field (default 300, -1 / 0 = infinite, non-numeric falls back to default, excluded from `ensureConfig()` written defaults). 5 scenarios.
- **ask-user-tool** — bridge → PromptBus timeout wiring; PromptBus skips `setTimeout` when `timeoutMs <= 0`; cross-method propagation to `select`/`input`/`confirm`/`multiselect`/`editor`. 5 scenarios.
- **settings-panel** — General → Sessions field; -1 round-trip; empty-field fallback to 300; no-restart-required guarantee. 5 scenarios. Also extends the General-tab field list to mention `reattachPlacement` / `askUserPromptTimeoutSeconds` / `defaultModel`.

Validation: `openspec validate ask-user-tool` ✓ valid. The `shared-config` and `settings-panel` validation failures are pre-existing (missing `## Purpose` header — affects 168/211 specs repo-wide) and unrelated to this PR.