### PR TITLE
fix: resolve jiti from @earendil-works/pi-coding-agent

### DIFF
--- a/packages/shared/src/resolve-jiti.ts
+++ b/packages/shared/src/resolve-jiti.ts
@@ -13,6 +13,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 const JITI_PACKAGES = [
+  "jiti",
   "@mariozechner/jiti",
   "@oh-my-pi/jiti",
 ];


### PR DESCRIPTION
The resolveJitiImport function only looked for `@mariozechner/jiti` and `@oh-my-pi/jiti` package names. `@earendil-works/pi-coding-agent` ships jiti as the unscoped `jiti` package, causing the dashboard server to fail with "Cannot find pi's TypeScript loader (jiti)."\n\nAdded `"jiti"` as the first lookup entry so the dashboard server works with all pi distributions.