### PR TITLE
fix: include server/scripts in npm publish so postinstall works

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "packages/server/src/",
+    "packages/server/scripts/",
     "packages/server/package.json",
     "packages/server/tsconfig.json",
     "packages/shared/src/",


### PR DESCRIPTION
The `files` array in package.json omitted `packages/server/scripts/`, but the postinstall script references `packages/server/scripts/fix-pty-permissions.cjs`. This caused `pi install npm:@blackbelt-technology/pi-agent-dashboard` to fail with:\n\n```\nError: Cannot find module '.../packages/server/scripts/fix-pty-permissions.cjs'\n```\n\nAdded the scripts directory to the publish manifest.