### PR TITLE
feat: dynamic document title shows session name and project directory (#23)

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef, useMemo } from "react"
 import { useRoute, useLocation, useSearchParams, Redirect, Switch, Route } from "wouter";
 import { useWebSocket } from "./hooks/useWebSocket.js";
 import { useSidebarState } from "./hooks/useSidebarState.js";
+import { useDocumentTitle } from "./hooks/useDocumentTitle.js";
 import { SessionList } from "./components/SessionList.js";
 import { ResizableSidebar } from "./components/ResizableSidebar.js";
 import { HamburgerButton, MobileOverlay } from "./components/MobileOverlay.js";
@@ -669,6 +670,7 @@ export default function App() {
   // change: pluginize-flows-via-registry.
 
   const selectedSession = selectedId ? sessions.get(selectedId) : undefined;
+  useDocumentTitle(selectedSession);
   const selectedCwd = selectedSession?.cwd;
   const editorCwds = useMemo(() => selectedCwd ? [selectedCwd] : [], [selectedCwd]);
   const editorMap = useEditors(editorCwds);

--- a/packages/client/src/__tests__/document-title.test.ts
+++ b/packages/client/src/__tests__/document-title.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { buildDocumentTitle } from "../lib/document-title.js";
+import type { DashboardSession } from "@blackbelt-technology/pi-dashboard-shared/types.js";
+
+function makeSession(overrides: Partial<DashboardSession> = {}): DashboardSession {
+  return {
+    id: "test-session-id-1234",
+    cwd: "/home/user/my-project",
+    source: "tui",
+    status: "active",
+    startedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("buildDocumentTitle", () => {
+  it("should return fallback when no session", () => {
+    expect(buildDocumentTitle(undefined)).toBe("PI Dashboard");
+  });
+
+  it("should show directory for unnamed session", () => {
+    const session = makeSession({});
+    expect(buildDocumentTitle(session)).toBe("my-project — PI Dashboard");
+  });
+
+  it("should show named session with directory in parens", () => {
+    const session = makeSession({ name: "Fix auth bug" });
+    expect(buildDocumentTitle(session)).toBe("Fix auth bug (my-project) — PI Dashboard");
+  });
+
+  it("should dedup when session name equals directory name", () => {
+    const session = makeSession({ name: "my-project" });
+    expect(buildDocumentTitle(session)).toBe("my-project — PI Dashboard");
+  });
+
+  it("should dedup case-insensitively", () => {
+    const session = makeSession({ name: "My-Project", cwd: "/home/user/my-project" });
+    expect(buildDocumentTitle(session)).toBe("My-Project — PI Dashboard");
+  });
+
+  it("should fall back to id prefix when cwd has no segments", () => {
+    const session = makeSession({ cwd: "/" });
+    expect(buildDocumentTitle(session)).toBe("test-ses — PI Dashboard");
+  });
+});

--- a/packages/client/src/hooks/useDocumentTitle.ts
+++ b/packages/client/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import type { DashboardSession } from "@blackbelt-technology/pi-dashboard-shared/types.js";
+import { buildDocumentTitle } from "../lib/document-title.js";
+
+const DEFAULT_TITLE = "PI Dashboard";
+
+export function useDocumentTitle(session: DashboardSession | undefined): void {
+  useEffect(() => {
+    document.title = buildDocumentTitle(session);
+    return () => {
+      document.title = DEFAULT_TITLE;
+    };
+  }, [session]);
+}

--- a/packages/client/src/lib/document-title.ts
+++ b/packages/client/src/lib/document-title.ts
@@ -1,0 +1,22 @@
+import type { DashboardSession } from "@blackbelt-technology/pi-dashboard-shared/types.js";
+
+function extractProjectDir(cwd: string, id: string): string {
+  const segments = cwd.split("/").filter(Boolean);
+  return segments.length > 0 ? segments[segments.length - 1] : id.slice(0, 8);
+}
+
+export function buildDocumentTitle(session: DashboardSession | undefined): string {
+  if (!session) return "PI Dashboard";
+
+  const dir = extractProjectDir(session.cwd, session.id);
+
+  if (session.name && session.name.trim()) {
+    const name = session.name.trim();
+    if (name.toLowerCase() === dir.toLowerCase()) {
+      return `${name} — PI Dashboard`;
+    }
+    return `${name} (${dir}) — PI Dashboard`;
+  }
+
+  return `${dir} — PI Dashboard`;
+}


### PR DESCRIPTION
Closes #23

## Summary

Updates `document.title` based on the focused session. Eliminates tab ambiguity across projects and monitors — every tab shows a meaningful title instead of "PI Dashboard".

Also aids window-title-aware tools (time trackers, tiling WMs, etc.) by exposing the project directory consistently.

## Format

| Session State | Title |
|---|---|
| Named (different from dir) | `Fix auth bug (my-project) — PI Dashboard` |
| Named (same as dir)       | `my-project — PI Dashboard` |
| Unnamed                   | `my-project — PI Dashboard` |
| No selection              | `PI Dashboard` |

## Design note

The original issue suggested reusing `getSessionDisplayName()` directly, which falls back through `name → firstMessage (truncated) → cwd`. This PR deliberately omits the firstMessage fallback here because:

- Time-tracking and window-manager tools benefit from stable titles — a session titled after a generic first message ("hi", "help me debug") would fragment activity logs across arbitrary text rather than project directories.

- Unnamed sessions consistently show the project directory, keeping tab titles short and scannable regardless of conversation content.

## Changes

- **`lib/document-title.ts`** — new `buildDocumentTitle()` pure function
- **`hooks/useDocumentTitle.ts`** — new hook wrapping `useEffect` + cleanup
- **`App.tsx`** — single-line integration
- **`__tests__/document-title.test.ts`** — 6 test cases

## Test Plan

- [x] `npm test` — all 196 client tests green
- [x] Named session → shows `Name (dir) — PI Dashboard`
- [x] Name matches dir → dedup to `dir — PI Dashboard`
- [x] Unnamed session → shows `dir — PI Dashboard`