### PR TITLE
feat: add standard favicon and platform metadata for tab icon support

### DIFF
--- a/packages/client/src/index.html
+++ b/packages/client/src/index.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#3b82f6" />
     <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="msapplication-TileImage" content="/icon-192.png" />
+    <meta name="msapplication-TileColor" content="#3b82f6" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="/icon-512.png" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>PI Dashboard</title>


### PR DESCRIPTION
Adds proper `<link rel="icon">` tags and Windows tile metadata to the HTML head, using the existing icon-192.png and icon-512.png assets from `public/`.

Previously only `apple-touch-icon` was declared, which meant browsers like Chrome and Firefox on Linux showed no tab icon.

Changes:
- Add `<link rel="icon" type="image/png" sizes="192x192">` 
- Add `<link rel="icon" type="image/png" sizes="512x512">`
- Add `<meta name="msapplication-TileImage">` 
- Add `<meta name="msapplication-TileColor">`