### PR TITLE
fix: set project-specific document title on folder routes (editor, terminals, etc.)

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -680,7 +680,10 @@ export default function App() {
   // change: pluginize-flows-via-registry.
 
   const selectedSession = selectedId ? sessions.get(selectedId) : undefined;
-  useDocumentTitle(selectedSession);
+  const folderTitleCwd = folderEditorCwd ?? folderTermCwd
+    ?? openspecPreviewCwd ?? archiveCwd ?? specsCwd
+    ?? readmeCwd ?? piResourcesCwd ?? null;
+  useDocumentTitle(selectedSession, folderTitleCwd ?? undefined);
   const selectedCwd = selectedSession?.cwd;
   const editorCwds = useMemo(() => selectedCwd ? [selectedCwd] : [], [selectedCwd]);
   const editorMap = useEditors(editorCwds);

--- a/packages/client/src/__tests__/document-title.test.ts
+++ b/packages/client/src/__tests__/document-title.test.ts
@@ -42,4 +42,12 @@ describe("buildDocumentTitle", () => {
     const session = makeSession({ cwd: "/" });
     expect(buildDocumentTitle(session)).toBe("test-ses — PI Dashboard");
   });
+
+  it("should show directory name for folder cwd when no session", () => {
+    expect(buildDocumentTitle(undefined, "/home/user/my-project")).toBe("my-project — PI Dashboard");
+  });
+
+  it("should fallback when neither session nor folderCwd is provided", () => {
+    expect(buildDocumentTitle(undefined, "")).toBe("PI Dashboard");
+  });
 });

--- a/packages/client/src/hooks/useDocumentTitle.ts
+++ b/packages/client/src/hooks/useDocumentTitle.ts
@@ -4,11 +4,14 @@ import { buildDocumentTitle } from "../lib/document-title.js";
 
 const DEFAULT_TITLE = "PI Dashboard";
 
-export function useDocumentTitle(session: DashboardSession | undefined): void {
+export function useDocumentTitle(
+  session: DashboardSession | undefined,
+  folderCwd?: string,
+): void {
   useEffect(() => {
-    document.title = buildDocumentTitle(session);
+    document.title = buildDocumentTitle(session, folderCwd);
     return () => {
       document.title = DEFAULT_TITLE;
     };
-  }, [session]);
+  }, [session, folderCwd]);
 }

--- a/packages/client/src/lib/document-title.ts
+++ b/packages/client/src/lib/document-title.ts
@@ -5,18 +5,27 @@ function extractProjectDir(cwd: string, id: string): string {
   return segments.length > 0 ? segments[segments.length - 1] : id.slice(0, 8);
 }
 
-export function buildDocumentTitle(session: DashboardSession | undefined): string {
-  if (!session) return "PI Dashboard";
+export function buildDocumentTitle(
+  session: DashboardSession | undefined,
+  folderCwd?: string,
+): string {
+  if (session) {
+    const dir = extractProjectDir(session.cwd, session.id);
 
-  const dir = extractProjectDir(session.cwd, session.id);
-
-  if (session.name && session.name.trim()) {
-    const name = session.name.trim();
-    if (name.toLowerCase() === dir.toLowerCase()) {
-      return `${name} — PI Dashboard`;
+    if (session.name && session.name.trim()) {
+      const name = session.name.trim();
+      if (name.toLowerCase() === dir.toLowerCase()) {
+        return `${name} — PI Dashboard`;
+      }
+      return `${name} (${dir}) — PI Dashboard`;
     }
-    return `${name} (${dir}) — PI Dashboard`;
+
+    return `${dir} — PI Dashboard`;
   }
 
-  return `${dir} — PI Dashboard`;
+  if (folderCwd) {
+    return `${extractProjectDir(folderCwd, "")} — PI Dashboard`;
+  }
+
+  return "PI Dashboard";
 }


### PR DESCRIPTION
This is a follow-up on #24 

When navigating to folder-level routes like `/folder/:encodedCwd/editor` or `/folder/:encodedCwd/terminals`, the browser tab title fell back to "PI Dashboard" because `useDocumentTitle` only received `selectedSession`, which is undefined outside `/session/:id` routes.

Now `buildDocumentTitle` accepts an optional `folderCwd` parameter. When no session is active but a folder CWD is present, it extracts the last path segment for a project-specific title (e.g. "my-project — PI Dashboard").
