### PR TITLE
fix(client): support pi-hashline-edit in EditToolRenderer with improved summary and defensive validation

### DIFF
--- a/packages/client/src/components/__tests__/EditToolRenderer.test.tsx
+++ b/packages/client/src/components/__tests__/EditToolRenderer.test.tsx
@@ -249,9 +249,9 @@ describe("EditToolRenderer — viewport branching", () => {
       />,
     );
     expect(queryAllByTestId("rich-diff").length).toBe(0);
-    expect(container.textContent).toContain("Replace 11#KT (1 lines)");
-    expect(container.textContent).toContain("Insert 1 lines after 15#AB");
-    expect(container.textContent).toContain("Insert 1 lines before BOF");
+    expect(container.textContent).toContain("Replace at 11#KT");
+    expect(container.textContent).toContain("Insert after 15#AB");
+    expect(container.textContent).toContain("Insert before BOF");
   });
 
   it("mobile: renders hashline replace/append/prepend as summaries", () => {
@@ -269,7 +269,7 @@ describe("EditToolRenderer — viewport branching", () => {
         context={ctx}
       />,
     );
-    expect(container.textContent).toContain("Replace 11#KT");
+    expect(container.textContent).toContain("Replace at 11#KT");
   });
 
   // --- NEW: mixed valid/invalid edits ---
@@ -316,8 +316,8 @@ describe("EditToolRenderer — viewport branching", () => {
     // Should render hashline summaries, NOT fall back to JSON or RichDiff
     expect(queryAllByTestId("rich-diff").length).toBe(0);
     expect(container.querySelector("pre")).toBeNull();
-    expect(container.textContent).toContain("Replace 11#KT (1 lines)");
-    expect(container.textContent).toContain("Insert 1 lines after 15#AB");
+    expect(container.textContent).toContain("Replace at 11#KT");
+    expect(container.textContent).toContain("Insert after 15#AB");
   });
 
   // --- NEW: defensive validation ---

--- a/packages/client/src/components/__tests__/EditToolRenderer.test.tsx
+++ b/packages/client/src/components/__tests__/EditToolRenderer.test.tsx
@@ -57,12 +57,12 @@ describe("EditToolRenderer — viewport branching", () => {
       />,
     );
     expect(getAllByTestId("rich-diff").length).toBe(1);
-    // homegrown DiffView renders .font-mono; should be absent on desktop
+    // homegrown diff renders .font-mono; should be absent on desktop
     expect(container.querySelectorAll("div.font-mono").length).toBe(0);
   });
 
-  // 5.3: mobile + oldText/newText → homegrown DiffView, no <RichDiff>
-  it("mobile: renders homegrown DiffView for oldText/newText args", () => {
+  // 5.3: mobile + oldText/newText → homegrown diff, no <RichDiff>
+  it("mobile: renders homegrown diff for oldText/newText args", () => {
     mockIsMobile = true;
     const { container, queryAllByTestId } = render(
       <EditToolRenderer
@@ -73,7 +73,7 @@ describe("EditToolRenderer — viewport branching", () => {
       />,
     );
     expect(queryAllByTestId("rich-diff").length).toBe(0);
-    // homegrown DiffView uses div.font-mono
+    // homegrown diff uses div.font-mono
     expect(container.querySelectorAll("div.font-mono").length).toBeGreaterThan(0);
   });
 
@@ -98,8 +98,8 @@ describe("EditToolRenderer — viewport branching", () => {
     expect(getAllByTestId("rich-diff").length).toBe(3);
   });
 
-  // 5.5: mobile + edits[] length 3 → exactly 3 homegrown DiffViews
-  it("mobile: renders exactly 3 homegrown DiffViews for edits[] of length 3", () => {
+  // 5.5: mobile + edits[] length 3 → exactly 3 homegrown diffs
+  it("mobile: renders exactly 3 homegrown diffs for edits[] of length 3", () => {
     mockIsMobile = true;
     const { container, queryAllByTestId } = render(
       <EditToolRenderer
@@ -142,6 +142,229 @@ describe("EditToolRenderer — viewport branching", () => {
       <EditToolRenderer
         toolName="edit"
         args={{ path: "file.ts" }}
+        status="complete"
+        context={ctx}
+      />,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre).toBeTruthy();
+    expect(pre!.textContent).toContain('"path"');
+  });
+
+  // --- NEW: toolDetails.diff tests ---
+
+  it("desktop: renders toolDetails.diff as UnifiedDiffView when present", () => {
+    mockIsMobile = false;
+    const diff = "--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new\n";
+    const { container, queryAllByTestId } = render(
+      <EditToolRenderer
+        toolName="edit"
+        args={{ path: "file.ts", oldText: "old", newText: "new" }}
+        status="complete"
+        context={ctx}
+        toolDetails={{ diff }}
+      />,
+    );
+    // diff should take priority over top-level oldText/newText
+    expect(queryAllByTestId("rich-diff").length).toBe(0);
+    expect(container.querySelectorAll("div.font-mono").length).toBeGreaterThan(0);
+    expect(container.textContent).toContain("+new");
+    expect(container.textContent).toContain("-old");
+  });
+
+  it("mobile: renders toolDetails.diff as UnifiedDiffView", () => {
+    mockIsMobile = true;
+    const diff = "--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new\n";
+    const { container } = render(
+      <EditToolRenderer
+        toolName="edit"
+        args={{ path: "file.ts" }}
+        status="complete"
+        context={ctx}
+        toolDetails={{ diff }}
+      />,
+    );
+    expect(container.querySelectorAll("div.font-mono").length).toBeGreaterThan(0);
+    expect(container.textContent).toContain("+new");
+  });
+
+  // --- NEW: hashline replace_text tests ---
+
+  it("desktop: renders hashline replace_text edits as <RichDiff>", () => {
+    mockIsMobile = false;
+    const { getAllByTestId } = render(
+      <EditToolRenderer
+        toolName="edit"
+        args={{
+          path: "file.ts",
+          edits: [
+            { op: "replace_text", oldText: "a", newText: "b" },
+            { op: "replace_text", oldText: "c", newText: "d" },
+          ],
+        }}
+        status="complete"
+        context={ctx}
+      />,
+    );
+    expect(getAllByTestId("rich-diff").length).toBe(2);
+  });
+
+  it("mobile: renders hashline replace_text edits as homegrown diffs", () => {
+    mockIsMobile = true;
+    const { container, queryAllByTestId } = render(
+      <EditToolRenderer
+        toolName="edit"
+        args={{
+          path: "file.ts",
+          edits: [
+            { op: "replace_text", oldText: "a", newText: "b" },
+          ],
+        }}
+        status="complete"
+        context={ctx}
+      />,
+    );
+    expect(queryAllByTestId("rich-diff").length).toBe(0);
+    expect(container.querySelectorAll("div.font-mono").length).toBeGreaterThan(0);
+  });
+
+  // --- NEW: hashline replace/append/prepend summary tests ---
+
+  it("desktop: renders hashline replace/append/prepend as summaries", () => {
+    mockIsMobile = false;
+    const { container, queryAllByTestId } = render(
+      <EditToolRenderer
+        toolName="edit"
+        args={{
+          path: "file.ts",
+          edits: [
+            { op: "replace", pos: "11#KT", lines: ["console.log('hello');"] },
+            { op: "append", pos: "15#AB", lines: ["// new line"]
+, },
+            { op: "prepend", lines: ["// header"] },
+          ],
+        }}
+        status="complete"
+        context={ctx}
+      />,
+    );
+    expect(queryAllByTestId("rich-diff").length).toBe(0);
+    expect(container.textContent).toContain("Replace 11#KT (1 lines)");
+    expect(container.textContent).toContain("Insert 1 lines after 15#AB");
+    expect(container.textContent).toContain("Insert 1 lines before BOF");
+  });
+
+  it("mobile: renders hashline replace/append/prepend as summaries", () => {
+    mockIsMobile = true;
+    const { container } = render(
+      <EditToolRenderer
+        toolName="edit"
+        args={{
+          path: "file.ts",
+          edits: [
+            { op: "replace", pos: "11#KT", lines: ["x"] },
+          ],
+        }}
+        status="complete"
+        context={ctx}
+      />,
+    );
+    expect(container.textContent).toContain("Replace 11#KT");
+  });
+
+  // --- NEW: mixed valid/invalid edits ---
+
+  it("filters out edits missing oldText/newText and renders only valid ones", () => {
+    mockIsMobile = false;
+    const { getAllByTestId, container } = render(
+      <EditToolRenderer
+        toolName="edit"
+        args={{
+          path: "file.ts",
+          edits: [
+            { oldText: "valid", newText: "edit" },
+            { op: "replace", pos: "11#KT", lines: ["hashline"] },
+            { oldText: undefined, newText: "missing" },
+          ],
+        }}
+        status="complete"
+        context={ctx}
+      />,
+    );
+    // Should render only the 1 valid text diff (hashline ops are skipped when text edits exist)
+    expect(getAllByTestId("rich-diff").length).toBe(1);
+    // Should NOT show raw JSON fallback
+    expect(container.querySelector("pre")).toBeNull();
+  });
+
+  it("renders hashline summaries when no text edits exist", () => {
+    mockIsMobile = false;
+    const { container, queryAllByTestId } = render(
+      <EditToolRenderer
+        toolName="edit"
+        args={{
+          path: "file.ts",
+          edits: [
+            { op: "replace", pos: "11#KT", lines: ["x"] },
+            { op: "append", pos: "15#AB", lines: ["y"] },
+          ],
+        }}
+        status="complete"
+        context={ctx}
+      />,
+    );
+    // Should render hashline summaries, NOT fall back to JSON or RichDiff
+    expect(queryAllByTestId("rich-diff").length).toBe(0);
+    expect(container.querySelector("pre")).toBeNull();
+    expect(container.textContent).toContain("Replace 11#KT (1 lines)");
+    expect(container.textContent).toContain("Insert 1 lines after 15#AB");
+  });
+
+  // --- NEW: defensive validation ---
+
+  it("falls back to JSON when oldText is present but newText is not", () => {
+    mockIsMobile = false;
+    const { container } = render(
+      <EditToolRenderer
+        toolName="edit"
+        args={{ path: "file.ts", oldText: "hello" }}
+        status="complete"
+        context={ctx}
+      />,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre).toBeTruthy();
+    expect(pre!.textContent).toContain('"path"');
+  });
+
+  it("does not crash when edits array is malformed (undefined fields)", () => {
+    mockIsMobile = false;
+    const { container } = render(
+      <EditToolRenderer
+        toolName="edit"
+        args={{
+          path: "file.ts",
+          edits: [
+            { oldText: "a", newText: null },
+            { oldText: null, newText: "b" },
+            {},
+          ] as unknown as Array<{ oldText: string; newText: string }>,
+        }}
+        status="complete"
+        context={ctx}
+      />,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre).toBeTruthy();
+    expect(pre!.textContent).toContain('"path"');
+  });
+
+  it("handles empty edits array", () => {
+    mockIsMobile = false;
+    const { container } = render(
+      <EditToolRenderer
+        toolName="edit"
+        args={{ path: "file.ts", edits: [] }}
         status="complete"
         context={ctx}
       />,

--- a/packages/client/src/components/tool-renderers/EditToolRenderer.tsx
+++ b/packages/client/src/components/tool-renderers/EditToolRenderer.tsx
@@ -82,21 +82,31 @@ function isHashlineOp(e: HashlineEditOp): boolean {
 }
 
 function HashlineEditSummary({ edit }: { edit: HashlineEditOp }) {
-  let label: string;
-  switch (edit.op) {
-    case "replace":
-      label = `Replace ${edit.pos}${edit.end ? ` to ${edit.end}` : ""} (${edit.lines?.length ?? 0} lines)`;
-      break;
-    case "append":
-      label = `Insert ${edit.lines?.length ?? 0} lines after ${edit.pos ?? "EOF"}`;
-      break;
-    case "prepend":
-      label = `Insert ${edit.lines?.length ?? 0} lines before ${edit.pos ?? "BOF"}`;
-      break;
-    default:
-      label = `Hashline edit (${edit.op})`;
-  }
-  return <div className="font-mono text-xs text-[var(--text-secondary)] px-2 py-1">{label}</div>;
+  const lines = Array.isArray(edit.lines) ? edit.lines : [];
+
+  const header = () => {
+    switch (edit.op) {
+      case "replace":
+        return `● Replace at ${edit.pos}`;
+      case "append":
+        return `● Insert after ${edit.pos ?? "EOF"}:`;
+      case "prepend":
+        return `● Insert before ${edit.pos ?? "BOF"}:`;
+      default:
+        return `● Hashline edit (${edit.op}):`;
+    }
+  };
+
+  return (
+    <div className="px-2 py-1">
+      <div className="font-mono text-xs text-[var(--text-secondary)] mb-0.5">{header()}</div>
+      <div className="font-mono text-xs leading-relaxed">
+        {lines.map((line, i) => (
+          <div key={i} className="text-[var(--accent-green)] px-2">+ {line}</div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 // --- Main renderer ---
@@ -175,7 +185,9 @@ export function EditToolRenderer({ args, status, result, toolDetails, context }:
       {renderDiffs()}
 
       {result && status !== "running" && (
-        <div className="text-xs text-[var(--text-tertiary)] italic">{result}</div>
+        result.startsWith("---")
+          ? <pre className="text-xs text-[var(--text-secondary)] whitespace-pre-wrap">{result}</pre>
+          : <div className="text-xs text-[var(--text-tertiary)] italic">{result}</div>
       )}
     </div>
   );

--- a/packages/client/src/components/tool-renderers/EditToolRenderer.tsx
+++ b/packages/client/src/components/tool-renderers/EditToolRenderer.tsx
@@ -5,7 +5,9 @@ import { OpenFileButton } from "./OpenFileButton.js";
 import { useMobile } from "../../hooks/useMobile.js";
 import { RichDiff } from "../RichDiff.js";
 
-function DiffView({ oldText, newText, filePath }: { oldText: string; newText: string; filePath: string }) {
+// --- Mobile-only diff renderer ---
+
+function HomegrownDiff({ oldText, newText, filePath }: { oldText: string; newText: string; filePath: string }) {
   const patch = createTwoFilesPatch(filePath, filePath, oldText, newText, "before", "after", { context: 3 });
   const lines = patch.split("\n");
 
@@ -32,36 +34,134 @@ function DiffView({ oldText, newText, filePath }: { oldText: string; newText: st
   );
 }
 
-export function EditToolRenderer({ args, status, result, context }: ToolRendererProps) {
+// --- Pre-computed diff renderer (for toolDetails.diff) ---
+
+function UnifiedDiffView({ diff }: { diff: string }) {
+  const lines = diff.split("\n");
+
+  return (
+    <div className="font-mono text-xs leading-relaxed overflow-auto max-h-80">
+      {lines.map((line, i) => {
+        let className = "text-[var(--text-tertiary)] px-2";
+        if (line.startsWith("+++") || line.startsWith("---")) {
+          className = "text-[var(--text-tertiary)] px-2 font-bold";
+        } else if (line.startsWith("@@")) {
+          className = "text-[var(--accent-blue)] px-2 bg-[color-mix(in_srgb,var(--accent-blue)_15%,transparent)]";
+        } else if (line.startsWith("+")) {
+          className = "text-[var(--accent-green)] px-2 bg-[color-mix(in_srgb,var(--accent-green)_15%,transparent)]";
+        } else if (line.startsWith("-")) {
+          className = "text-[var(--accent-red)] px-2 bg-[color-mix(in_srgb,var(--accent-red)_15%,transparent)]";
+        }
+        return (
+          <div key={i} className={className}>
+            {line || "\u00A0"}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// --- Type guards for edits ---
+
+interface HashlineEditOp {
+  op?: string;
+  pos?: string;
+  end?: string;
+  lines?: string[];
+  oldText?: string;
+  newText?: string;
+}
+
+function isTextEdit(e: HashlineEditOp): e is HashlineEditOp & { oldText: string; newText: string } {
+  return typeof e.oldText === "string" && typeof e.newText === "string";
+}
+
+function isHashlineOp(e: HashlineEditOp): boolean {
+  return typeof e.op === "string" && !isTextEdit(e);
+}
+
+function HashlineEditSummary({ edit }: { edit: HashlineEditOp }) {
+  let label: string;
+  switch (edit.op) {
+    case "replace":
+      label = `Replace ${edit.pos}${edit.end ? ` to ${edit.end}` : ""} (${edit.lines?.length ?? 0} lines)`;
+      break;
+    case "append":
+      label = `Insert ${edit.lines?.length ?? 0} lines after ${edit.pos ?? "EOF"}`;
+      break;
+    case "prepend":
+      label = `Insert ${edit.lines?.length ?? 0} lines before ${edit.pos ?? "BOF"}`;
+      break;
+    default:
+      label = `Hashline edit (${edit.op})`;
+  }
+  return <div className="font-mono text-xs text-[var(--text-secondary)] px-2 py-1">{label}</div>;
+}
+
+// --- Main renderer ---
+
+export function EditToolRenderer({ args, status, result, toolDetails, context }: ToolRendererProps) {
   const isMobile = useMobile();
   const filePath = args?.path as string | undefined;
   const oldText = args?.oldText as string | undefined;
   const newText = args?.newText as string | undefined;
-  const edits = Array.isArray(args?.edits) ? (args.edits as Array<{ oldText: string; newText: string }>) : null;
+  const rawEdits = Array.isArray(args?.edits) ? (args.edits as HashlineEditOp[]) : null;
+
+  // Defensive: filter edits to only those we can actually render a diff for
+  const textEdits = rawEdits?.filter(isTextEdit);
+  const hashlineOps = rawEdits?.filter(isHashlineOp);
 
   const renderDiffs = () => {
-    if (oldText != null && newText != null) {
+    // Priority 1: toolDetails.diff (pre-computed from pi-hashline-edit)
+    if (typeof toolDetails?.diff === "string" && toolDetails.diff.length > 0) {
+      return (
+        <div className="rounded bg-[var(--bg-code)] overflow-hidden">
+          <UnifiedDiffView diff={toolDetails.diff} />
+        </div>
+      );
+    }
+
+    // Priority 2: top-level oldText/newText (built-in edit format)
+    if (typeof oldText === "string" && typeof newText === "string") {
       return (
         <div className="rounded bg-[var(--bg-code)] overflow-hidden">
           {isMobile
-            ? <DiffView oldText={oldText} newText={newText} filePath={filePath ?? "file"} />
+            ? <HomegrownDiff oldText={oldText} newText={newText} filePath={filePath ?? "file"} />
             : <RichDiff oldText={oldText} newText={newText} filePath={filePath ?? "file"} maxHeight="20rem" />}
         </div>
       );
     }
-    if (edits && edits.length > 0) {
+
+    // Priority 3: edits[] with replace_text (hashline compat)
+    if (textEdits && textEdits.length > 0) {
       return (
         <div className="rounded bg-[var(--bg-code)] overflow-hidden">
-          {edits.map((edit, i) => (
+          {textEdits.map((edit, i) => (
             <div key={i} className={i > 0 ? "border-t border-[var(--border-secondary)]" : ""}>
               {isMobile
-                ? <DiffView oldText={edit.oldText} newText={edit.newText} filePath={filePath ?? "file"} />
+                ? <HomegrownDiff oldText={edit.oldText} newText={edit.newText} filePath={filePath ?? "file"} />
                 : <RichDiff oldText={edit.oldText} newText={edit.newText} filePath={filePath ?? "file"} maxHeight="20rem" />}
             </div>
           ))}
         </div>
       );
     }
+
+    // Priority 4: hashline replace/append/prepend — render descriptions
+    if (hashlineOps && hashlineOps.length > 0) {
+      return (
+        <div className="rounded bg-[var(--bg-code)] overflow-hidden">
+          {hashlineOps.map((edit, i) => (
+            <div key={i} className={i > 0 ? "border-t border-[var(--border-secondary)]" : ""}>
+              <HashlineEditSummary edit={edit} />
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    // Fallback: show raw JSON args
     return <pre className="text-xs text-[var(--text-secondary)]">{JSON.stringify(args, null, 2)}</pre>;
   };
 


### PR DESCRIPTION
Fixes crash when edit tool args contain hashline-style edits without oldText/newText (e.g. [pi-hashline-edit](https://github.com/RimuruW/pi-hashline-edit)'s `replace`, `append`, `prepend`): `Render error: Cannot read properties of undefined (reading 'split')`

**Changes:**

- **`UnifiedDiffView`** — Renders pre-computed diffs from `toolDetails.diff` when available (highest priority; currently unused because pi's event system strips `details` from tool results — this is a pi-side gap, but the renderer will work if/when pi starts forwarding it).
- **`HashlineEditSummary`** — Shows actual line content with a green `+` prefix instead of just a bare line count. Example:

  ● Replace at 2#KH
     Modified line

- **Result display** — Hashline anchor blocks (starting with `---`) are now rendered as a `<pre>` code block instead of italic text, making them readable.
- **Hashline `replace_text`** — Edits with `{ op: "replace_text", oldText, newText }` are treated as valid text diffs and rendered through the existing HomegrownDiff/RichDiff pipeline.
- **Defensive validation** — Type guards (`isTextEdit`, `isHashlineOp`) filter edits before rendering. Missing `oldText`/`newText` no longer causes `createTwoFilesPatch` to crash. Falls back to JSON when nothing is renderable.
- **17 tests** (7 existing + 10 new) covering all priority paths.

**Limitation:** A proper unified diff can't be reconstructed from hashline args alone — we have the new `lines` content but not the old content. Pi-hashline-edit computes the diff internally and includes it in `details.diff`, but pi doesn't forward tool `details` in its events to the bridge.