### PR TITLE
feat(node-floor,pi-compat): land source edits for bump-pi-compat-to-0-75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ see [`docs/release-process.md`](docs/release-process.md).
 ### Added
 
 ### Changed
+- **Pi compatibility floor lifted to 0.75.0 (recommended 0.75.5).** Users on pi 0.74.x now see the red "below minimum" bootstrap banner with an upgrade hint at 0.75.5. The dashboard's declared Node engines floor rose to `>=22.19.0` (root + server) to mirror pi 0.75.0's own breaking-change Node bump. `node-guard.ts::isAffectedNode` now refuses to start on Node `v22.18.x` (previously accepted). Bundled-extension peer-deps (`pi-anthropic-messages`, `pi-flows`) bumped to `>=0.75.0` / `^0.75.0` in lockstep — they replace the deleted `offline-packages.json` as the dashboard's pin surface. A new repo-lint `bundled-node-meets-pi-floor.test.ts` asserts the bundled Node version (`BUNDLED_NODE_VERSION` in `_node-version.sh`) meets the Node floor required by `piCompatibility.minimum`. (change: `bump-pi-compat-to-0-75`)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "screenshots": "npm --prefix site run screenshots"
   },
   "engines": {
-    "node": ">=22.12.0 <25"
+    "node": ">=22.19.0 <25"
   },
   "dependencies": {
     "@blackbelt-technology/pi-dashboard-extension": "^0.5.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,11 +12,11 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=22.18.0"
+    "node": ">=22.19.0"
   },
   "piCompatibility": {
-    "minimum": "0.74.0",
-    "recommended": "0.74.0",
+    "minimum": "0.75.0",
+    "recommended": "0.75.5",
     "maximum": null
   },
   "main": "src/cli.ts",
@@ -35,7 +35,7 @@
     "@blackbelt-technology/dashboard-plugin-runtime": "^0.5.4",
     "@blackbelt-technology/pi-dashboard-extension": "^0.5.4",
     "@blackbelt-technology/pi-dashboard-shared": "^0.5.4",
-    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.75.0",
     "@fastify/compress": "^8.3.1",
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.0.0",

--- a/packages/server/src/__tests__/node-guard.test.ts
+++ b/packages/server/src/__tests__/node-guard.test.ts
@@ -6,12 +6,20 @@ describe("isAffectedNode", () => {
     expect(isAffectedNode("v22.0.0")).toBe(true);
   });
 
-  it("returns true for v22.17.999 (upper bound of 22.x affected)", () => {
+  it("returns true for v22.17.999 (well inside 22.x affected)", () => {
     expect(isAffectedNode("v22.17.999")).toBe(true);
   });
 
-  it("returns false for v22.18.0 (first 22.x fixed)", () => {
-    expect(isAffectedNode("v22.18.0")).toBe(false);
+  it("returns true for v22.18.0 (now refused after bump-pi-compat-to-0-75)", () => {
+    expect(isAffectedNode("v22.18.0")).toBe(true);
+  });
+
+  it("returns true for v22.18.999 (upper bound of 22.x affected)", () => {
+    expect(isAffectedNode("v22.18.999")).toBe(true);
+  });
+
+  it("returns false for v22.19.0 (first 22.x fixed; new floor)", () => {
+    expect(isAffectedNode("v22.19.0")).toBe(false);
   });
 
   it("returns false for v22.22.2 (current LTS)", () => {
@@ -47,8 +55,8 @@ describe("isAffectedNode", () => {
   });
 
   it("accepts versions without the v prefix", () => {
-    expect(isAffectedNode("22.17.0")).toBe(true);
-    expect(isAffectedNode("22.18.0")).toBe(false);
+    expect(isAffectedNode("22.18.0")).toBe(true);
+    expect(isAffectedNode("22.19.0")).toBe(false);
   });
 
   it("returns false for malformed input rather than throwing", () => {
@@ -72,7 +80,7 @@ describe("buildNodeUpgradeMessage", () => {
 
   it("names the minimum acceptable versions", () => {
     const msg = buildNodeUpgradeMessage("v22.17.1");
-    expect(msg).toMatch(/22\.18/);
+    expect(msg).toMatch(/22\.19/);
     expect(msg).toMatch(/24\.3/);
   });
 

--- a/packages/server/src/node-guard.ts
+++ b/packages/server/src/node-guard.ts
@@ -4,8 +4,14 @@
  * The bug (`ERR_INTERNAL_ASSERTION: Unexpected module status 3`) fires when
  * Fastify loads its internal ajv-compiler under affected Node versions.
  *
- * Affected: Node v22.0–v22.17 and v24.1–v24.2.
- * Fixed in: v22.18+, v24.3+, v25.x.
+ * Affected: Node v22.0–v22.18 and v24.1–v24.2.
+ * Fixed in: v22.19+, v24.3+, v25.x.
+ *
+ * 22.x cutoff widened from `< 22.18` to `< 22.19` in change
+ * `bump-pi-compat-to-0-75` (pi 0.75.0 raised its own Node floor to 22.19;
+ * mirror it here so the runtime guard matches the engines.node floor).
+ * If `packages/electron/src/lib/pick-node.ts::isBundledNodeAffected`
+ * exists as a deliberate mirror, it MUST move in lockstep.
  *
  * Rationale for a preflight refuse-to-start (instead of a preload workaround):
  * see openspec/changes/adapt-windows-integration-pr9/proposal.md and
@@ -17,7 +23,7 @@ export function isAffectedNode(version: string): boolean {
   if (!m) return false;
   const major = Number(m[1]);
   const minor = Number(m[2]);
-  if (major === 22 && minor < 18) return true;
+  if (major === 22 && minor < 19) return true;
   if (major === 24 && minor >= 1 && minor < 3) return true;
   return false;
 }
@@ -30,7 +36,7 @@ export function buildNodeUpgradeMessage(version: string): string {
     `    This Node version has a bug that crashes Fastify at startup:`,
     `    https://github.com/nodejs/node/issues/58515`,
     ``,
-    `    Fix: upgrade Node to >=22.18.0 (LTS) or >=24.3.0.`,
+    `    Fix: upgrade Node to >=22.19.0 (LTS) or >=24.3.0.`,
     `    Install:`,
     `      nvm:   nvm install 22 && nvm use 22`,
     `      brew:  brew upgrade node`,

--- a/packages/shared/src/__tests__/bundled-node-meets-pi-floor.test.ts
+++ b/packages/shared/src/__tests__/bundled-node-meets-pi-floor.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Repo-level invariant: the Electron-bundled Node version (single
+ * source of truth in `packages/electron/scripts/_node-version.sh::
+ * BUNDLED_NODE_VERSION`) MUST satisfy the Node floor required by the
+ * pi version pinned in `packages/server/package.json::
+ * piCompatibility.minimum`.
+ *
+ * Pi 0.75.0 raised its own Node floor to 22.19; future pi minors may
+ * raise it further. This test catches a future bundled-Node downgrade
+ * (or pi-floor bump that outruns the bundled Node) at lint time
+ * instead of at user-install time.
+ *
+ * The piMinimum → required Node table is intentionally a literal in
+ * this file. When a future change bumps `piCompatibility.minimum`, add
+ * a row and update `BUNDLED_NODE_VERSION` together.
+ *
+ * See change: bump-pi-compat-to-0-75.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..", "..");
+
+const NODE_VERSION_SH = path.join(
+  REPO_ROOT,
+  "packages/electron/scripts/_node-version.sh",
+);
+const SERVER_PKG_JSON = path.join(
+  REPO_ROOT,
+  "packages/server/package.json",
+);
+
+/** piCompatibility.minimum → minimum Node major.minor required by that pi. */
+const PI_MIN_TO_NODE_FLOOR: Record<string, { major: number; minor: number }> = {
+  "0.70.0": { major: 22, minor: 18 },
+  "0.71.0": { major: 22, minor: 18 },
+  "0.72.0": { major: 22, minor: 18 },
+  "0.73.0": { major: 22, minor: 18 },
+  "0.74.0": { major: 22, minor: 18 },
+  "0.75.0": { major: 22, minor: 19 },
+};
+
+function parseSemver(v: string): [number, number, number] | null {
+  const m = v.trim().replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function readBundledNodeVersion(): string {
+  const sh = fs.readFileSync(NODE_VERSION_SH, "utf8");
+  const m = sh.match(/^\s*export\s+BUNDLED_NODE_VERSION="([^"]+)"/m);
+  if (!m) {
+    throw new Error(
+      `Could not find BUNDLED_NODE_VERSION in ${NODE_VERSION_SH}`,
+    );
+  }
+  return m[1];
+}
+
+function readPiMinimum(): string {
+  const pkg = JSON.parse(fs.readFileSync(SERVER_PKG_JSON, "utf8"));
+  const min = pkg?.piCompatibility?.minimum;
+  if (typeof min !== "string") {
+    throw new Error(
+      `piCompatibility.minimum missing or not a string in ${SERVER_PKG_JSON}`,
+    );
+  }
+  return min;
+}
+
+describe("bundled Node version meets pi-floor Node requirement", () => {
+  it("BUNDLED_NODE_VERSION >= required Node for piCompatibility.minimum", () => {
+    const bundled = readBundledNodeVersion();
+    const piMin = readPiMinimum();
+    const bundledParts = parseSemver(bundled);
+    expect(
+      bundledParts,
+      `Could not parse BUNDLED_NODE_VERSION="${bundled}" as semver`,
+    ).not.toBeNull();
+    const [bMajor, bMinor] = bundledParts as [number, number, number];
+
+    const floor = PI_MIN_TO_NODE_FLOOR[piMin];
+    expect(
+      floor,
+      `No Node-floor entry for piCompatibility.minimum="${piMin}". ` +
+        `Add a row to PI_MIN_TO_NODE_FLOOR in this test (and check ` +
+        `BUNDLED_NODE_VERSION in _node-version.sh meets the new floor).`,
+    ).toBeDefined();
+
+    const ok =
+      bMajor > floor.major ||
+      (bMajor === floor.major && bMinor >= floor.minor);
+
+    expect(
+      ok,
+      `Bundled Node v${bMajor}.${bMinor} is below the floor required ` +
+        `by pi ${piMin} (Node >= ${floor.major}.${floor.minor}). ` +
+        `Bump BUNDLED_NODE_VERSION in ` +
+        `packages/electron/scripts/_node-version.sh to at least ` +
+        `Node ${floor.major}.${floor.minor}.0.`,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
The archived `bump-pi-compat-to-0-75` change (openspec/changes/archive/2026-05-28-bump-pi-compat-to-0-75/) ticked these source edits but they were never written to develop — see CORRECTION.md in the archive for the audit log. This commit lands them from a dedicated worktree (.shadow/bump-pi-compat-to-0-75/) so the work is no longer subject to parallel-workspace snapshot shadowing.

Source edits (carry-over from the lost 0-75 implementation):

- package.json::engines.node                                >=22.12.0 <25  →  >=22.19.0 <25
- packages/server/package.json::
    engines.node                                            >=22.18.0      →  >=22.19.0
    piCompatibility.minimum                                 0.74.0         →  0.75.0
    piCompatibility.recommended                             0.74.0         →  0.75.5
    dependencies.@earendil-works/pi-coding-agent            ^0.74.0        →  ^0.75.0
- packages/server/src/node-guard.ts::
    isAffectedNode 22.x cutoff                              < 18           →  < 19
    buildNodeUpgradeMessage Fix: line                       >=22.18.0      →  >=22.19.0
- packages/server/src/__tests__/node-guard.test.ts:
    v22.18.0 cases flipped to refused;
    new v22.19.0 acceptance case;
    upgrade-message regex 22\.18 → 22\.19.
- packages/shared/src/__tests__/bundled-node-meets-pi-floor.test.ts (NEW):
    Repo-lint that reads BUNDLED_NODE_VERSION from _node-version.sh and
    cross-references piCompatibility.minimum via a literal PI_MIN_TO_NODE_FLOOR
    table (0.70-0.75). Fails with a clear remediation message if the bundled
    Node falls below the pi-floor's required Node major.minor.
- CHANGELOG.md [Unreleased] / ### Changed: pi compat floor + Node engines summary.

Verification:
  npm test -- node-guard bundled-node-meets-pi-floor
  → Test Files  2 passed (2)
    Tests      20 passed (20)

Note: this lands the 0-75 source edits only. The companion change `bump-pi-compat-to-0-76` (active in openspec/changes/) bumps further to 0.76.0; once that ships, the piCompatibility lines here move forward another minor and the bundled-node-meets-pi-floor PI_MIN_TO_NODE_FLOOR table gains a 0.76.0 row.

The existing wip/recover-bump-pi-compat-to-0-75-source-edits branch on origin (commit 61ed781d) carries the same diff; the new branch from this worktree supersedes it.