### PR TITLE
openspec: propose ship-browser-skill-and-electron-cdp

### DIFF
--- a/openspec/changes/ship-browser-skill-and-electron-cdp/.openspec.yaml
+++ b/openspec/changes/ship-browser-skill-and-electron-cdp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/ship-browser-skill-and-electron-cdp/design.md
+++ b/openspec/changes/ship-browser-skill-and-electron-cdp/design.md
@@ -1,0 +1,156 @@
+## Context
+
+The dashboard ships as an Electron app (`packages/electron`) which embeds the dashboard web client and orchestrates the dashboard server. Today the Electron shell exposes no Chrome DevTools Protocol (CDP) port, so neither QA automation nor agent-driven debugging can attach to the *installed app* — they can only point a separate Chrome at `http://localhost:8000`, which tests the web UI but not the Electron-specific surfaces (tray, native menus, IPC, wizard window, doctor window).
+
+Separately, the repo carries a `.pi/skills/browser-visual-debug/` skill that teaches agents how to use the `agent-browser` CLI for visual verification. Because it lives at the repo root, only sessions inside this repo see it. Every other pi-dashboard user has to discover the CLI on their own and figure out the workflow from scratch.
+
+Upstream `agent-browser` ships well-crafted skills (`core`, `electron`) inside its npm package, but those skills are only visible to pi sessions that have installed the CLI — a chicken-and-egg problem when the agent first encounters a task that needs them.
+
+The pi extension API already supports bundled skills: a pi extension's `package.json` declares `pi.skills[]` and pi auto-registers everything at session start. The dashboard's bridge extension (`packages/extension`) already uses this for the `pi-dashboard` skill. Adding another skill is mechanically a drop-in.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow attaching `agent-browser` (or any CDP-speaking client) to the running Pi Dashboard Electron app, by explicit developer opt-in only.
+- Surface a single universal `browser` skill to every dashboard session that teaches agents both web automation and Electron-app automation via `agent-browser`.
+- Avoid bundling the `agent-browser` CLI (or its 181 MB Chromium download) inside the dashboard installer. Skill self-bootstraps with install instructions when the CLI is missing.
+- Replace the repo-local `browser-visual-debug` skill with the universal one. Migrate its valuable recipes; remove the spec.
+- Keep CDP off for end users. No production-mode CDP. No promiscuous binding.
+
+**Non-Goals:**
+- Bundling `agent-browser`, `pi-agent-browser`, or Chromium inside the Electron installer.
+- Triggering `agent-browser install` (Chrome download) automatically. Lazy on-demand only.
+- Driving the Electron app via anything other than its existing Chromium CDP surface (no Playwright Electron driver, no custom IPC RPC for automation).
+- Auto-installing `pi-agent-browser` into user pi sessions. The skill instructs the user; the user decides.
+- Building a QA test harness around the CDP surface. (Possible follow-up, deliberately out of scope here.)
+- Shipping the niche agent-browser skills (`slack`, `exploratory`, `cloud`). Out of scope.
+
+## Decisions
+
+### Decision 1 — Activation surface for the CDP debug switch
+
+**Choice**: Two equivalent activation paths, both opt-in:
+- CLI flag: `--debug-cdp` (default port 9222) or `--debug-cdp=<port>`
+- Env var: `PI_DEBUG_CDP=1` (port 9222) or `PI_DEBUG_CDP=<port>`
+
+Precedence: CLI flag wins if both present.
+
+**Why not `--remote-debugging-port` directly**: that's Chromium's flag name and implies "this is a Chromium thing, always available." Our flag name surfaces *intent* ("this is a debug-only opt-in for Pi Dashboard") and lets us add policy (loopback enforcement, warning log, single-instance handling) without confusing flag semantics.
+
+**Alternative considered**: env-only. Rejected because CLI flag is easier to discover from `--help` and easier to wire into the `dev:cdp` npm script.
+
+### Decision 2 — Where in main.ts the switch is appended
+
+**Choice**: At top of `main.ts`, before any other Electron API call that materializes Chromium state. Specifically, before the single-instance lock acquisition and before `app.whenReady()`.
+
+**Why**: Chromium reads `remote-debugging-port` during browser initialization. Setting it after `app.whenReady()` resolves is a no-op. The single-instance lock contract (Decision 4) reinforces this — the second instance's argv handoff happens after the first instance is already past initialization.
+
+### Decision 3 — Loopback-only, never promiscuous
+
+**Choice**: Append only `remote-debugging-port`. Never `remote-debugging-address`. Chromium defaults the address to `127.0.0.1`, which is what we want.
+
+**Why**: Exposing CDP on `0.0.0.0` turns local-debug into a remote RCE on any LAN. We never want a flag that does that. If a user wants remote CDP, they can SSH-tunnel localhost:9222 — that's their explicit decision, not ours by default.
+
+### Decision 4 — Single-instance-lock contract
+
+**Choice**: Document and enforce: "to enable CDP, you must fully quit the running app and relaunch with the flag." When the second-instance hook fires with `--debug-cdp` in argv but the first instance was launched without it, log a one-line warning to the first instance's stderr explaining the contract. Do not attempt to enable CDP retroactively.
+
+**Why**: Chromium stands up its CDP HTTP server during browser-process initialization. There is no Electron API to enable it later. Pretending we can would silently fail. Surfacing a clear warning is the honest path.
+
+**Alternative considered**: making `--debug-cdp` skip the single-instance lock (start a fresh process). Rejected — that breaks the dashboard's session-singleton invariant.
+
+### Decision 5 — Skill name `browser` (composite, single entry)
+
+**Choice**: One skill directory `packages/extension/.pi/skills/browser/`, frontmatter `name: browser`, with internal recipes in `references/web.md` and `references/electron.md`.
+
+**Why**:
+- One entry in `/skill:` autocomplete keeps the user-facing surface tight.
+- `browser` matches the tool name registered by `pi-agent-browser` extension — consistent vocabulary.
+- The composite shape lets us include common preflight (Step 0: `command -v agent-browser`) without repeating it.
+
+**Alternative considered**: separate `browser-web` and `browser-electron` skills. Rejected — more autocomplete noise, duplicated preflight, no real benefit since recipes share 90% of their mechanics.
+
+**Collision risk**: a user with their own `.pi/skills/browser/` in their project would shadow this one. That's pi's local > extension precedence behavior, and is correct: user choice wins.
+
+### Decision 6 — Vendor the skill markdown, do not link
+
+**Choice**: Copy `agent-browser`'s `core` and `electron` skill text into `packages/extension/.pi/skills/browser/references/`, adapt for the composite shape, and record provenance in `UPSTREAM.md`.
+
+**Why**:
+- Linking (depending on the `agent-browser` npm package and pointing `pi.skills[]` into `node_modules/`) is uncertain — pi's resource scanner may not resolve node_modules-relative skill paths. Verifying that and adopting a less-tested pattern is more work than vendoring a few markdown files.
+- Vendoring decouples skill content from CLI version. Upstream CLI updates don't silently change what every dashboard user sees in their skill list.
+- Drift is mitigated by `UPSTREAM.md` (records source repo + commit + CLI version + refresh date), making "is this stale?" a mechanical check.
+
+**Alternative considered**: hybrid (vendor markdown, depend on package for the CLI). Rejected — we explicitly do NOT bundle the CLI (Decision 8), so there's no benefit to taking the dep.
+
+### Decision 7 — License & attribution
+
+**Choice**: Verify `agent-browser`'s upstream license before merging. If MIT or similar permissive, reproduce the upstream copyright notice in `packages/extension/.pi/skills/browser/LICENSE`. If non-permissive (unexpected), vendoring is blocked and we redesign as either a link or a docs-only pointer.
+
+**Why**: vendoring third-party content without attribution is sloppy regardless of license; a permissive license still requires the notice. This is a pre-merge gate, not a runtime concern.
+
+### Decision 8 — No CLI bundling; skill self-bootstraps
+
+**Choice**: The skill's `SKILL.md` performs `command -v agent-browser` as Step 0. If missing, the skill stops and instructs the user to run `pi install npm:pi-agent-browser`. No automatic install.
+
+**Why**:
+- Bundling adds install footprint for users who never invoke the skill.
+- Auto-install would trigger network access from the bridge extension's startup path — not something the bridge should do unsolicited.
+- `pi install npm:pi-agent-browser` is the right install target (not raw `agent-browser`) because the `pi-agent-browser` extension registers the `browser` tool with pi's tool registry, integrating cleanly with the rest of the agent's toolset.
+
+### Decision 9 — Replace, don't keep, the repo-local skill
+
+**Choice**: Delete `.pi/skills/browser-visual-debug/` entirely. Migrate dashboard-specific recipes (responsive testing, command cheatsheet, dashboard URL detection script) into the new universal skill where they benefit all users.
+
+**Why**:
+- Keeping both means two overlapping entries in `/skill:` autocomplete in this repo, which is confusing.
+- The repo-local skill's `.pi/settings.json` `pi-agent-browser` pre-install requirement (forcing every developer of this repo to install the package even if they never use it) is replaced by on-demand install via the new skill's Step 0 — strictly better.
+- Removing the `browser-visual-debug` capability spec keeps the spec set lean.
+
+**Alternative considered**: keep repo-local as a "deep" variant. Rejected — the universal skill should be at least as useful as the repo-local one was. If we keep both, the universal one will atrophy.
+
+### Decision 10 — Worked example in `electron.md` references Pi Dashboard
+
+**Choice**: The Electron recipe doc includes a concrete worked example of attaching to `Pi Dashboard.app` via `--debug-cdp`. This is the narrative link that justifies bundling Parts 1 + 2 in one proposal.
+
+**Why**: Every other Electron app's CDP workflow is the same flag mechanic, but using *our own app* as the worked example dogfoods the skill against the binary the user is most likely to actually have installed.
+
+## Risks / Trade-offs
+
+[Risk] CDP flag accidentally left on in a release build → user-installed Pi Dashboard ships with a CDP port open by default, gigantic security hole.
+→ Mitigation: default is OFF. Activation requires explicit flag or env. Add a build-time test that asserts `app.commandLine.appendSwitch('remote-debugging-port', ...)` is not unconditionally called. Add a startup log line whenever CDP is enabled, so the user can see it.
+
+[Risk] Single-instance-lock UX surprise — user passes `--debug-cdp` to an already-running app, nothing happens, they're confused.
+→ Mitigation: second-instance hook logs a warning explaining "fully quit and relaunch to enable CDP." Documented in skill's `electron.md` recipe.
+
+[Risk] Vendored skill drifts from upstream `agent-browser` behavior, agent gets wrong instructions.
+→ Mitigation: `UPSTREAM.md` records the exact commit + version + date. Skill content is small (a few dozen lines per recipe) and the upstream API surface is stable. Refresh is a manual periodic task; no automation needed.
+
+[Risk] Defaulting a `browser` skill to every dashboard user creates noise for users who never automate browsers.
+→ Mitigation: explicitly accepted during exploration. Skill is one entry in `/skill:` autocomplete, opt-in to use. Reversible by removing one entry from `pi.skills[]`.
+
+[Risk] Pre-merge license verification finds `agent-browser` is not permissively licensed.
+→ Mitigation: gate is in tasks.md. If verification fails, the proposal is paused and we fall back to a docs-only pointer (cite the upstream skill, do not reproduce it) — degraded but not blocked.
+
+[Risk] `pi-agent-browser` install target turns out wrong (e.g., the published name differs, or it doesn't actually register the `browser` tool the way we expect).
+→ Mitigation: verification is in tasks.md. If wrong, Step 0 of the skill instructs the user to install raw `agent-browser` instead.
+
+[Risk] `/skill:browser` collides with a user's own local skill named `browser`.
+→ Mitigation: pi's local > extension precedence handles this correctly (user wins). No code change needed; documented as expected behavior in the skill.
+
+[Risk] Removing `browser-visual-debug` skill breaks any external doc or agent prompt that references the path `.pi/skills/browser-visual-debug/`.
+→ Mitigation: this repo is the only place that references it (verified). External docs (README, file-index) updated as part of tasks. The new skill description carries the same trigger phrases, so agent skill-auto-loading continues to work.
+
+## Migration Plan
+
+1. Land Part 2 (bridge ships `browser` skill) first — additive, low risk.
+2. Land Part 1 (`--debug-cdp` in main.ts) in the same change but as a separable commit — easy rollback.
+3. Land Part 3 (delete repo-local skill, remove its spec) last — it's the destructive step and only safe once the replacement is in place.
+
+Rollback: if the universal skill is wrong, remove its path from `packages/extension/.pi/skills/` and `pi.skills[]`. If `--debug-cdp` causes problems, revert the main.ts hunk.
+
+## Open Questions
+
+- **`pi-agent-browser` vs `agent-browser` as install target**: pre-merge verification (tasks.md item).
+- **Skill description phrasing for auto-trigger heuristic**: needs at least one round of tuning against real agent usage. Initial draft will use the trigger phrases from upstream's `electron` skill plus general web-automation phrases.
+- **Where the warning log goes when single-instance second-instance hook sees `--debug-cdp` on argv**: currently planned for the first instance's stderr. Open question: does that surface anywhere visible to the user, or do we also need a system notification? Decision deferred until tasks reveal whether stderr is plausibly seen.

--- a/openspec/changes/ship-browser-skill-and-electron-cdp/proposal.md
+++ b/openspec/changes/ship-browser-skill-and-electron-cdp/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+Two related gaps make automating the dashboard's own Electron shell awkward today:
+
+1. **No agent can drive the shipped Electron app.** The dashboard ships as an Electron application, but the app exposes no Chrome DevTools Protocol (CDP) surface, so neither QA automation, agent-driven visual debugging, nor manual `agent-browser`/Playwright workflows can attach to the *actual installed binary*. They can only drive a separate Chrome pointed at `http://localhost:8000`, which tests the web UI but not the Electron shell (tray, IPC, wizard window, doctor window, menus).
+2. **The skill that knows how to do this only exists for one repo.** The `browser-visual-debug` skill lives at `.pi/skills/` in this repository, so only sessions opened inside this repo see it. Every other pi-dashboard user has to discover the `agent-browser` CLI on their own. Meanwhile the `agent-browser` CLI itself ships excellent skills (`core`, `electron`) — they just aren't surfaced to dashboard users.
+
+Closing both gaps at once turns "drive the dashboard's Electron app" from a tribal-knowledge task into a one-skill, one-flag affair available to every dashboard user.
+
+## What Changes
+
+### Electron shell — CDP debug surface
+- Add `--debug-cdp[=<port>]` CLI flag and `PI_DEBUG_CDP` env var to `packages/electron/src/main.ts`. Activation appends Chromium's `remote-debugging-port` switch *before* `app.whenReady()` resolves.
+- Default OFF. Default port `9222`. Loopback-only — do not expose `remote-debugging-address`.
+- Log a one-line warning at startup when CDP is enabled.
+- Document the single-instance-lock contract: enabling CDP requires fully quitting and relaunching; the second-instance hook cannot retroactively enable it.
+- Add `dev:cdp` npm script in `packages/electron/package.json` for one-shot dev use.
+
+### Bridge extension — ship a universal `browser` skill
+- Add a new skill directory `packages/extension/.pi/skills/browser/` with vendored content from upstream `agent-browser` skills (`core` + `electron` recipes). Composite single-skill shape with `references/web.md`, `references/electron.md`, `UPSTREAM.md` (provenance), and `LICENSE` (attribution).
+- Register the new skill in `packages/extension/package.json` under `pi.skills[]` so every dashboard session sees it.
+- Skill's `SKILL.md` performs a Step-0 preflight (`command -v agent-browser`); if the CLI is missing, the skill instructs the user to `pi install npm:pi-agent-browser` and stops. **No CLI is bundled** — install is on-demand.
+- The Electron recipe in `references/electron.md` SHALL include a worked example of attaching to the Pi Dashboard app via `--debug-cdp` (closes the loop with Part 1).
+
+### Repo-local skill cleanup
+- Delete `.pi/skills/browser-visual-debug/` (skill files, references, scripts).
+- Migrate its valuable content (responsive-testing recipes, command cheatsheet, dashboard-debug recipes) into the new universal `browser` skill so all dashboard users benefit, not just this repo's developers.
+- Remove the `browser-visual-debug` capability spec.
+
+### Pre-merge gates (not part of the spec'd behavior, but enforced by tasks)
+- Verify `agent-browser`'s upstream license permits vendoring; reproduce notice in `LICENSE` alongside vendored content.
+- Verify `pi-agent-browser` is the correct install target for the Step-0 preflight (vs. raw `agent-browser`); pick whichever integrates pi's `browser` tool registry cleanly.
+
+## Capabilities
+
+### New Capabilities
+- `default-browser-skill`: a composite `browser` skill shipped to every dashboard session by the bridge extension, covering web automation and Electron-app automation, with self-bootstrapping preflight for the `agent-browser` CLI.
+
+### Modified Capabilities
+- `electron-shell`: adds opt-in CDP debug surface (`--debug-cdp` flag, `PI_DEBUG_CDP` env, loopback-only, default-off, single-instance-lock contract).
+- `bridge-extension`: adds the new `browser` skill to its bundled `pi.skills[]` so every session receives it.
+- `browser-visual-debug`: **REMOVED** — superseded by `default-browser-skill`. The repo-local skill and its `.pi/settings.json` `pi-agent-browser` pre-install requirement are deleted; equivalent functionality is delivered to all users on demand.
+
+## Impact
+
+- **Code touched**: `packages/electron/src/main.ts`, `packages/electron/package.json`, `packages/extension/package.json`, `packages/extension/.pi/skills/browser/**` (new), `.pi/skills/browser-visual-debug/**` (deleted), `.pi/settings.json` (remove `pi-agent-browser` requirement if it ends up unused after deletion).
+- **Specs touched**: new `openspec/specs/default-browser-skill/spec.md`; delta files for `electron-shell`, `bridge-extension`, `browser-visual-debug` (removal).
+- **Dependencies**: no new runtime deps. No new npm package created. Vendored content from `agent-browser` requires license-attribution housekeeping.
+- **Installer size**: unchanged. Chrome download (181MB) is *not* triggered — CDP-into-Electron needs no Chrome; non-CDP browser use triggers `agent-browser install` lazily on first invocation.
+- **Audience**: every pi-dashboard user worldwide. New `/skill:browser` entry appears in autocomplete. Explicitly chosen during exploration; reversible by removing one entry from `pi.skills[]`.
+- **Security**: `--debug-cdp` defaults off, loopback-only, requires explicit opt-in via flag or env. Warning logged on activation. Documented as developer-only.
+- **Breaking**: removal of repo-local `browser-visual-debug` skill is a breaking change for any agent or doc that hard-codes the path `.pi/skills/browser-visual-debug/`. Mitigation: the universal `browser` skill covers the same workflows.

--- a/openspec/changes/ship-browser-skill-and-electron-cdp/specs/bridge-extension/spec.md
+++ b/openspec/changes/ship-browser-skill-and-electron-cdp/specs/bridge-extension/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Bridge extension ships a universal `browser` skill
+
+The bridge extension's `package.json` SHALL declare a `browser` skill in its `pi.skills[]` array, pointing at `.pi/skills/browser`. The extension's `files[]` array SHALL include `.pi/skills/browser/` so the directory ships in the published npm tarball.
+
+The skill content (SKILL.md, references, UPSTREAM.md, LICENSE) is specified by the `default-browser-skill` capability; this requirement covers only the registration mechanics.
+
+#### Scenario: pi.skills[] declares the skill
+
+- **WHEN** `packages/extension/package.json` is parsed
+- **THEN** the `pi.skills` array SHALL contain the entry `.pi/skills/browser`
+
+#### Scenario: Skill files ship in the published package
+
+- **WHEN** `packages/extension/package.json` is parsed
+- **THEN** the `files` array SHALL contain `.pi/skills/browser/` (or an equivalent glob that includes it)
+
+#### Scenario: Skill loads in real sessions
+
+- **WHEN** a pi session installs the bridge extension and starts
+- **THEN** `pi.getCommands()` SHALL include an entry with `name === "browser"` and `source === "skill"`
+
+### Requirement: Bridge does not auto-install agent-browser
+
+The bridge extension SHALL NOT attempt to install the `agent-browser` or `pi-agent-browser` package automatically at session start or during skill registration. The user remains in control of installing the CLI; the skill's Step-0 preflight handles the missing-CLI case by instructing the user.
+
+#### Scenario: No install side-effects at registration
+
+- **WHEN** the bridge extension registers the `browser` skill at session start
+- **THEN** the bridge SHALL NOT spawn `npm install`, `pi install`, or any equivalent install command
+- **AND** the bridge SHALL NOT modify the user's `.pi/settings.json` or `~/.pi/agent/settings.json` to add either package

--- a/openspec/changes/ship-browser-skill-and-electron-cdp/specs/browser-visual-debug/spec.md
+++ b/openspec/changes/ship-browser-skill-and-electron-cdp/specs/browser-visual-debug/spec.md
@@ -1,0 +1,37 @@
+## REMOVED Requirements
+
+### Requirement: pi-agent-browser package installation
+
+**Reason**: Replaced by the bridge-shipped universal `browser` skill (see `default-browser-skill` capability), whose Step-0 preflight handles the `agent-browser` CLI presence check on demand. Pre-installing `pi-agent-browser` as a project-local package forced every developer of this repo to take the dependency even if they never used the skill — strictly worse than the on-demand model.
+
+**Migration**: Remove `"npm:pi-agent-browser"` from this repo's `.pi/settings.json` `packages` array if present. Agents needing the `browser` tool can run `pi install npm:pi-agent-browser` themselves; the universal skill's Step-0 preflight tells them when and how.
+
+### Requirement: Skill SKILL.md with core workflows
+
+**Reason**: The repo-local skill at `.pi/skills/browser-visual-debug/SKILL.md` is being removed. Its content is migrated into the universal `browser` skill shipped by the bridge extension at `packages/extension/.pi/skills/browser/SKILL.md`, where it benefits all dashboard users rather than only sessions in this repo.
+
+**Migration**: Use `/skill:browser` instead of `/skill:browser-visual-debug`. The universal skill's `SKILL.md` covers the same four core workflows (visual verification, interactive debugging, responsive checks, console error hunting) via its preflight + recipe-routing structure.
+
+### Requirement: Dashboard detection script
+
+**Reason**: The `scripts/detect-dashboard.sh` helper that auto-detects the running dashboard URL is being migrated into the universal `browser` skill's references where it remains useful for any dashboard user, not just developers of this repo.
+
+**Migration**: The detection script SHALL be reproduced under `packages/extension/.pi/skills/browser/scripts/detect-dashboard.sh` (or equivalent path inside the universal skill). The universal skill's `references/web.md` SHALL document how to invoke it.
+
+### Requirement: Dashboard-specific recipes reference
+
+**Reason**: Repo-local skill being removed. Dashboard-specific visual-debug recipes are migrated into the universal `browser` skill where they remain accessible to anyone debugging the dashboard, regardless of which repo their pi session is rooted in.
+
+**Migration**: Recipe content from `.pi/skills/browser-visual-debug/references/dashboard-recipes.md` (or equivalent) is folded into the universal skill's `references/web.md` or its own reference file under `packages/extension/.pi/skills/browser/references/`.
+
+### Requirement: Responsive testing reference
+
+**Reason**: Repo-local skill being removed. Responsive-testing recipes (viewport presets, common breakpoints, browser tool invocations) are useful for all dashboard users, not just this repo.
+
+**Migration**: Content from `.pi/skills/browser-visual-debug/references/responsive-testing.md` is migrated into the universal skill's references — either appended to `references/web.md` or as a dedicated `references/responsive.md` file.
+
+### Requirement: Commands cheatsheet reference
+
+**Reason**: Repo-local skill being removed. The `agent-browser` commands cheatsheet is generic reference material applicable to any dashboard user.
+
+**Migration**: Content from `.pi/skills/browser-visual-debug/references/commands-cheatsheet.md` is migrated into the universal skill's references. The vendored `agent-browser` upstream content (`core` skill) already contains substantially the same material; the cheatsheet content SHALL be merged with it rather than duplicated.

--- a/openspec/changes/ship-browser-skill-and-electron-cdp/specs/default-browser-skill/spec.md
+++ b/openspec/changes/ship-browser-skill-and-electron-cdp/specs/default-browser-skill/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Skill is delivered by the bridge extension to every session
+
+The dashboard bridge extension SHALL ship a composite skill named `browser` such that every pi session loading the bridge automatically registers the skill via pi's extension `pi.skills[]` mechanism. No project-local `.pi/skills/` directory and no manual install SHALL be required.
+
+#### Scenario: Skill registered at session start
+
+- **WHEN** a pi session loads the dashboard bridge extension (`@blackbelt-technology/pi-dashboard-extension`)
+- **THEN** the skill `browser` SHALL appear in `pi.getCommands()` output with `source === "skill"`
+
+#### Scenario: Skill visible in slash-command autocomplete
+
+- **WHEN** an agent types `/skill:` or `/browser` in a dashboard session
+- **THEN** the `browser` skill SHALL appear in autocomplete
+
+### Requirement: Composite skill structure
+
+The skill SHALL be a single composite skill (one entry in autocomplete) covering two recipes — general web automation and Electron-app automation — via internal reference docs.
+
+The skill SHALL ship at `packages/extension/.pi/skills/browser/` with this layout:
+
+- `SKILL.md` — top-level orchestrator with YAML frontmatter (`name: browser`, descriptive `description:` covering both recipes' trigger phrases, `allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*)`)
+- `references/web.md` — vendored adaptation of upstream `agent-browser` `core` skill
+- `references/electron.md` — vendored adaptation of upstream `agent-browser` `electron` skill, including a worked example targeting the Pi Dashboard Electron app via `--debug-cdp`
+- `UPSTREAM.md` — provenance record (upstream repo URL, commit SHA, CLI version, refresh date)
+- `LICENSE` — attribution per upstream `agent-browser` license terms
+
+#### Scenario: Required files present
+
+- **WHEN** the bridge extension package is installed
+- **THEN** all five files above SHALL exist under `node_modules/@blackbelt-technology/pi-dashboard-extension/.pi/skills/browser/`
+
+#### Scenario: SKILL.md frontmatter declares allowed tools
+
+- **WHEN** the agent reads `SKILL.md`
+- **THEN** the `allowed-tools:` frontmatter field SHALL include `Bash(agent-browser:*)` and `Bash(npx agent-browser:*)`
+
+### Requirement: Step-0 preflight checks for the agent-browser CLI
+
+The skill's `SKILL.md` SHALL instruct the agent to verify that the `agent-browser` CLI is on `PATH` as Step 0 before attempting any browser-automation work. If the CLI is missing, the skill SHALL halt with a clear instruction to install it via `pi install npm:pi-agent-browser`, and SHALL NOT attempt automatic installation.
+
+#### Scenario: CLI present
+
+- **WHEN** the agent invokes the skill and `command -v agent-browser` exits 0
+- **THEN** the skill SHALL proceed to recipe routing (Step 1)
+
+#### Scenario: CLI missing
+
+- **WHEN** the agent invokes the skill and `command -v agent-browser` exits non-zero
+- **THEN** the skill SHALL emit "agent-browser CLI not installed. Run: pi install npm:pi-agent-browser" and halt
+- **AND** the skill SHALL NOT attempt `npm install`, `pi install`, or any other side-effecting command on the agent's behalf
+
+### Requirement: Electron recipe includes Pi Dashboard worked example
+
+`references/electron.md` SHALL include a worked example demonstrating how to attach `agent-browser` to the Pi Dashboard Electron app via the `--debug-cdp` flag introduced by this change. The example SHALL cover: launching the app with the flag, calling `agent-browser connect 9222`, listing tabs (main window, wizard window, doctor window), and taking a screenshot.
+
+#### Scenario: Worked example present
+
+- **WHEN** the agent reads `references/electron.md`
+- **THEN** the document SHALL contain a section titled "Worked example: Pi Dashboard" (or equivalent) showing the launch command, connect command, tab listing, and screenshot capture
+- **AND** the example SHALL reference the `--debug-cdp` flag (or `PI_DEBUG_CDP` env var) introduced in this change
+
+### Requirement: Upstream provenance is recorded
+
+The skill SHALL include an `UPSTREAM.md` file documenting the source of vendored content so future maintainers can detect drift mechanically. The file SHALL record at minimum: upstream repository URL, commit SHA (or tag), `agent-browser` CLI version the content was extracted from, and the date of last refresh.
+
+#### Scenario: UPSTREAM.md contents
+
+- **WHEN** the agent (or a maintainer) reads `UPSTREAM.md`
+- **THEN** it SHALL contain entries for `source`, `commit` (or `tag`), `agent-browser version`, and `refreshed` (ISO date)
+
+### Requirement: Skill is composable with user-local skills
+
+If a user has their own skill named `browser` at `<cwd>/.pi/skills/browser/`, pi's local > extension skill precedence SHALL apply and the user's skill SHALL win. The bridge-shipped skill does NOT preempt user-local skills.
+
+#### Scenario: User-local override
+
+- **WHEN** a pi session is opened in a directory containing `.pi/skills/browser/SKILL.md`
+- **THEN** that local skill SHALL be the one resolved by `/skill:browser`, not the bridge-shipped skill
+
+### Requirement: No CLI is bundled
+
+The bridge extension package SHALL NOT add `agent-browser`, `pi-agent-browser`, or any Chromium binary as a runtime dependency. The skill is documentation only; the CLI is installed on demand by the user per Step 0 instructions.
+
+#### Scenario: No agent-browser dependency
+
+- **WHEN** `packages/extension/package.json` is inspected
+- **THEN** neither `dependencies`, `peerDependencies`, nor `optionalDependencies` SHALL contain `agent-browser` or `pi-agent-browser`

--- a/openspec/changes/ship-browser-skill-and-electron-cdp/specs/electron-shell/spec.md
+++ b/openspec/changes/ship-browser-skill-and-electron-cdp/specs/electron-shell/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Opt-in CDP debug surface
+
+The Electron main process SHALL accept an opt-in activation that exposes Chromium's Chrome DevTools Protocol (CDP) on a loopback port for the lifetime of the app instance. Activation SHALL require an explicit CLI flag (`--debug-cdp[=<port>]`) or environment variable (`PI_DEBUG_CDP=<value>`). Default behavior with no flag and no env var SHALL be CDP-disabled.
+
+The activated port SHALL default to `9222`. A non-default port MAY be supplied via `--debug-cdp=<port>` or `PI_DEBUG_CDP=<port>`. When `PI_DEBUG_CDP=1` (truthy non-port value) is supplied without an explicit port, the default `9222` SHALL apply. When both CLI flag and env var are present, the CLI flag SHALL take precedence.
+
+When activated, the main process SHALL append Chromium's `remote-debugging-port` command-line switch via `app.commandLine.appendSwitch('remote-debugging-port', <port>)` before any code path that materializes Chromium state (specifically: before `app.whenReady()` resolves and before the first `BrowserWindow` is created).
+
+The main process SHALL NOT append `remote-debugging-address`. Chromium's default loopback (`127.0.0.1`) binding SHALL apply, restricting CDP to local clients.
+
+#### Scenario: Default — CDP disabled
+
+- **WHEN** the Electron app is launched without `--debug-cdp` and without `PI_DEBUG_CDP` set
+- **THEN** Chromium SHALL NOT expose any CDP HTTP endpoint
+- **AND** `app.commandLine.hasSwitch('remote-debugging-port')` SHALL return `false`
+
+#### Scenario: CLI flag with default port
+
+- **WHEN** the Electron app is launched with `--debug-cdp` (no `=<port>`)
+- **THEN** the main process SHALL call `app.commandLine.appendSwitch('remote-debugging-port', '9222')` before `app.whenReady()`
+
+#### Scenario: CLI flag with explicit port
+
+- **WHEN** the Electron app is launched with `--debug-cdp=9333`
+- **THEN** the main process SHALL call `app.commandLine.appendSwitch('remote-debugging-port', '9333')`
+
+#### Scenario: Env var activates default port
+
+- **WHEN** the Electron app is launched with `PI_DEBUG_CDP=1` and no CLI flag
+- **THEN** the main process SHALL call `app.commandLine.appendSwitch('remote-debugging-port', '9222')`
+
+#### Scenario: Env var supplies explicit port
+
+- **WHEN** the Electron app is launched with `PI_DEBUG_CDP=9444` and no CLI flag
+- **THEN** the main process SHALL call `app.commandLine.appendSwitch('remote-debugging-port', '9444')`
+
+#### Scenario: CLI flag overrides env var
+
+- **WHEN** the Electron app is launched with both `--debug-cdp=9555` and `PI_DEBUG_CDP=9777`
+- **THEN** the main process SHALL use port `9555`
+
+#### Scenario: Never binds promiscuously
+
+- **WHEN** CDP is activated by any means
+- **THEN** the main process SHALL NOT call `app.commandLine.appendSwitch('remote-debugging-address', ...)`
+- **AND** there SHALL be no CLI flag, env var, or config field that causes such an append to occur
+
+### Requirement: Activation logs a warning
+
+When CDP is activated, the main process SHALL log a single-line warning to stderr at startup making the activation visible to the user. The warning SHALL include the port number and indicate that local automation is enabled.
+
+#### Scenario: Warning emitted on activation
+
+- **WHEN** the Electron app is launched with CDP activated
+- **THEN** stderr SHALL contain a log line matching the form `[debug-cdp] CDP listening on :<port> — local automation is enabled` (or equivalent prose with the same elements: tag, port, intent)
+
+#### Scenario: No warning when disabled
+
+- **WHEN** the Electron app is launched without CDP activation
+- **THEN** stderr SHALL NOT contain any `[debug-cdp]` log line
+
+### Requirement: Single-instance-lock interaction
+
+The CDP debug surface SHALL be enabled only at first-instance launch. The dashboard's existing single-instance lock SHALL continue to apply: a second launch with `--debug-cdp` (or `PI_DEBUG_CDP`) while a first instance is already running SHALL NOT retroactively enable CDP on the first instance.
+
+When the single-instance second-instance hook is invoked with `--debug-cdp` present in the second instance's argv and the first instance was launched without CDP, the first instance SHALL log a single warning line to its stderr explaining that CDP enablement requires fully quitting and relaunching.
+
+#### Scenario: Second launch with flag against running app
+
+- **WHEN** a first instance is running without CDP and a second launch is invoked with `--debug-cdp`
+- **THEN** the second-instance hook SHALL log a warning to the first instance's stderr indicating that CDP cannot be enabled retroactively
+- **AND** the first instance SHALL NOT open a CDP port
+- **AND** the second-instance process SHALL exit normally (per existing single-instance behavior)
+
+#### Scenario: Second launch without flag against CDP-enabled app
+
+- **WHEN** a first instance is running with CDP enabled and a second launch is invoked without `--debug-cdp`
+- **THEN** behavior SHALL be unchanged from existing single-instance handling
+- **AND** the first instance's CDP port SHALL remain open

--- a/openspec/changes/ship-browser-skill-and-electron-cdp/tasks.md
+++ b/openspec/changes/ship-browser-skill-and-electron-cdp/tasks.md
@@ -1,0 +1,61 @@
+## 1. Pre-merge verification gates
+
+- [ ] 1.1 Verify upstream `agent-browser` package license — fetch its `LICENSE` or `package.json` `license` field. Confirm it permits vendoring with attribution (MIT/BSD/Apache-2 expected). If non-permissive, halt and re-design Part 2 as docs-pointer only.
+- [ ] 1.2 Verify `pi install npm:pi-agent-browser` is the correct install target for Step 0. Confirm the `pi-agent-browser` npm package exists, that installing it registers a `browser` tool in pi sessions, and that this is the user-facing surface we want the skill to recommend. If the published name differs or the integration is broken, fall back to recommending raw `npm install -g agent-browser`.
+- [ ] 1.3 Confirm the exact upstream commit/version of `agent-browser` whose `core` and `electron` skill text we will vendor. Record SHA + version + extraction date as the seed for `UPSTREAM.md`.
+
+## 2. Electron CDP debug switch (Part 1)
+
+- [ ] 2.1 Write failing tests for the activation logic. Test matrix: no flag/env → no append; `--debug-cdp` → append with `9222`; `--debug-cdp=9333` → append with `9333`; `PI_DEBUG_CDP=1` → append with `9222`; `PI_DEBUG_CDP=9444` → append with `9444`; both flag + env → flag wins; activation logs `[debug-cdp]` warning to stderr; never appends `remote-debugging-address`.
+- [ ] 2.2 Extract a pure helper `resolveCdpActivation(argv, env): { enabled: boolean, port?: number }` so the parse logic is testable in isolation. Place under `packages/electron/src/lib/` per repo convention.
+- [ ] 2.3 Wire `resolveCdpActivation` into `packages/electron/src/main.ts` at the top of the file, before `app.requestSingleInstanceLock()` and before any `app.whenReady()`-dependent code. If enabled, call `app.commandLine.appendSwitch('remote-debugging-port', String(port))` and emit the stderr warning.
+- [ ] 2.4 Handle the second-instance hook case: when the first instance's `second-instance` listener fires and the second-instance argv contains `--debug-cdp`, log a one-line warning to stderr explaining that CDP enablement requires fully quitting and relaunching.
+- [ ] 2.5 Add a repo-lint test that fails the build if `packages/electron/src/**` ever calls `app.commandLine.appendSwitch('remote-debugging-address', ...)`. The promiscuous-bind escape hatch must not exist.
+- [ ] 2.6 Add `dev:cdp` npm script to `packages/electron/package.json` invoking the existing dev entry with `--debug-cdp` (exact command depends on existing `start`/`dev` script shape).
+- [ ] 2.7 Run the test suite; confirm new tests pass and no existing tests regress.
+
+## 3. Universal `browser` skill (Part 2)
+
+- [ ] 3.1 Create directory `packages/extension/.pi/skills/browser/`.
+- [ ] 3.2 Write `packages/extension/.pi/skills/browser/SKILL.md` with frontmatter (`name: browser`, descriptive `description:` covering both web and Electron trigger phrases, `allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*)`). Body covers: Step 0 preflight (`command -v agent-browser`) with halt-and-instruct on failure; Step 1 recipe routing (web → references/web.md, Electron → references/electron.md).
+- [ ] 3.3 Vendor upstream `agent-browser` `core` skill content into `packages/extension/.pi/skills/browser/references/web.md`. Adapt frontmatter (drop standalone-skill frontmatter; this is a reference file, not a standalone skill).
+- [ ] 3.4 Vendor upstream `agent-browser` `electron` skill content into `packages/extension/.pi/skills/browser/references/electron.md`. Adapt the same way as web.md.
+- [ ] 3.5 Append a "Worked example: Pi Dashboard" section to `references/electron.md` showing: `open -a "PI Dashboard" --args --debug-cdp` (or env-var equivalent), `agent-browser connect 9222`, `agent-browser tab` listing main/wizard/doctor windows, and `agent-browser screenshot pi-dashboard.png`.
+- [ ] 3.6 Write `packages/extension/.pi/skills/browser/UPSTREAM.md` recording source repo URL, commit SHA, `agent-browser` CLI version, refresh date (today).
+- [ ] 3.7 Write `packages/extension/.pi/skills/browser/LICENSE` reproducing the upstream `agent-browser` license notice as required by attribution.
+- [ ] 3.8 Update `packages/extension/package.json`:
+  - Add `.pi/skills/browser` to `pi.skills[]` array.
+  - Add `.pi/skills/browser/` to `files[]` array.
+- [ ] 3.9 Write a test under `packages/extension/__tests__/` (or wherever extension tests live) asserting the skill files exist and that `package.json` declares the skill in both `pi.skills` and `files`.
+- [ ] 3.10 Verify by building the extension package locally (`npm run build -w @blackbelt-technology/pi-dashboard-extension` or equivalent) that the skill directory appears in the resulting tarball — run `npm pack` and inspect.
+
+## 4. Repo-local skill removal (Part 3)
+
+- [ ] 4.1 Migrate `.pi/skills/browser-visual-debug/scripts/detect-dashboard.sh` into `packages/extension/.pi/skills/browser/scripts/detect-dashboard.sh` (or merge its content into a reference doc, whichever fits the universal skill's structure better). Update `references/web.md` to document the script's invocation.
+- [ ] 4.2 Migrate `.pi/skills/browser-visual-debug/references/dashboard-recipes.md` content into the universal skill's references (web.md or a dedicated dashboard.md). Avoid duplicating content already covered by vendored `core` material.
+- [ ] 4.3 Migrate `.pi/skills/browser-visual-debug/references/responsive-testing.md` content into the universal skill's references (append to web.md or as `references/responsive.md`).
+- [ ] 4.4 Migrate any unique content from `.pi/skills/browser-visual-debug/references/commands-cheatsheet.md` into the universal skill — merge with vendored `core` content rather than duplicating.
+- [ ] 4.5 Delete `.pi/skills/browser-visual-debug/` entirely.
+- [ ] 4.6 Remove `"npm:pi-agent-browser"` from this repo's `.pi/settings.json` `packages` array if present. (Verify no other code path depends on it being pre-installed in this repo's session.)
+- [ ] 4.7 Search the repo for any remaining references to `browser-visual-debug` — README, AGENTS.md, docs/, file-index splits — and either update to point at the new universal skill or remove. Use `grep -rn "browser-visual-debug" --include='*.md' --include='*.json' --include='*.ts'`.
+
+## 5. Documentation updates
+
+- [ ] 5.1 Per AGENTS.md "Documentation Update Protocol", route per-file additions for the new skill files into the appropriate `docs/file-index-<area>.md` split (likely `docs/file-index-extension.md` for `packages/extension/.pi/skills/browser/**`, and `docs/file-index-electron.md` for the new `packages/electron/src/lib/resolve-cdp-activation.ts` helper). Delegate to a subagent per the protocol.
+- [ ] 5.2 Add a one-line entry to AGENTS.md "Key Files" backbone if (and only if) the new files qualify as architectural backbone. Otherwise leave AGENTS.md unchanged.
+- [ ] 5.3 If `.pi/skills/browser-visual-debug/` was referenced in `docs/file-index-skills-misc.md` (or equivalent split), remove those rows. Delegate per protocol.
+- [ ] 5.4 Update `packages/electron/README.md` (or repo README if there's no per-package README) with a short section documenting `--debug-cdp` / `PI_DEBUG_CDP` and the `dev:cdp` script — including the single-instance-lock contract ("must fully quit and relaunch to enable CDP").
+
+## 6. Build and verification
+
+- [ ] 6.1 Run `npm test` repo-wide; tee to `/tmp/pi-test.log`; grep for failures per AGENTS.md conventions. All tests SHALL pass.
+- [ ] 6.2 Build the client (`npm run build`) and restart the dashboard server (`curl -X POST http://localhost:8000/api/restart`). Confirm no startup errors in `~/.pi/dashboard/server.log`.
+- [ ] 6.3 Reload all connected pi sessions (`npm run reload`). In a fresh session, verify `pi.getCommands()` (or `/skill:` autocomplete) shows the `browser` skill.
+- [ ] 6.4 Open the Electron app via `npm run dev:cdp` in `packages/electron`. Confirm the stderr warning line appears; from a separate shell run `agent-browser connect 9222` and `agent-browser tab`; verify the list includes the main dashboard window.
+- [ ] 6.5 Run `openspec validate ship-browser-skill-and-electron-cdp` — passes cleanly.
+
+## 7. Manual sanity gates before archive
+
+- [ ] 7.1 Launch the production-built Electron app (not the `dev:cdp` script) and confirm CDP is NOT enabled (no `[debug-cdp]` line in stderr, port 9222 not listening).
+- [ ] 7.2 Confirm the `browser` skill's Step-0 preflight behaves correctly in a session where `agent-browser` is NOT installed — the skill emits the install instruction and halts, no side effects.
+- [ ] 7.3 Confirm the universal skill's electron-recipe worked example, when executed against a CDP-enabled Pi Dashboard app, produces a valid screenshot.


### PR DESCRIPTION
Bundle three coordinated parts:

* Electron --debug-cdp[=<port>] + PI_DEBUG_CDP opt-in CDP surface (loopback only, default off).
* Bridge extension ships universal `browser` composite skill to every dashboard session, vendoring agent-browser's core + electron recipes with Step-0 CLI preflight (no CLI bundled).
* Remove repo-local browser-visual-debug skill; migrate content into the universal skill.

4 spec files: 1 new capability (default-browser-skill), 2 modified (electron-shell, bridge-extension), 1 removed (browser-visual-debug). 7 task groups including pre-merge license + install-target verification gates.