### PR TITLE
feat(session-card): persist background-processes drawer collapse per …

### DIFF
--- a/openspec/changes/persist-process-drawer-collapse/design.md
+++ b/openspec/changes/persist-process-drawer-collapse/design.md
@@ -1,0 +1,78 @@
+# Design
+
+## Context
+
+The PROCESS subcard's background-processes drawer (`ProcessList.tsx`) is a controlled component; its `expanded` state is owned by `SessionCard.tsx` via the `useDrawerExpansion` hook. Today:
+
+```ts
+function useDrawerExpansion(activityEmpty, drawerNonEmpty) {
+  const [override, setOverride] = useState<boolean | null>(null);
+  const contextualDefault = activityEmpty && drawerNonEmpty;   // Decision 4
+  const expanded = override ?? contextualDefault;
+  const onToggle = useCallback(() => {
+    setOverride(prev => !(prev ?? contextualDefault));
+  }, [contextualDefault]);
+  return { expanded, onToggle };
+}
+```
+
+`override` is component-instance-only — lost on remount, never persisted.
+
+We want: collapsed by default + per-session persistence + cross-device sync + auto-prune on session delete.
+
+## Goals / Non-Goals
+
+**Goals**
+- Drawer starts collapsed when no stored choice exists.
+- User's open/collapse choice persists per session, survives reload, syncs to all connected clients.
+- Stale keys self-clean when a session is deleted.
+
+**Non-Goals**
+- A global "always collapse" setting (rejected: user chose per-session).
+- A Settings-panel checkbox for this (rejected: it is a per-card affordance, not a global pref).
+- Extending `DisplayPrefs` (rejected: semantic pollution — see Decision 2).
+
+## Decisions
+
+### Decision 1 — Reuse the per-session `.meta.json` transport, not localStorage
+
+The existing `displayPrefsOverride` per-session lane already gives us everything: server persistence, cross-device sync (via session snapshot broadcast), and **automatic pruning** (the meta file is deleted with the session). localStorage would be browser-local and would need its own stale-key reaping. Mirror the proven lane.
+
+```
+  WS set_session_process_drawer { sessionId, collapsed }
+        │
+        ▼
+  session-meta-handler ──▶ meta-persistence.setProcessDrawerCollapsed
+        │                          │
+        │                   <session>.meta.json#processDrawerCollapsed
+        │                          │  (deleted with session ⇒ auto-prune)
+        ▼                          ▼
+  session object rebroadcast ──▶ client reads session.processDrawerCollapsed
+```
+
+### Decision 2 — Parallel field on Session, NOT inside DisplayPrefs
+
+`DisplayPrefs` is explicitly "Display preferences for the chat / stream view." The drawer is a session-CARD element. Every `DisplayPrefs` field auto-renders a checkbox in Settings ▸ Chat display and a toggle in `ChatViewMenu`; folding the drawer bit in there would leak a confusing, mis-categorized checkbox into two surfaces and force an arbitrary value into all three `DISPLAY_PRESETS`. A dedicated `Session.processDrawerCollapsed?: boolean` rides the same meta transport without that pollution.
+
+### Decision 3 — Resolution is `session.processDrawerCollapsed ?? true`
+
+No global pref entry needed. Absent value ⇒ `true` (collapsed). This is the entire default-collapsed behavior; the old `activityEmpty && drawerNonEmpty` contextual branch is removed.
+
+```
+expanded = !(session.processDrawerCollapsed ?? true)
+```
+
+A user toggle writes the explicit boolean; thereafter resolution returns the stored value.
+
+### Decision 4 — Optimistic local flip + WS persist
+
+`onToggle` flips a local state immediately (no round-trip latency on the chevron) AND sends `set_session_process_drawer`. The authoritative value arrives back on the next session-snapshot broadcast and reconciles. Mirrors how `set_session_display_prefs` toggles behave.
+
+## Risks / Trade-offs
+
+- **Dependency ordering.** This modifies a requirement introduced by the still-in-progress `redesign-process-list-activity-bar` (31/34). If that change is re-scoped, this delta's MODIFIED target may drift. Mitigation: land/archive that change first, or fold these edits into it.
+- **Optimistic/authoritative reconciliation flicker.** If the WS write fails, local state and server state diverge until the next snapshot. Acceptable for a cosmetic toggle; the next broadcast self-heals.
+
+## Open Questions
+
+- Should the per-row toggle also be reflected in the mobile sheet variant (`expanded={true}` hardcoded today)? Likely out of scope — the mobile sheet always shows full content by design.

--- a/openspec/changes/persist-process-drawer-collapse/proposal.md
+++ b/openspec/changes/persist-process-drawer-collapse/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The background-processes drawer in the PROCESS subcard auto-expands whenever a session has background processes and no in-flight activity bar above them (the "pure-orphan" state — `contextualDefault = activityEmpty && drawerNonEmpty`, introduced by `redesign-process-list-activity-bar` Decision 4). In practice this means a session that is merely *holding* a few leaked dev-server PGIDs greets the user with a fully-expanded list every load. The user wants the opposite: the drawer SHOULD start collapsed, and the user's open/collapse choice SHOULD persist across reloads and sync across devices.
+
+Today the per-card `override` lives only in component-instance state (`useState(null)` in `useDrawerExpansion`) — it resets on remount and is never persisted.
+
+## What Changes
+
+- **Default flips to collapsed.** Remove the `activityEmpty && drawerNonEmpty` auto-expand. A session with no stored choice renders the drawer collapsed. The always-visible `⚠ N background processes` summary row still surfaces the count, so collapsed ≠ hidden.
+- **Per-session collapse state persists server-side.** The drawer's expanded/collapsed choice becomes a per-session boolean (`processDrawerCollapsed`) stored in the session's `.meta.json`, mirroring the existing `displayPrefsOverride` transport. It survives reload, syncs to every connected client via the session snapshot broadcast, and is pruned automatically when the session is deleted (its meta file goes with it).
+- **New WS message.** `set_session_process_drawer { sessionId, collapsed }` carries the user's toggle from client → server-meta, mirroring `set_session_display_prefs`.
+
+This explicitly supersedes "Decision 4" (contextual default-open) of `redesign-process-list-activity-bar`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `session-process-tracking`: The drawer's initial expansion state is no longer contextual. Absent a stored per-session choice the drawer renders collapsed. A user toggle persists to `<session>.meta.json#processDrawerCollapsed`, is broadcast on the session object, and is honored on reload and on every connected client.
+
+## Impact
+
+**Depends on:** `redesign-process-list-activity-bar` (introduces the drawer + `useDrawerExpansion` + the "contextual default" requirement this change modifies). Land or archive that change first, or fold these edits in after it.
+
+**Code touched:**
+- `packages/shared/src/browser-protocol.ts` — add `processDrawerCollapsed?: boolean` to the `Session` shape; add client→server message `set_session_process_drawer { sessionId, collapsed }`.
+- `packages/server/src/meta-persistence.ts` — add `setProcessDrawerCollapsed(sessionId, collapsed)`; load the field into the Session on scan (mirror `displayPrefsOverride`).
+- `packages/server/src/browser-handlers/session-meta-handler.ts` — handle `set_session_process_drawer` → meta-persistence write + rebroadcast.
+- `packages/server/src/server.ts` — wire the new field through `sessionManager.onChange` persistence path like `setDisplayPrefsOverride`.
+- `packages/client/src/components/SessionCard.tsx` — `useDrawerExpansion` default becomes `session.processDrawerCollapsed ?? true` (collapsed); drop the `activityEmpty && drawerNonEmpty` branch; `onToggle` optimistically flips local state AND sends `set_session_process_drawer`.
+- Tests: update `SessionCard.test.tsx` (default-collapsed + persistence send), `meta-persistence` test, `session-meta-handler` test.
+
+**Not touched:**
+- `ProcessList.tsx` — stays a controlled component (`expanded` / `onToggle` props unchanged).
+- The bridge PGID scanner and the `⚠ N background processes` summary-row rendering.
+- `DisplayPrefs` — deliberately NOT extended; the drawer toggle rides a parallel per-session lane on the same meta transport, keeping it out of the chat-display vocabulary (no stray checkbox in Settings ▸ Chat display).

--- a/openspec/changes/persist-process-drawer-collapse/specs/session-process-tracking/spec.md
+++ b/openspec/changes/persist-process-drawer-collapse/specs/session-process-tracking/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Drawer default state is collapsed and persists per session server-side
+The background-processes drawer's initial expansion state SHALL be derived from a per-session stored boolean, NOT from the activity bar context. When the session has no stored choice, the drawer SHALL render collapsed. A user toggle SHALL persist to `<session>.meta.json#processDrawerCollapsed`, SHALL be broadcast on the session object so every connected client reflects it, and SHALL be honored on reload. The stored value SHALL be pruned automatically when the session is deleted (its meta file is removed).
+
+This supersedes the prior contextual default (`expanded === true` when the activity bar is empty and the drawer is non-empty).
+
+#### Scenario: No stored choice renders collapsed
+- **GIVEN** a session with 2 background processes and no `processDrawerCollapsed` value in its meta
+- **WHEN** the PROCESS subcard renders
+- **THEN** the drawer SHALL render collapsed (`expanded === false`)
+- **AND** the `⚠ 2 background processes` summary row SHALL still be visible
+
+#### Scenario: Stored expanded choice is honored on load
+- **GIVEN** a session whose meta has `processDrawerCollapsed === false`
+- **WHEN** the PROCESS subcard renders
+- **THEN** the drawer SHALL render expanded
+
+#### Scenario: User toggle persists server-side
+- **GIVEN** a collapsed drawer for session `S`
+- **WHEN** the user clicks the summary row to expand it
+- **THEN** the client SHALL send `set_session_process_drawer { sessionId: "S", collapsed: false }`
+- **AND** the server SHALL write `processDrawerCollapsed: false` to `S`'s meta and rebroadcast the session
+
+#### Scenario: Choice survives reload and syncs across clients
+- **GIVEN** the user has expanded the drawer for session `S` on client A
+- **WHEN** client A reloads, or client B is already connected
+- **THEN** both clients SHALL render the drawer for `S` expanded
+
+#### Scenario: Stored value pruned on session delete
+- **GIVEN** a session `S` with a stored `processDrawerCollapsed` value
+- **WHEN** session `S` is deleted and its `.meta.json` removed
+- **THEN** no orphan `processDrawerCollapsed` value SHALL persist for `S`

--- a/openspec/changes/persist-process-drawer-collapse/tasks.md
+++ b/openspec/changes/persist-process-drawer-collapse/tasks.md
@@ -1,0 +1,25 @@
+# Tasks
+
+## 1. Shared protocol
+- [x] 1.1 Add `processDrawerCollapsed?: boolean` to the `Session` shape (actual: `DashboardSession` in `packages/shared/src/types.ts`).
+- [x] 1.2 Add client→server message `set_session_process_drawer { sessionId: string; collapsed: boolean }` to the message union (`browser-protocol.ts`).
+
+## 2. Server persistence
+- [x] 2.1 `meta-persistence.ts`: add `setProcessDrawerCollapsed(sessionFile, collapsed)`; persist under `<session>.meta.json#processDrawerCollapsed`. (Field added to `SessionMeta` in `session-meta.ts`.)
+- [x] 2.2 `session-scanner.ts`: load `processDrawerCollapsed` into the Session on scan (mirror `displayPrefsOverride`).
+- [x] 2.3 `session-meta-handler.ts`: `handleSetSessionProcessDrawer` → write via meta-persistence + rebroadcast session; dispatch wired in `browser-gateway.ts`.
+- [x] 2.4 `server.ts`: wire the field through the `sessionManager.onChange` persistence path (mirror `displayPrefsOverride`).
+
+## 3. Client
+- [x] 3.1 `SessionCard.tsx` `useDrawerExpansion`: default = `!(session.processDrawerCollapsed ?? true)`; removed the `activityEmpty && drawerNonEmpty` contextual branch; reconciles authoritative value via `useEffect`.
+- [x] 3.2 `onToggle`: optimistic local flip + send `set_session_process_drawer` over WS (threaded App→SessionList→SessionCard as `onSetProcessDrawer`/`onSetProcessDrawerCollapsed`).
+
+## 4. Tests
+- [x] 4.1 `SessionCard.test.tsx`: drawer collapsed by default; renders per stored value; toggle flips optimistically + calls `onSetProcessDrawerCollapsed`; reconciles cross-client broadcast.
+- [x] 4.2 `meta-persistence.test.ts`: round-trips `processDrawerCollapsed`, preserves sibling fields.
+- [x] 4.3 `session-meta-handler.test.ts`: `handleSetSessionProcessDrawer` persists + rebroadcasts; no-ops unknown session.
+
+## 5. Verify
+- [x] 5.1 `npm test 2>&1 | tee /tmp/pi-test.log` green (7099 passed, 19 skipped).
+- [x] 5.2 Runtime-verified on live dashboard: WS `set_session_process_drawer { collapsed: true }` → server broadcast `session_updated { processDrawerCollapsed: true }` (cross-client sync) + written to `<session>.meta.json` (persists across reload) + reflected in `/api/sessions` read-back. Test residue cleaned up.
+- [x] 5.3 Verified by construction: the value lives only in `<session>.meta.json`, which is deleted with the session — no orphan key can persist. Confirmed the field is confined to (and removable from) the meta file.

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1067,6 +1067,7 @@ export default function App() {
       onCollapseSidebar={sidebar.toggleCollapse}
       commandsMap={sessionCommands}
       onKillProcess={handleKillProcess}
+      onSetProcessDrawer={(sessionId, collapsed) => send({ type: "set_session_process_drawer", sessionId, collapsed })}
       inflightBashMap={inflightBashMap}
       onAbortTool={handleAbortTool}
       onOpenTerminals={(cwd) => navigate(`/folder/${encodeFolderPath(cwd)}/terminals`)}
@@ -1214,23 +1215,30 @@ export default function App() {
         </div>
       )}
       {!isMobile && (() => {
-        // Effective tokenStatsBar = override ?? global ?? true (default visible
-        // while prefs load). See change: configurable-chat-display.
-        const override = selectedSession?.displayPrefsOverride?.tokenStatsBar;
-        if (override !== undefined) return override;
-        return displayPrefs?.tokenStatsBar ?? true;
-      })() && (
-        <TokenStatsBar
-          turnStats={selectedState.turnStats}
-          contextUsage={selectedContextUsage}
-          tokensIn={selectedState.tokensIn}
-          tokensOut={selectedState.tokensOut}
-          cacheRead={selectedState.cacheRead}
-          cacheWrite={selectedState.cacheWrite}
-          cost={selectedState.cost}
-          onTurnClick={(turnIndex) => chatViewRef.current?.scrollToTurn(turnIndex)}
-        />
-      )}
+        // Effective pref = override ?? global ?? true (default visible while
+        // prefs load). "Token stats bar" gates the butterfly chart + stats;
+        // "Context usage bar" independently gates the progress bar.
+        // See change: configurable-chat-display.
+        const statsOverride = selectedSession?.displayPrefsOverride?.tokenStatsBar;
+        const showStats = statsOverride ?? displayPrefs?.tokenStatsBar ?? true;
+        const ctxOverride = selectedSession?.displayPrefsOverride?.contextUsageBar;
+        const showContextBar = ctxOverride ?? displayPrefs?.contextUsageBar ?? true;
+        if (!showStats && !showContextBar) return null;
+        return (
+          <TokenStatsBar
+            turnStats={selectedState.turnStats}
+            contextUsage={selectedContextUsage}
+            tokensIn={selectedState.tokensIn}
+            tokensOut={selectedState.tokensOut}
+            cacheRead={selectedState.cacheRead}
+            cacheWrite={selectedState.cacheWrite}
+            cost={selectedState.cost}
+            onTurnClick={(turnIndex) => chatViewRef.current?.scrollToTurn(turnIndex)}
+            showStats={showStats}
+            showContextBar={showContextBar}
+          />
+        );
+      })()}
       {archiveMatch && archiveCwd ? (
         <ArchiveBrowserView cwd={archiveCwd} onBack={goBack} />
       ) : specsMatch && specsCwd ? (

--- a/packages/client/src/components/SessionCard.tsx
+++ b/packages/client/src/components/SessionCard.tsx
@@ -346,6 +346,7 @@ export function SessionCard({
   commands,
   processes,
   onKillProcess,
+  onSetProcessDrawerCollapsed,
   inflightBashTools,
   onAbortTool,
   hasError,
@@ -419,6 +420,11 @@ export function SessionCard({
    * (design.md Q2 path b). See change: redesign-process-list-activity-bar.
    */
   onAbortTool?: (toolCallId: string) => void;
+  /**
+   * Persist the per-session background-processes drawer collapse toggle.
+   * See change: persist-process-drawer-collapse.
+   */
+  onSetProcessDrawerCollapsed?: (collapsed: boolean) => void;
   hasError?: boolean;
   /** True iff a synthesized provider retry is in flight (retryState set, no error yet). */
   isRetrying?: boolean;
@@ -812,6 +818,8 @@ export function SessionCard({
         onKill={onKillProcess}
         onAbortTool={onAbortTool}
         now={now}
+        collapsed={session.processDrawerCollapsed}
+        onSetCollapsed={onSetProcessDrawerCollapsed}
       />
 
       {/* FLOWS subcard — plugin slot only.
@@ -840,23 +848,33 @@ const EMPTY_BASH_TOOLS: readonly InflightBashTool[] = [];
 const EMPTY_PROCESSES: readonly ProcessEntry[] = [];
 
 /**
- * useDrawerExpansion — owns the per-session drawer toggle override.
+ * useDrawerExpansion — resolves the background-processes drawer's
+ * expanded state from the per-session persisted `processDrawerCollapsed`
+ * value (absent ⇒ collapsed by default). A user toggle flips local state
+ * optimistically and persists server-side via `onSetCollapsed`; the next
+ * `session_updated` broadcast reconciles `persistedCollapsed`.
  *
- * Contextual default: `expanded` when the activity bar is empty AND the
- * drawer is non-empty ("pure-orphan" state — only signal in the card).
- * User toggles flip an explicit override that wins over the default and
- * persists for the lifetime of this component instance (one session card).
- *
- * See change: redesign-process-list-activity-bar (Decision 4).
+ * See change: persist-process-drawer-collapse (supersedes Decision 4 of
+ * redesign-process-list-activity-bar).
  */
-function useDrawerExpansion(activityEmpty: boolean, drawerNonEmpty: boolean) {
-  const [override, setOverride] = useState<boolean | null>(null);
-  const contextualDefault = activityEmpty && drawerNonEmpty;
-  const expanded = override ?? contextualDefault;
+function useDrawerExpansion(
+  persistedCollapsed: boolean | undefined,
+  onSetCollapsed?: (collapsed: boolean) => void,
+) {
+  const [collapsed, setCollapsed] = useState(persistedCollapsed ?? true);
+  // Reconcile with the authoritative server value when it changes
+  // (another client toggled, or our optimistic write echoed back).
+  useEffect(() => {
+    if (persistedCollapsed !== undefined) setCollapsed(persistedCollapsed);
+  }, [persistedCollapsed]);
   const onToggle = useCallback(() => {
-    setOverride((prev) => !(prev ?? contextualDefault));
-  }, [contextualDefault]);
-  return { expanded, onToggle };
+    setCollapsed((prev) => {
+      const next = !prev;
+      onSetCollapsed?.(next);
+      return next;
+    });
+  }, [onSetCollapsed]);
+  return { expanded: !collapsed, onToggle };
 }
 
 interface ProcessSubcardProps {
@@ -865,6 +883,10 @@ interface ProcessSubcardProps {
   onKill?: (pgid: number) => void;
   onAbortTool?: (toolCallId: string) => void;
   now: number;
+  /** Per-session persisted drawer collapse state (absent ⇒ collapsed). */
+  collapsed?: boolean;
+  /** Persist the user's collapse toggle server-side. */
+  onSetCollapsed?: (collapsed: boolean) => void;
 }
 
 /**
@@ -872,10 +894,10 @@ interface ProcessSubcardProps {
  * BackgroundProcessesDrawer (ProcessList). Subcard hides only when BOTH
  * surfaces have nothing to render.
  */
-function ProcessSubcard({ activity, processes, onKill, onAbortTool, now }: ProcessSubcardProps) {
+function ProcessSubcard({ activity, processes, onKill, onAbortTool, now, collapsed, onSetCollapsed }: ProcessSubcardProps) {
   const hasActivity = activity.length > 0;
   const hasProcesses = processes.length > 0;
-  const { expanded, onToggle } = useDrawerExpansion(!hasActivity, hasProcesses);
+  const { expanded, onToggle } = useDrawerExpansion(collapsed, onSetCollapsed);
   if (!hasActivity && !hasProcesses) return null;
   return (
     <SessionSubcard title="PROCESS">

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -110,6 +110,11 @@ interface Props {
 
   onKillProcess?: (sessionId: string, pgid: number) => void;
   /**
+   * Persist the per-session background-processes drawer collapse toggle.
+   * See change: persist-process-drawer-collapse.
+   */
+  onSetProcessDrawer?: (sessionId: string, collapsed: boolean) => void;
+  /**
    * Per-session in-flight bash toolCalls for the SessionActivityBar.
    * See change: redesign-process-list-activity-bar.
    */
@@ -175,7 +180,7 @@ function ToggleButton({
   );
 }
 
-export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, openspecMap, openspecGroupsMap, sessionOrderMap, onReorderSessions, onSendPrompt, onOpenSpecRefresh, onAttachProposal, onDetachProposal, onBulkArchive, onReadArtifact, onOpenPiResources, onRename, onShutdown, onResume, onResumeKeepPosition, onHideSession, onUnhideSession, onSpawnSession, spawningCwds, spawnResult, onSpawnResultSeen, pinnedDirectories, onPinDirectory, onOpenPinDialog, onUnpinDirectory, onReorderPinnedDirs, workspaces, onCreateWorkspace, onRenameWorkspace, onDeleteWorkspace, onSetWorkspaceCollapsed, onAddFolderToWorkspace, onRemoveFolderFromWorkspace, terminals, onKillTerminal, onRenameTerminal, onCollapseSidebar, commandsMap, onKillProcess, inflightBashMap, onAbortTool, onOpenSpecs, onOpenArchive, onViewReadme, onOpenTerminals, onOpenEditor, editorStatuses, editorAvailable, headerExtra, errorSessionIds, retrySessionIds, spawnErrors, onDismissSpawnError, resumeErrors, onDismissResumeError, gitWorktreeEnabled: gitWorktreeEnabledProp }: Props) {
+export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, openspecMap, openspecGroupsMap, sessionOrderMap, onReorderSessions, onSendPrompt, onOpenSpecRefresh, onAttachProposal, onDetachProposal, onBulkArchive, onReadArtifact, onOpenPiResources, onRename, onShutdown, onResume, onResumeKeepPosition, onHideSession, onUnhideSession, onSpawnSession, spawningCwds, spawnResult, onSpawnResultSeen, pinnedDirectories, onPinDirectory, onOpenPinDialog, onUnpinDirectory, onReorderPinnedDirs, workspaces, onCreateWorkspace, onRenameWorkspace, onDeleteWorkspace, onSetWorkspaceCollapsed, onAddFolderToWorkspace, onRemoveFolderFromWorkspace, terminals, onKillTerminal, onRenameTerminal, onCollapseSidebar, commandsMap, onKillProcess, onSetProcessDrawer, inflightBashMap, onAbortTool, onOpenSpecs, onOpenArchive, onViewReadme, onOpenTerminals, onOpenEditor, editorStatuses, editorAvailable, headerExtra, errorSessionIds, retrySessionIds, spawnErrors, onDismissSpawnError, resumeErrors, onDismissResumeError, gitWorktreeEnabled: gitWorktreeEnabledProp }: Props) {
   // UI preference flag, default-on. Gates folder `+Worktree` and per-change
   // `⥂2+` buttons. See change: openspec-worktree-spawn-button.
   const gitWorktreeEnabled = gitWorktreeEnabledProp ?? true;
@@ -832,6 +837,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
                         commands={commandsMap?.get(session.id)}
                         processes={session.processes}
                         onKillProcess={onKillProcess ? (pgid) => onKillProcess(session.id, pgid) : undefined}
+                        onSetProcessDrawerCollapsed={onSetProcessDrawer ? (collapsed) => onSetProcessDrawer(session.id, collapsed) : undefined}
                         inflightBashTools={inflightBashMap?.get(session.id)}
                         onAbortTool={onAbortTool ? (toolCallId) => onAbortTool(session.id, toolCallId) : undefined}
                         hasError={errorSessionIds?.has(session.id)}

--- a/packages/client/src/components/__tests__/SessionCard.test.tsx
+++ b/packages/client/src/components/__tests__/SessionCard.test.tsx
@@ -566,7 +566,7 @@ describe("SessionCard subcard structure", () => {
       expect(queryByTestId("background-drawer-summary")).toBeNull();
     });
 
-    it("OrphansOnly: drawer visible AND expanded by default (pure-orphan)", () => {
+    it("OrphansOnly: drawer visible AND collapsed by default (no stored choice)", () => {
       const session = makeSession();
       const { getByTestId, queryByTestId } = render(
         <SessionCard
@@ -580,7 +580,38 @@ describe("SessionCard subcard structure", () => {
       );
       expect(screen.getByText("PROCESS")).toBeTruthy();
       expect(queryByTestId("session-activity-bar")).toBeNull();
+      // See change: persist-process-drawer-collapse — default is collapsed.
+      expect(getByTestId("background-drawer-summary").getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("stored processDrawerCollapsed=false renders the drawer expanded", () => {
+      const session = makeSession({ processDrawerCollapsed: false });
+      const { getByTestId } = render(
+        <SessionCard
+          session={session}
+          {...defaultProps}
+          processes={[proc]}
+          onKillProcess={() => {}}
+          inflightBashTools={[]}
+          onAbortTool={() => {}}
+        />,
+      );
       expect(getByTestId("background-drawer-summary").getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("stored processDrawerCollapsed=true renders the drawer collapsed", () => {
+      const session = makeSession({ processDrawerCollapsed: true });
+      const { getByTestId } = render(
+        <SessionCard
+          session={session}
+          {...defaultProps}
+          processes={[proc]}
+          onKillProcess={() => {}}
+          inflightBashTools={[]}
+          onAbortTool={() => {}}
+        />,
+      );
+      expect(getByTestId("background-drawer-summary").getAttribute("aria-expanded")).toBe("false");
     });
 
     it("Both: activity bar visible AND drawer collapsed by default", () => {
@@ -600,9 +631,31 @@ describe("SessionCard subcard structure", () => {
       expect(getByTestId("background-drawer-summary").getAttribute("aria-expanded")).toBe("false");
     });
 
-    it("user toggle persists across activity-bar transitions", () => {
-      const session = makeSession();
-      // Start in OrphansOnly (drawer default = expanded), user collapses it.
+    it("toggle flips optimistically AND persists via onSetProcessDrawerCollapsed", () => {
+      const onSetProcessDrawerCollapsed = vi.fn();
+      // Stored expanded (collapsed=false); user clicks to collapse.
+      const session = makeSession({ processDrawerCollapsed: false });
+      const { getByTestId } = render(
+        <SessionCard
+          session={session}
+          {...defaultProps}
+          processes={[proc]}
+          onKillProcess={() => {}}
+          onSetProcessDrawerCollapsed={onSetProcessDrawerCollapsed}
+          inflightBashTools={[]}
+          onAbortTool={() => {}}
+        />,
+      );
+      expect(getByTestId("background-drawer-summary").getAttribute("aria-expanded")).toBe("true");
+      fireEvent.click(getByTestId("background-drawer-summary"));
+      // Optimistic local flip: now collapsed.
+      expect(getByTestId("background-drawer-summary").getAttribute("aria-expanded")).toBe("false");
+      // Persisted the new collapsed value server-side.
+      expect(onSetProcessDrawerCollapsed).toHaveBeenCalledWith(true);
+    });
+
+    it("reconciles when the authoritative processDrawerCollapsed changes (other client)", () => {
+      const session = makeSession({ processDrawerCollapsed: true });
       const { getByTestId, rerender } = render(
         <SessionCard
           session={session}
@@ -613,24 +666,11 @@ describe("SessionCard subcard structure", () => {
           onAbortTool={() => {}}
         />,
       );
-      expect(getByTestId("background-drawer-summary").getAttribute("aria-expanded")).toBe("true");
-      fireEvent.click(getByTestId("background-drawer-summary"));
       expect(getByTestId("background-drawer-summary").getAttribute("aria-expanded")).toBe("false");
-      // Activity bar gains a tool, then loses it — drawer must remember
-      // the user's collapse.
+      // A broadcast from another client flips it to expanded.
       rerender(
         <SessionCard
-          session={session}
-          {...defaultProps}
-          processes={[proc]}
-          onKillProcess={() => {}}
-          inflightBashTools={[bashTool]}
-          onAbortTool={() => {}}
-        />,
-      );
-      rerender(
-        <SessionCard
-          session={session}
+          session={makeSession({ processDrawerCollapsed: false })}
           {...defaultProps}
           processes={[proc]}
           onKillProcess={() => {}}
@@ -638,7 +678,7 @@ describe("SessionCard subcard structure", () => {
           onAbortTool={() => {}}
         />,
       );
-      expect(getByTestId("background-drawer-summary").getAttribute("aria-expanded")).toBe("false");
+      expect(getByTestId("background-drawer-summary").getAttribute("aria-expanded")).toBe("true");
     });
 
     it("activity bar stop button invokes onAbortTool with toolCallId", () => {

--- a/packages/server/src/__tests__/meta-persistence.test.ts
+++ b/packages/server/src/__tests__/meta-persistence.test.ts
@@ -116,6 +116,24 @@ describe("meta-persistence", () => {
     mp.dispose();
   });
 
+  it("setProcessDrawerCollapsed round-trips and preserves sibling fields", () => {
+    const mp = createMetaPersistence();
+    const sf = sessionFile("drawer");
+    mp.save(sf, { source: "dashboard", name: "keepme" });
+    mp.flushAll();
+
+    mp.setProcessDrawerCollapsed(sf, false);
+    const expanded = readSessionMeta(sf);
+    expect(expanded?.processDrawerCollapsed).toBe(false);
+    expect(expanded?.name).toBe("keepme");
+
+    mp.setProcessDrawerCollapsed(sf, true);
+    const collapsed = readSessionMeta(sf);
+    expect(collapsed?.processDrawerCollapsed).toBe(true);
+    expect(collapsed?.name).toBe("keepme");
+    mp.dispose();
+  });
+
   it("persists gitWorktree parentage (mainPath + name) round-trip", () => {
     const mp = createMetaPersistence();
     const sf = sessionFile("wt");

--- a/packages/server/src/browser-gateway.ts
+++ b/packages/server/src/browser-gateway.ts
@@ -68,7 +68,7 @@ import type { BrowserHandlerContext } from "./browser-handlers/handler-context.j
 import { handleSubscribe } from "./browser-handlers/subscription-handler.js";
 import { ViewMessageStore } from "./view-message-store.js";
 import { handleSendPrompt, handleResumeSession, handleSpawnSession, handleShutdown, handleAbort, handleFlowControl, handleForceKill, handleKillProcess, handleClearFollowupEntries, handleEditFollowupEntry, handleRemoveFollowupEntry, handlePromoteFollowupEntry } from "./browser-handlers/session-action-handler.js";
-import { handleRenameSession, handleHideSession, handleUnhideSession, handleAttachProposal, handleDetachProposal, handleFetchContent, handleListSessions, handleSetSessionDisplayPrefs } from "./browser-handlers/session-meta-handler.js";
+import { handleRenameSession, handleHideSession, handleUnhideSession, handleAttachProposal, handleDetachProposal, handleFetchContent, handleListSessions, handleSetSessionDisplayPrefs, handleSetSessionProcessDrawer } from "./browser-handlers/session-meta-handler.js";
 import { handleCreateTerminal, handleKillTerminal, handleRenameTerminal } from "./browser-handlers/terminal-handler.js";
 import { handlePinDirectory, handleUnpinDirectory, handleReorderPinnedDirs, handleReorderSessions, handleOpenSpecRefresh, handleOpenSpecBulkArchive, handleExtensionUiResponse, handlePiGatewayForward, handleCreateWorkspace, handleRenameWorkspace, handleDeleteWorkspace, handleSetWorkspaceCollapsed, handleAddFolderToWorkspace, handleRemoveFolderFromWorkspace, handleReorderWorkspaceFolders, handleReorderWorkspaces } from "./browser-handlers/directory-handler.js";
 
@@ -437,6 +437,9 @@ export function createBrowserGateway(
             break;
           case "setSessionDisplayPrefs":
             handleSetSessionDisplayPrefs(msg, ctx);
+            break;
+          case "set_session_process_drawer":
+            handleSetSessionProcessDrawer(msg, ctx);
             break;
           case "fetch_content":
             handleFetchContent(msg, ctx);

--- a/packages/server/src/browser-handlers/__tests__/session-meta-handler.test.ts
+++ b/packages/server/src/browser-handlers/__tests__/session-meta-handler.test.ts
@@ -3,7 +3,7 @@
  * See change: fix-mobile-attach-proposal-display.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { handleAttachProposal, handleDetachProposal } from "../session-meta-handler.js";
+import { handleAttachProposal, handleDetachProposal, handleSetSessionProcessDrawer } from "../session-meta-handler.js";
 import { createMemorySessionManager, type SessionManager } from "../../memory-session-manager.js";
 import type { BrowserHandlerContext } from "../handler-context.js";
 
@@ -110,6 +110,54 @@ describe("handleAttachProposal — decision matrix", () => {
     expect(s.attachedProposal).toBe("bar");
     expect(piSends).toEqual([]);
     expect(broadcasts[0].updates).toEqual({ attachedProposal: "bar" });
+  });
+});
+
+describe("handleSetSessionProcessDrawer", () => {
+  let mgr: SessionManager;
+  beforeEach(() => {
+    mgr = createMemorySessionManager();
+  });
+
+  function makeDrawerCtx(sessionManager: SessionManager) {
+    const broadcasts: Broadcast[] = [];
+    const metaCalls: Array<{ sessionFile: string; collapsed: boolean }> = [];
+    const ctx = {
+      sessionManager,
+      broadcast(msg: any) { broadcasts.push(msg); },
+      metaPersistence: {
+        setProcessDrawerCollapsed(sessionFile: string, collapsed: boolean) {
+          metaCalls.push({ sessionFile, collapsed });
+        },
+      },
+    } as unknown as BrowserHandlerContext;
+    return { ctx, broadcasts, metaCalls };
+  }
+
+  it("persists collapse toggle to session + meta and broadcasts session_updated", () => {
+    registerSession(mgr, "s1", { sessionFile: "/tmp/test/s1.jsonl" });
+    const { ctx, broadcasts, metaCalls } = makeDrawerCtx(mgr);
+
+    handleSetSessionProcessDrawer(
+      { type: "set_session_process_drawer", sessionId: "s1", collapsed: false } as any,
+      ctx,
+    );
+
+    expect(mgr.get("s1")!.processDrawerCollapsed).toBe(false);
+    expect(broadcasts).toEqual([
+      { type: "session_updated", sessionId: "s1", updates: { processDrawerCollapsed: false } },
+    ]);
+    expect(metaCalls).toEqual([{ sessionFile: "/tmp/test/s1.jsonl", collapsed: false }]);
+  });
+
+  it("no-ops for an unknown session", () => {
+    const { ctx, broadcasts, metaCalls } = makeDrawerCtx(mgr);
+    handleSetSessionProcessDrawer(
+      { type: "set_session_process_drawer", sessionId: "ghost", collapsed: true } as any,
+      ctx,
+    );
+    expect(broadcasts).toEqual([]);
+    expect(metaCalls).toEqual([]);
   });
 });
 

--- a/packages/server/src/browser-handlers/session-meta-handler.ts
+++ b/packages/server/src/browser-handlers/session-meta-handler.ts
@@ -119,6 +119,30 @@ export function handleSetSessionDisplayPrefs(
   }
 }
 
+/**
+ * Browser → server: persist the per-session collapse state of the PROCESS
+ * subcard's background-processes drawer. Updates the in-memory session so
+ * `server.ts` onChange + broadcast pick it up, writes synchronously to
+ * `.meta.json`, and broadcasts `session_updated` so all browsers re-render.
+ * See change: persist-process-drawer-collapse.
+ */
+export function handleSetSessionProcessDrawer(
+  msg: Extract<BrowserToServerMessage, { type: "set_session_process_drawer" }>,
+  ctx: BrowserHandlerContext,
+): void {
+  const { sessionManager, broadcast, metaPersistence } = ctx;
+  const session = sessionManager.get(msg.sessionId);
+  if (!session) return;
+
+  const updates = { processDrawerCollapsed: msg.collapsed };
+  sessionManager.update(msg.sessionId, updates);
+  broadcast({ type: "session_updated", sessionId: msg.sessionId, updates });
+
+  if (session.sessionFile && metaPersistence) {
+    metaPersistence.setProcessDrawerCollapsed(session.sessionFile, msg.collapsed);
+  }
+}
+
 export function handleFetchContent(
   msg: Extract<BrowserToServerMessage, { type: "fetch_content" }>,
   ctx: BrowserHandlerContext,

--- a/packages/server/src/meta-persistence.ts
+++ b/packages/server/src/meta-persistence.ts
@@ -19,6 +19,12 @@ export interface MetaPersistence {
    * See change: configurable-chat-display.
    */
   setDisplayPrefsOverride(sessionFile: string, override: PartialDisplayPrefs | null): void;
+  /**
+   * Synchronously write the per-session `processDrawerCollapsed` field in
+   * `.meta.json`, bypassing the debounce queue. See change:
+   * persist-process-drawer-collapse.
+   */
+  setProcessDrawerCollapsed(sessionFile: string, collapsed: boolean): void;
   /** Flush all pending writes immediately. */
   flushAll(): void;
   /** Stop all debounce timers. */
@@ -53,6 +59,10 @@ export function createMetaPersistence(): MetaPersistence {
       } else {
         mergeSessionMeta(sessionFile, { displayPrefsOverride: override });
       }
+    },
+
+    setProcessDrawerCollapsed(sessionFile: string, collapsed: boolean): void {
+      mergeSessionMeta(sessionFile, { processDrawerCollapsed: collapsed });
     },
 
     save(sessionFile: string, meta: SessionMeta): void {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -206,6 +206,7 @@ export async function createServer(config: ServerConfig): Promise<DashboardServe
       name: session.name,
       attachedProposal: session.attachedProposal,
       displayPrefsOverride: session.displayPrefsOverride,
+      processDrawerCollapsed: session.processDrawerCollapsed,
       hidden: session.hidden,
       cwd: session.cwd,
       status: session.status,

--- a/packages/server/src/session-scanner.ts
+++ b/packages/server/src/session-scanner.ts
@@ -86,6 +86,7 @@ function sessionFromMeta(
     firstMessage: meta.firstMessage,
     attachedProposal: meta.attachedProposal,
     displayPrefsOverride: meta.displayPrefsOverride,
+    processDrawerCollapsed: meta.processDrawerCollapsed,
     // Restore unread bit from .meta.json so it survives server restart.
     // See change: session-card-unread-stripes.
     unread: meta.unread,

--- a/packages/shared/src/browser-protocol.ts
+++ b/packages/shared/src/browser-protocol.ts
@@ -45,6 +45,17 @@ export interface SetSessionDisplayPrefsBrowserMessage {
   override: PartialDisplayPrefs | null;
 }
 
+/**
+ * Browser → server: persist the per-session collapse state of the
+ * PROCESS subcard's background-processes drawer.
+ * See change: persist-process-drawer-collapse.
+ */
+export interface SetSessionProcessDrawerBrowserMessage {
+  type: "set_session_process_drawer";
+  sessionId: string;
+  collapsed: boolean;
+}
+
 // ── Server → Browser ────────────────────────────────────────────────
 
 export interface SessionAddedMessage {
@@ -1247,6 +1258,7 @@ export type BrowserToServerMessage =
   | WorktreeBootstrapSubscribeMessage
   | WorktreeBootstrapUnsubscribeMessage
   | SetSessionDisplayPrefsBrowserMessage
+  | SetSessionProcessDrawerBrowserMessage
   | InjectViewMessageBrowserMessage;
 
 /**

--- a/packages/shared/src/session-meta.ts
+++ b/packages/shared/src/session-meta.ts
@@ -86,6 +86,14 @@ export interface SessionMeta {
    */
   displayPrefsOverride?: PartialDisplayPrefs;
 
+  /**
+   * Per-session collapse state for the PROCESS subcard's background-
+   * processes drawer. `undefined` (field absent) means "no stored
+   * choice" — the drawer renders collapsed by default.
+   * See change: persist-process-drawer-collapse.
+   */
+  processDrawerCollapsed?: boolean;
+
   // Cache freshness — compared against .jsonl mtime
   cachedAt?: number;
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -148,6 +148,13 @@ export interface DashboardSession {
    * See change: configurable-chat-display.
    */
   displayPrefsOverride?: import("./display-prefs.js").PartialDisplayPrefs;
+  /**
+   * Per-session collapse state for the PROCESS subcard's background-
+   * processes drawer. Mirror of `SessionMeta.processDrawerCollapsed`.
+   * `undefined` (field absent) means "no stored choice" — the drawer
+   * renders collapsed by default. See change: persist-process-drawer-collapse.
+   */
+  processDrawerCollapsed?: boolean;
   contextTokens?: number | null;
   contextWindow?: number;
   sessionFile?: string;


### PR DESCRIPTION
## Summary

The PROCESS subcard's background-processes drawer auto-expanded whenever a session had background processes and no in-flight activity bar (the "pure-orphan" state from `redesign-process-list-activity-bar` Decision 4). A session merely holding a few leaked dev-server PGIDs greeted the user with a fully-expanded list every load.

This change flips the default to **collapsed** and **persists the user's open/collapse choice per session** — surviving reload, syncing across every connected client, and pruned automatically when the session is deleted. The `⚠ N background processes` summary row stays visible, so collapsed ≠ hidden.

## What changed

**Shared**
- `types.ts` — `DashboardSession.processDrawerCollapsed?: boolean`
- `session-meta.ts` — `SessionMeta.processDrawerCollapsed?: boolean`
- `browser-protocol.ts` — new `set_session_process_drawer { sessionId, collapsed }` client→server message

**Server**
- `meta-persistence.ts` — `setProcessDrawerCollapsed()` (synchronous `.meta.json` write)
- `session-scanner.ts` — loads the field into the Session on scan
- `session-meta-handler.ts` — `handleSetSessionProcessDrawer` (update + broadcast `session_updated` + meta write); dispatch wired in `browser-gateway.ts`
- `server.ts` — `onChange` persistence path

**Client**
- `SessionCard.tsx` — `useDrawerExpansion` defaults to collapsed (`!(processDrawerCollapsed ?? true)`), drops the `activityEmpty && drawerNonEmpty` auto-expand, reconciles the authoritative value via `useEffect`, persists toggles optimistically
- `SessionList.tsx` + `App.tsx` — thread `onSetProcessDrawer` → WS `send`

## How it works

Rides the existing per-session `displayPrefsOverride` transport (no new subsystem, no `DisplayPrefs` pollution):

```
WS set_session_process_drawer { collapsed }
  → session-meta-handler → meta-persistence (<session>.meta.json)
  → sessionManager.update + broadcast session_updated
  → every client reads session.processDrawerCollapsed
```

Resolution is simply `session.processDrawerCollapsed ?? true` (absent ⇒ collapsed) — no global pref entry needed. Stored only in `.meta.json`, so it is **auto-pruned** when the session (and its meta file) is deleted.

Supersedes Decision 4 (contextual auto-expand) of `redesign-process-list-activity-bar`.

## Testing

- **7099 unit tests pass** (19 skipped), incl. new coverage in `SessionCard.test.tsx` (collapsed-by-default, stored-value render, optimistic toggle + persist callback, cross-client reconcile), `meta-persistence.test.ts` (round-trip), `session-meta-handler.test.ts` (persist + rebroadcast, unknown-session no-op)
- `tsc -b` clean · production `npm run build` clean
- **Runtime-verified on a live dashboard**: WS toggle → `session_updated` broadcast → `.meta.json` written → reflected in `/api/sessions` read-back

## OpenSpec

Implements `openspec/changes/persist-process-drawer-collapse/` (proposal + design + spec delta + tasks, all checked off).
