### PR TITLE
[codex] Add Simplified Chinese localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 
 - [Quickstart](#quickstart)
 - [Features](#features)
+- [Chinese UI](#chinese-ui)
 - [Prerequisites](#prerequisites)
 - [Configuration](#configuration)
 - [Usage](#usage)
@@ -205,6 +206,20 @@ Remove with `pi remove /path/to/pi-agent-dashboard`. Alternatively, add the pack
 **Networking & distribution**
 - **Network discovery** — mDNS-based auto-discovery of other dashboard servers on the local network
 - **Zrok tunnel** — optional persistent public URL via reserved shares (see [Configuration → Tunnel](#tunnel-zrok))
+
+---
+
+## Chinese UI
+
+PI Dashboard now includes a lightweight Simplified Chinese interface for the core operator workflow: onboarding, the session sidebar, chat composer, connection banners, Settings, provider setup, and package management.
+
+The language selector lives in **Settings → General → Interface**. English remains the default for existing users, and the selection is saved in the browser. Deployments that want to start in Chinese can build the web client with:
+
+```bash
+VITE_PI_DASHBOARD_DEFAULT_LANGUAGE=zh-CN npm run build --workspace=@blackbelt-technology/pi-dashboard-web
+```
+
+This keeps plugin-provided dynamic content, package names, model names, and command output unchanged while making the main dashboard usable for Chinese-speaking operators out of the box.
 
 ---
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -97,6 +97,7 @@ import { ApiContext, deriveApiBase, VITE_API_URL, setGlobalApiBase } from "./lib
 import { DisplayPrefsProvider } from "./lib/DisplayPrefsContext.js";
 import { FirstLaunchDisplayModal } from "./components/FirstLaunchDisplayModal.js";
 import { SessionAssetsProvider } from "./lib/SessionAssetsContext.js";
+import { useI18n } from "./lib/i18n.js";
 import { PluginContextProvider, applyPluginConfigUpdate, type SubagentStateSnapshot } from "@blackbelt-technology/dashboard-plugin-runtime/context";
 // Stable empty references for plugin context's session-state primitives.
 // See change: route-flow-asks-to-upper-slot + add-flow-agent-popout.
@@ -269,6 +270,7 @@ function PiResourceFileRoute({
 }
 
 export default function App() {
+  const { t } = useI18n();
   const [wsUrl, setWsUrl] = useState(getInitialWsUrl);
   const { send, onMessage, status } = useWebSocket(wsUrl);
   // Worktree-init bus needs a way to send subscribe/unsubscribe
@@ -1135,19 +1137,19 @@ export default function App() {
     <>
       {status === "connecting" && (
         <div className="bg-yellow-600/20 text-yellow-400 text-xs px-3 py-1 text-center">
-          Connecting...
+          {t("connection.connecting", undefined, "Connecting...")}
         </div>
       )}
       {status === "offline" && (
         <div className="bg-red-600/20 text-red-400 text-xs px-3 py-1 text-center">
-          Server offline
+          {t("connection.offline", undefined, "Server offline")}
         </div>
       )}
       {status === "auth_required" && (
         <div className="bg-amber-600/20 text-amber-400 text-xs px-3 py-1 text-center">
-          Session expired —{" "}
+          {t("connection.authRequired", undefined, "Session expired")}{" - "}
           <a href={`${apiBase}/auth/login?return=${encodeURIComponent(window.location.pathname)}`} className="underline hover:text-amber-300">
-            Sign in
+            {t("connection.signIn", undefined, "Sign in")}
           </a>
         </div>
       )}
@@ -1225,7 +1227,7 @@ export default function App() {
               <span className="text-yellow-400">⚡ {selectedState.currentTool}</span>
             )}
             {selectedState.status === "streaming" && !selectedState.currentTool && (
-              <span className="text-green-400">Thinking…</span>
+              <span className="text-green-400">{t("status.thinking", undefined, "Thinking...")}</span>
             )}
             <span className="flex-1" />
             {selectedState.cost > 0 && <span>${selectedState.cost.toFixed(2)}</span>}
@@ -1325,8 +1327,8 @@ export default function App() {
           <ErrorBoundary fallback={
             <div className="flex-1 flex items-center justify-center p-8">
               <div className="text-center space-y-2">
-                <div className="text-red-400 text-sm">Chat view encountered an error</div>
-                <button onClick={() => window.location.reload()} className="text-xs text-blue-400 hover:underline">Reload page</button>
+                <div className="text-red-400 text-sm">{t("shell.chatError", undefined, "Chat view encountered an error")}</div>
+                <button onClick={() => window.location.reload()} className="text-xs text-blue-400 hover:underline">{t("shell.reloadPage", undefined, "Reload page")}</button>
               </div>
             </div>
           }>
@@ -1473,10 +1475,10 @@ export default function App() {
             }));
             return (
               <SearchableSelectDialog
-                title="Extension Modules"
+                title={t("extension.modules", undefined, "Extension Modules")}
                 options={options}
-                placeholder="Search modules..."
-                emptyMessage="No modules available"
+                placeholder={t("extension.searchModules", undefined, "Search modules...")}
+                emptyMessage={t("extension.noModules", undefined, "No modules available")}
                 onSelect={(moduleId) => {
                   setExtensionModuleOpen({ sessionId: selectedId, moduleId });
                   setExtensionModulePickerOpen(false);
@@ -1592,8 +1594,8 @@ export default function App() {
         <ErrorBoundary fallback={
           <div className="min-h-screen flex items-center justify-center p-8 bg-[var(--bg-primary)] text-[var(--text-primary)]" data-testid="shell-error-fallback">
             <div className="text-center space-y-2">
-              <div className="text-red-400 text-sm">Shell encountered an error</div>
-              <button onClick={() => window.location.reload()} className="text-xs text-blue-400 hover:underline">Reload page</button>
+              <div className="text-red-400 text-sm">{t("shell.error", undefined, "Shell encountered an error")}</div>
+              <button onClick={() => window.location.reload()} className="text-xs text-blue-400 hover:underline">{t("shell.reloadPage", undefined, "Reload page")}</button>
             </div>
           </div>
         }>
@@ -1873,6 +1875,7 @@ export default function App() {
  * See change: redesign-session-card-and-composer (refresh-before-model).
  */
 function StatusBarRefreshButton({ cwd, onRefresh }: { cwd: string; onRefresh: (cwd: string) => void }) {
+  const { t } = useI18n();
   const [spinning, setSpinning] = useState(false);
   return (
     <button
@@ -1882,7 +1885,7 @@ function StatusBarRefreshButton({ cwd, onRefresh }: { cwd: string; onRefresh: (c
         setSpinning(true);
         setTimeout(() => setSpinning(false), 600);
       }}
-      title="Refresh OpenSpec data"
+      title={t("status.refreshOpenSpec", undefined, "Refresh OpenSpec data")}
       data-testid="statusbar-refresh-btn"
       className="text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] p-0.5"
     >

--- a/packages/client/src/components/CommandInput.tsx
+++ b/packages/client/src/components/CommandInput.tsx
@@ -6,6 +6,7 @@ import type { ChatMessage } from "../lib/event-reducer.js";
 import { useImagePaste } from "../hooks/useImagePaste.js";
 import { ImagePreviewStrip } from "./ImagePreviewStrip.js";
 import { extractRecentUrls } from "../lib/extract-urls.js";
+import { useI18n } from "../lib/i18n.js";
 
 /** Built-in pi commands available from the dashboard */
 const BUILTIN_COMMANDS: CommandInfo[] = [
@@ -151,6 +152,7 @@ function extractAtQuery(text: string): string | null {
 type StopState = "idle" | "aborting" | "killing";
 
 export function CommandInput({ commands: externalCommands, onSend, onListFiles, fileResults, disabled, sessionStatus, retrying, onAbort, onForceKill, pendingPrompt, onCancelPending, sessionId, draft, onDraftChange, history, images, onImagesChange, currentCwd, onViewLocal, onOpenInlineTerminal, sessionMessages }: Props) {
+  const { t } = useI18n();
   // Treat retry-sleep as "still working" for Stop/Force-Stop visibility.
   const isWorking = sessionStatus === "streaming" || retrying === true;
   // Merge server commands with built-in + dashboard-local commands, avoiding duplicates.
@@ -336,6 +338,22 @@ export function CommandInput({ commands: externalCommands, onSend, onListFiles, 
       inputRef.current?.setSelectionRange(newCursorPos, newCursorPos);
       inputRef.current?.focus();
     });
+  };
+
+  const localizedCommandDescription = (cmd: CommandInfo) => {
+    if (cmd.source !== "builtin") return cmd.description;
+    switch (cmd.name) {
+      case "compact":
+        return t("command.compactDescription", undefined, cmd.description);
+      case "reload":
+        return t("command.reloadDescription", undefined, cmd.description);
+      case "new":
+        return t("command.newDescription", undefined, cmd.description);
+      case "view":
+        return t("command.previewDescription", undefined, cmd.description);
+      default:
+        return cmd.description;
+    }
   };
 
   const handleSend = useCallback((delivery?: "steer" | "followUp") => {
@@ -529,7 +547,7 @@ export function CommandInput({ commands: externalCommands, onSend, onListFiles, 
               <span className="inline-flex">{sourceIcons[cmd.source] ?? <Icon path={mdiFlash} size={0.6} />}</span>
               <span className="font-mono text-blue-400">/{cmd.name}</span>
               {cmd.description && (
-                <span className="text-[var(--text-tertiary)] truncate">{cmd.description}</span>
+                <span className="text-[var(--text-tertiary)] truncate">{localizedCommandDescription(cmd)}</span>
               )}
             </button>
           ))}
@@ -597,7 +615,7 @@ export function CommandInput({ commands: externalCommands, onSend, onListFiles, 
           }}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
-          placeholder="Message, /command, !shell, or @file..."
+          placeholder={t("command.placeholder", undefined, "Message, /command, !shell, or @file...")}
           /* Bridge-owned mid-turn queue: keep input enabled while the agent
              is streaming so further sends queue. Per the modified
              `optimistic-prompt` capability, disable only when pendingPrompt
@@ -618,7 +636,7 @@ export function CommandInput({ commands: externalCommands, onSend, onListFiles, 
             onClick={() => onOpenInlineTerminal()}
             disabled={disabled}
             className="p-2 bg-[var(--bg-tertiary)] rounded-lg hover:bg-[var(--bg-surface)] disabled:opacity-50 disabled:cursor-not-allowed self-end"
-            title="Open inline terminal"
+            title={t("command.inlineTerminal", undefined, "Open inline terminal")}
             data-testid="open-inline-terminal-button"
           >
             <Icon path={mdiConsole} size={0.7} />
@@ -630,7 +648,7 @@ export function CommandInput({ commands: externalCommands, onSend, onListFiles, 
              user can queue another mid-turn message. */
           disabled={disabled || (pendingPrompt && !isWorking) || !text.trim()}
           className="p-2 bg-blue-600 rounded-lg hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed self-end"
-          title="Send"
+          title={t("command.send", undefined, "Send")}
           data-testid="send-button"
         >
           <Icon path={mdiPlay} size={0.7} />
@@ -646,7 +664,7 @@ export function CommandInput({ commands: externalCommands, onSend, onListFiles, 
               }
             }}
             className="p-2 bg-red-600 rounded-lg hover:bg-red-500 self-end"
-            title="Stop"
+            title={t("command.stop", undefined, "Stop")}
             data-testid="stop-button"
           >
             <Icon path={mdiStop} size={0.7} />
@@ -656,7 +674,7 @@ export function CommandInput({ commands: externalCommands, onSend, onListFiles, 
           <button
             onClick={() => { onForceKill(); setStopState("killing"); }}
             className="p-2 bg-orange-600 rounded-lg hover:bg-orange-500 self-end animate-pulse"
-            title="Force Stop — kill the process"
+            title={t("command.forceStop", undefined, "Force Stop - kill the process")}
             data-testid="force-stop-button"
           >
             <Icon path={mdiAlert} size={0.7} />
@@ -666,7 +684,7 @@ export function CommandInput({ commands: externalCommands, onSend, onListFiles, 
           <button
             disabled
             className="p-2 bg-orange-800 rounded-lg opacity-60 cursor-not-allowed self-end"
-            title="Killing process..."
+            title={t("command.killing", undefined, "Killing process...")}
             data-testid="killing-button"
           >
             <Icon path={mdiStop} size={0.7} />

--- a/packages/client/src/components/LandingPage.tsx
+++ b/packages/client/src/components/LandingPage.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useI18n } from "../lib/i18n.js";
 
 export interface LandingPageProps {
   /** True when at least one LLM provider has a non-empty apiKey. */
@@ -57,10 +58,11 @@ function Card({
   onClick: () => void;
   titleAttr?: string;
 }) {
+  const { t } = useI18n();
   return (
     <div className="flex flex-col gap-3 p-4 rounded-lg border border-[var(--border-secondary)] bg-[var(--bg-secondary)] w-full sm:w-56">
       <div className="flex items-center gap-2">
-        <span className="text-xs text-[var(--text-tertiary)]">Step {step}</span>
+        <span className="text-xs text-[var(--text-tertiary)]">{t("landing.step", { step }, `Step ${step}`)}</span>
       </div>
       <div className="text-base font-semibold text-[var(--text-primary)]">{title}</div>
       <div className="text-xs text-[var(--text-tertiary)] flex-1">{description}</div>
@@ -94,6 +96,7 @@ export function LandingPage({
   onSpawnSession,
   navigate,
 }: LandingPageProps = {}) {
+  const { t } = useI18n();
   // Legacy behaviour: if no onboarding props are supplied at all, fall back to the
   // original minimal placeholder (keeps existing tests and stories intact).
   const hasOnboardingContext =
@@ -106,7 +109,7 @@ export function LandingPage({
       <div className="flex-1 flex items-center justify-center text-[var(--text-tertiary)]">
         <div className="text-center">
           <div className="text-6xl mb-4 text-blue-500 opacity-50">π</div>
-          <p className="text-sm">Select a session to get started</p>
+          <p className="text-sm">{t("landing.selectSession", undefined, "Select a session to get started")}</p>
         </div>
       </div>
     );
@@ -133,11 +136,13 @@ export function LandingPage({
         <div className="text-center">
           <div className="text-6xl mb-2 text-blue-500 opacity-50">π</div>
           <div className="text-lg font-semibold text-[var(--text-primary)]">
-            {allDone ? "Pick a session on the left to continue" : "Welcome to pi-dashboard"}
+            {allDone
+              ? t("landing.pickSession", undefined, "Pick a session on the left to continue")
+              : t("landing.welcome", undefined, "Welcome to pi-dashboard")}
           </div>
           {!allDone && (
             <p className="text-xs text-[var(--text-tertiary)] mt-1">
-              Three quick steps to get your first session running.
+              {t("landing.stepsHint", undefined, "Three quick steps to get your first session running.")}
             </p>
           )}
         </div>
@@ -145,13 +150,13 @@ export function LandingPage({
         <div className="flex flex-col sm:flex-row gap-3 w-full justify-center flex-wrap">
           {/* Step 1 */}
           {step1 === "done" ? (
-            <DoneRow testId="onboarding-step-1-done" label="Credentials configured" />
+            <DoneRow testId="onboarding-step-1-done" label={t("landing.credentialsConfigured", undefined, "Credentials configured")} />
           ) : (
             <Card
               step={1}
-              title="Setup credentials"
-              description="Connect an LLM provider (Anthropic, OpenAI, …) so sessions can reach a model."
-              ctaLabel="Open settings"
+              title={t("landing.setupCredentials", undefined, "Setup credentials")}
+              description={t("landing.setupCredentialsDescription", undefined, "Connect an LLM provider (Anthropic, OpenAI, ...) so sessions can reach a model.")}
+              ctaLabel={t("landing.openSettings", undefined, "Open settings")}
               ctaTestId="onboarding-step-1-cta"
               disabled={false}
               onClick={() => navigate?.("/settings?tab=providers")}
@@ -162,19 +167,19 @@ export function LandingPage({
           {step2 === "done" ? (
             <DoneRow
               testId="onboarding-step-2-done"
-              label={`${pinnedCount} folder${pinnedCount === 1 ? "" : "s"} pinned`}
+              label={t("landing.pinnedFolders", { count: pinnedCount }, `${pinnedCount} folder${pinnedCount === 1 ? "" : "s"} pinned`)}
             />
           ) : (
             <Card
               step={2}
-              title="Add folder"
-              description="Pin a project directory to the sidebar so you can spawn sessions inside it."
-              hint={step2 === "locked" ? "Requires: credentials" : undefined}
-              ctaLabel="Add folder…"
+              title={t("landing.addFolder", undefined, "Add folder")}
+              description={t("landing.addFolderDescription", undefined, "Pin a project directory to the sidebar so you can spawn sessions inside it.")}
+              hint={step2 === "locked" ? t("landing.requiresCredentials", undefined, "Requires: credentials") : undefined}
+              ctaLabel={t("landing.addFolderCta", undefined, "Add folder...")}
               ctaTestId="onboarding-step-2-cta"
               disabled={step2 === "locked"}
               titleAttr={
-                step2 === "locked" ? "Set up credentials first" : undefined
+                step2 === "locked" ? t("landing.setCredentialsFirst", undefined, "Set up credentials first") : undefined
               }
               onClick={() => onOpenPinDialog?.()}
             />
@@ -184,23 +189,23 @@ export function LandingPage({
           {step3 === "done" ? (
             <DoneRow
               testId="onboarding-step-3-done"
-              label={`${sessionsCount} active session${sessionsCount === 1 ? "" : "s"}`}
+              label={t("landing.activeSessions", { count: sessionsCount }, `${sessionsCount} active session${sessionsCount === 1 ? "" : "s"}`)}
             />
           ) : (
             <Card
               step={3}
-              title="Start session"
+              title={t("landing.startSession", undefined, "Start session")}
               description={
                 firstPinnedCwd
-                  ? `+Session: a pi session in ${truncatePath(firstPinnedCwd)}.`
-                  : "+Session: your first pi session in a pinned folder."
+                  ? t("landing.startSessionDescription", { path: truncatePath(firstPinnedCwd) }, `+Session: a pi session in ${truncatePath(firstPinnedCwd)}.`)
+                  : t("landing.startSessionDescriptionFallback", undefined, "+Session: your first pi session in a pinned folder.")
               }
-              hint={step3 === "locked" ? "Requires: a pinned folder" : undefined}
-              ctaLabel="Start session"
+              hint={step3 === "locked" ? t("landing.requiresFolder", undefined, "Requires: a pinned folder") : undefined}
+              ctaLabel={t("landing.startSession", undefined, "Start session")}
               ctaTestId="onboarding-step-3-cta"
               disabled={step3 === "locked" || !firstPinnedCwd}
               titleAttr={
-                step3 === "locked" ? "Pin a folder first" : undefined
+                step3 === "locked" ? t("landing.pinFolderFirst", undefined, "Pin a folder first") : undefined
               }
               onClick={() => firstPinnedCwd && onSpawnSession?.(firstPinnedCwd)}
             />

--- a/packages/client/src/components/PackageBrowser.tsx
+++ b/packages/client/src/components/PackageBrowser.tsx
@@ -10,6 +10,7 @@ import { PackageRow } from "./PackageRow.js";
 import { classifySource } from "../lib/package-classifier.js";
 import { RecommendedExtensions } from "./RecommendedExtensions.js";
 import type { NpmPackageResult } from "@blackbelt-technology/pi-dashboard-shared/rest-api.js";
+import { useI18n } from "../lib/i18n.js";
 
 const TYPE_PILLS = ["extension", "skill", "theme", "prompt"] as const;
 
@@ -39,6 +40,7 @@ export function PackageBrowser({
   onConfirmInstall,
   showInstalledSection = true,
 }: PackageBrowserProps) {
+  const { t } = useI18n();
   const search = usePackageSearch();
   const installedOwn = useInstalledPackages(scope, cwd);
   // Also fetch the other scope to show cross-scope badges
@@ -168,7 +170,7 @@ export function PackageBrowser({
       {showInstalledSection && installedNonRecommended.length > 0 && (
         <div data-testid="installed-packages-section">
           <h3 className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wide mb-1.5">
-            Installed Packages
+            {t("packages.installed", undefined, "Installed Packages")}
           </h3>
           <div className="space-y-1">
             {installedNonRecommended.map((pkg) => {
@@ -224,7 +226,7 @@ export function PackageBrowser({
           disabled={!urlInput.trim()}
           className="px-3 py-1.5 text-xs bg-[var(--accent-primary)] text-white rounded hover:bg-[var(--accent-primary)]/80 disabled:opacity-50 font-medium"
         >
-          Install
+          {t("common.install", undefined, "Install")}
         </button>
       </div>
 
@@ -239,7 +241,7 @@ export function PackageBrowser({
           type="text"
           value={search.query}
           onChange={(e) => search.setQuery(e.target.value)}
-          placeholder="Search pi packages on npm..."
+          placeholder={t("packages.searchPlaceholder", undefined, "Search pi packages on npm...")}
           className="w-full pl-7 pr-2 py-1.5 text-xs bg-[var(--bg-surface)] border border-[var(--border-secondary)] rounded text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
           data-testid="package-search-input"
         />
@@ -278,10 +280,10 @@ export function PackageBrowser({
             <Icon path={mdiLoading} size={0.4} className="inline animate-spin mr-1" />
           )}
           {operations.operation.status === "running"
-            ? `Installing ${operations.operation.source}…`
+            ? t("packages.installing", { source: operations.operation.source }, `Installing ${operations.operation.source}...`)
             : operations.operation.message}
           {operations.queueDepth > 0 && operations.operation.status === "running" && (
-            <span className="ml-2 opacity-80">({operations.queueDepth} queued)</span>
+            <span className="ml-2 opacity-80">({t("common.queuedCount", { count: operations.queueDepth }, `${operations.queueDepth} queued`)})</span>
           )}
         </div>
       )}
@@ -300,14 +302,14 @@ export function PackageBrowser({
       {!search.isLoading && displayPackages.length === 0 && !search.error && (
         <div className="text-center py-6 text-[var(--text-muted)]">
           <Icon path={mdiPackageVariantClosed} size={1.2} className="mx-auto mb-2 opacity-30" />
-          <p className="text-xs">No packages found</p>
+          <p className="text-xs">{t("packages.noPackages", undefined, "No packages found")}</p>
         </div>
       )}
 
       {displayPackages.length > 0 && (
         <>
           <div className="text-[10px] text-[var(--text-muted)]">
-            {displayPackages.length} package{displayPackages.length !== 1 ? "s" : ""}
+            {t("packages.packageCount", { count: displayPackages.length }, `${displayPackages.length} package${displayPackages.length !== 1 ? "s" : ""}`)}
           </div>
           <div className="grid gap-2" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))" }}>
             {displayPackages.map((pkg) => {
@@ -328,7 +330,7 @@ export function PackageBrowser({
                   })()}
                   operationMessage={(() => {
                     const s = operations.statusFor(`npm:${pkg.name}`);
-                    if (s === "queued") return "Queued…";
+                    if (s === "queued") return t("common.queued", undefined, "Queued...");
                     if (s === "idle") return undefined;
                     return operations.messageFor(`npm:${pkg.name}`);
                   })()}

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -50,6 +50,7 @@ import { selectedCardScrollFingerprint } from "../lib/session-list-scroll.js";
 import { TunnelButton } from "./TunnelButton.js";
 import { InstallButton } from "./InstallButton.js";
 import { useInstallPrompt } from "../hooks/useInstallPrompt.js";
+import { useI18n } from "../lib/i18n.js";
 
 
 export interface ContextUsageInfo {
@@ -192,6 +193,7 @@ function ToggleButton({
 }
 
 export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, openspecMap, openspecGroupsMap, sessionOrderMap, onReorderSessions, onSendPrompt, onOpenSpecRefresh, onAttachProposal, onDetachProposal, onBulkArchive, onReadArtifact, onOpenPiResources, onRename, onShutdown, onResume, onResumeKeepPosition, onHideSession, onUnhideSession, onSpawnSession, spawningCwds, addSpawningCwd, clearSpawningCwd, spawnResult, onSpawnResultSeen, pinnedDirectories, onPinDirectory, onOpenPinDialog, onUnpinDirectory, onReorderPinnedDirs, workspaces, onCreateWorkspace, onRenameWorkspace, onDeleteWorkspace, onSetWorkspaceCollapsed, onAddFolderToWorkspace, onRemoveFolderFromWorkspace, terminals, onKillTerminal, onRenameTerminal, onCollapseSidebar, commandsMap, onKillProcess, onSetProcessDrawer, inflightBashMap, onAbortTool, onOpenSpecs, onOpenArchive, onViewReadme, onOpenTerminals, onOpenEditor, editorStatuses, editorAvailable, headerExtra, errorSessionIds, retrySessionIds, spawnErrors, onDismissSpawnError, resumeErrors, onDismissResumeError, gitWorktreeEnabled: gitWorktreeEnabledProp }: Props) {
+  const { t } = useI18n();
   // UI preference flag, default-on. Gates folder `+Worktree` and per-change
   // `⥂2+` buttons. See change: openspec-worktree-spawn-button.
   const gitWorktreeEnabled = gitWorktreeEnabledProp ?? true;
@@ -279,7 +281,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
   // Show toast for spawn results
   useEffect(() => {
     if (spawnResult) {
-      showToast(spawnResult.success ? spawnResult.message : `+Session failed: ${spawnResult.message}`);
+      showToast(spawnResult.success ? spawnResult.message : `${t("sessionList.sessionFailed", undefined, "+Session failed")}: ${spawnResult.message}`);
       onSpawnResultSeen?.();
     }
   }, [spawnResult, showToast, onSpawnResultSeen]);
@@ -561,7 +563,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
                 setAddToWsMenuFor(menuOpen ? null : group.cwd);
               }}
               className="text-[10px] px-1 py-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--accent-blue)]"
-              title="Add to workspace"
+              title={t("sessionList.addToWorkspace", undefined, "Add to workspace")}
               data-testid={`add-to-workspace-btn-${group.cwd}`}
             >
               +ws
@@ -621,7 +623,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
                   else onPinDirectory?.(group.cwd);
                 }}
                 className={`ml-auto px-1 py-0.5 rounded ${isPinned ? "text-yellow-400 hover:text-yellow-300" : "text-[var(--text-tertiary)] hover:text-yellow-400"}`}
-                title={isPinned ? "Unpin directory" : "Pin directory"}
+                title={isPinned ? t("sessionList.unpinDirectory", undefined, "Unpin directory") : t("sessionList.pinDirectory", undefined, "Pin directory")}
                 data-testid={isPinned ? "unpin-dir-btn" : "pin-dir-btn"}
               >
                 <Icon path={mdiPin} size={0.55} />
@@ -638,7 +640,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
               <button
                 onClick={(e) => { e.stopPropagation(); onViewReadme(group.cwd); }}
                 className="ml-auto text-[var(--text-muted)] hover:text-blue-400 transition-colors"
-                title="View README.md"
+                title={t("sessionList.viewReadme", undefined, "View README.md")}
                 data-testid="view-readme-btn"
               >
                 <Icon path={mdiFileDocumentOutline} size={0.5} />
@@ -771,7 +773,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
                   className="text-xs text-[var(--text-muted)] italic px-2 py-2 select-none"
                   data-testid="folder-search-empty"
                 >
-                  No sessions match your search
+                  {t("sessionList.noSessionsMatch", undefined, "No sessions match your search")}
                 </div>
               );
             }
@@ -824,10 +826,10 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
                           onClick={(e) => { e.stopPropagation(); toggleEndedExpanded(group.cwd); }}
                           className="w-full text-[10px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] py-1 px-2 select-none flex items-center justify-center gap-1 border-t border-[var(--border-subtle)]"
                           data-testid={`folder-ended-toggle-top-${group.cwd}`}
-                          aria-label={`Hide ${endedSessions.length} ended sessions`}
+                          aria-label={t("sessionList.hideEndedCount", { count: endedSessions.length }, `Hide ${endedSessions.length} ended sessions`)}
                         >
                           <Icon path={mdiChevronDown} size={0.4} />
-                          <span>Hide ended</span>
+                          <span>{t("sessionList.hideEnded", undefined, "Hide ended")}</span>
                         </button>
                       )}
                     <SortableSessionCard key={id} id={id}>
@@ -908,7 +910,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
                 onClick={(e) => { e.stopPropagation(); toggleEndedExpanded(group.cwd); }}
                 className="w-full text-[10px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] py-1 px-2 select-none flex items-center justify-center gap-1"
                 data-testid={`folder-ended-toggle-${group.cwd}`}
-                aria-label={expanded ? `Hide ${endedCount} ended sessions` : `Show ${endedCount} ended sessions`}
+                aria-label={expanded ? t("sessionList.hideEndedCount", { count: endedCount }, `Hide ${endedCount} ended sessions`) : t("sessionList.showEndedCount", { count: endedCount }, `Show ${endedCount} ended sessions`)}
               >
                 {/* Bottom toggle: arrow points UP when expanded (collapse-up
                     direction — matches where the click takes the eye) and
@@ -918,7 +920,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
                     pointing down at it would still mean "this collapses what's
                     below me" — inverse direction is intentional. */}
                 <Icon path={expanded ? mdiChevronUp : mdiChevronRight} size={0.4} />
-                <span>{expanded ? `Hide ended` : `${endedCount} ended`}</span>
+                <span>{expanded ? t("sessionList.hideEnded", undefined, "Hide ended") : t("sessionList.showEnded", { count: endedCount }, `${endedCount} ended`)}</span>
               </button>
             );
           })()}
@@ -933,7 +935,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
       <div className="border-b border-[var(--border-primary)]">
         <div className="flex items-center justify-between px-3 py-1.5" data-testid="header-app-bar">
           <div className="flex gap-1.5 items-center">
-            <button onClick={() => navigate("/")} className="flex items-center leading-none text-blue-500 hover:text-blue-400 transition-colors" title="Home">
+            <button onClick={() => navigate("/")} className="flex items-center leading-none text-blue-500 hover:text-blue-400 transition-colors" title={t("common.home", undefined, "Home")}>
               <PiLogo size={24} />
             </button>
             <ThemePicker />
@@ -946,7 +948,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
             <button
               onClick={() => navigate("/settings")}
               className="text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
-              title="Settings"
+              title={t("sessionList.settings", undefined, "Settings")}
               data-testid="settings-btn"
             >
               <Icon path={mdiCog} size={0.6} />
@@ -958,28 +960,28 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
             type="search"
             value={workspaceFilter}
             onChange={(e) => setWorkspaceFilter(e.target.value)}
-            placeholder="Folder…"
+            placeholder={t("sessionList.folderPlaceholder", undefined, "Folder...")}
             className="min-w-0 flex-1 px-2 py-1 text-xs rounded bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-blue)]"
             data-testid="workspace-filter-input"
-            aria-label="Filter folders by path"
+            aria-label={t("sessionList.filterFolders", undefined, "Filter folders by path")}
           />
           <input
             type="search"
             value={sessionSearch}
             onChange={(e) => setSessionSearch(e.target.value)}
-            placeholder="Session…"
+            placeholder={t("sessionList.sessionPlaceholder", undefined, "Session...")}
             className="min-w-0 flex-1 px-2 py-1 text-xs rounded bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-blue)]"
             data-testid="session-search-input"
-            aria-label="Search sessions across folders"
+            aria-label={t("sessionList.searchSessions", undefined, "Search sessions across folders")}
           />
           <ToggleButton active={showHidden} onClick={() => setShowHidden((p) => !p)}>
-            Hidden
+            {t("common.hidden", undefined, "Hidden")}
           </ToggleButton>
         </div>
       </div>
       <div ref={listRef} className="flex-1 overflow-y-auto">
       {filteredSessions.length === 0 && pinnedGroups.length === 0 && (workspaces?.length ?? 0) === 0 ? (
-        <div className="p-4 text-sm text-[var(--text-tertiary)]">No active sessions</div>
+        <div className="p-4 text-sm text-[var(--text-tertiary)]">{t("sessionList.noActiveSessions", undefined, "No active sessions")}</div>
       ) : (
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
         <ul className="flex flex-col gap-2 p-2">
@@ -1011,7 +1013,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
                 <div className="flex flex-col gap-1 p-1.5">
                   {ws.folders.length === 0 && (
                     <div className="text-[11px] text-[var(--text-muted)] italic px-2 py-2 text-center">
-                      Empty workspace. Use “+ Add to workspace” on a folder’s actions to assign it here.
+                      {t("sessionList.emptyWorkspace", undefined, "Empty workspace. Use \"+ Add to workspace\" on a folder's actions to assign it here.")}
                     </div>
                   )}
                   {ws.folders.map((folder) => (
@@ -1022,7 +1024,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
                       <button
                         onClick={() => onRemoveFolderFromWorkspace?.(ws.id, folder.cwd)}
                         className="absolute top-1 right-1 text-[10px] text-[var(--text-muted)] hover:text-red-400 px-1"
-                        title="Remove from workspace"
+                        title={t("sessionList.removeFromWorkspace", undefined, "Remove from workspace")}
                         data-testid={`ws-remove-${ws.id}-${folder.cwd}`}
                       >
                         ×
@@ -1099,7 +1101,7 @@ export function SessionList({ sessions, selectedId, onSelect, contextUsageMap, o
       )}
       {hiddenCount > 0 && !showHidden && (
         <div className="p-2 text-center text-[11px] text-[var(--text-muted)]">
-          {hiddenCount} hidden
+          {t("sessionList.hiddenCount", { count: hiddenCount }, `${hiddenCount} hidden`)}
         </div>
       )}
       {worktreeDialogCwd && (
@@ -1185,4 +1187,3 @@ function FolderDragGutter({
     </div>
   );
 }
-

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -22,6 +22,7 @@ import { usePackageOperations } from "../hooks/usePackageOperations.js";
 import { UnifiedPackagesSection } from "./UnifiedPackagesSection.js";
 import { PluginsSection } from "./PluginsSection.js";
 import type { NpmPackageResult } from "@blackbelt-technology/pi-dashboard-shared/rest-api.js";
+import { LANGUAGE_OPTIONS, useI18n, type Language } from "../lib/i18n.js";
 
 interface ProviderConfig {
   clientId: string;
@@ -126,6 +127,7 @@ const PROVIDER_LABELS: Record<string, string> = {
 const NEEDS_ISSUER = new Set(["keycloak", "oidc"]);
 
 export function SettingsPanel({ availableModels }: { availableModels?: Array<{ provider: string; id: string }> }) {
+  const { language, setLanguage, t } = useI18n();
   const [, navigate] = useLocation();
   const [config, setConfig] = useState<Config | null>(null);
   const [original, setOriginal] = useState<Config | null>(null);
@@ -173,9 +175,9 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
           setOriginalLlmProviders(JSON.parse(JSON.stringify(list)));
         }
       })
-      .catch(() => setMessage({ type: "error", text: "Failed to load settings" }))
+      .catch(() => setMessage({ type: "error", text: t("settings.failedLoad", undefined, "Failed to load settings") }))
       .finally(() => setLoading(false));
-  }, []);
+  }, [t]);
 
   const handleSave = useCallback(async () => {
     if (!config || !original) return;
@@ -252,7 +254,7 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
     const llmChanged = JSON.stringify(llmProviders) !== JSON.stringify(originalLlmProviders);
 
     if (Object.keys(partial).length === 0 && !llmChanged) {
-      setMessage({ type: "warn", text: "No changes to save" });
+      setMessage({ type: "warn", text: t("settings.noChanges", undefined, "No changes to save") });
       setSaving(false);
       return;
     }
@@ -269,7 +271,7 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
         });
         const data = await res.json();
         if (!data.success) {
-          setMessage({ type: "error", text: data.error || "Failed to save config" });
+          setMessage({ type: "error", text: data.error || t("settings.saveFailed", undefined, "Failed to save settings") });
           setSaving(false);
           return;
         }
@@ -295,7 +297,7 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
         });
         const data = await res.json();
         if (!data.success) {
-          setMessage({ type: "error", text: data.error || "Failed to save providers" });
+          setMessage({ type: "error", text: data.error || t("settings.saveFailed", undefined, "Failed to save settings") });
           setSaving(false);
           return;
         }
@@ -306,21 +308,21 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
       }
 
       if (restartRequired) {
-        setMessage({ type: "warn", text: "Saved. Some changes require a server restart to take effect." });
+        setMessage({ type: "warn", text: t("settings.restartRequired", undefined, "Saved. Some changes require a server restart to take effect.") });
       } else {
-        setMessage({ type: "success", text: "Settings saved" });
+        setMessage({ type: "success", text: t("settings.saved", undefined, "Settings saved") });
       }
     } catch {
-      setMessage({ type: "error", text: "Failed to save settings" });
+      setMessage({ type: "error", text: t("settings.saveFailed", undefined, "Failed to save settings") });
     } finally {
       setSaving(false);
     }
-  }, [config, original, llmProviders, originalLlmProviders]);
+  }, [config, original, llmProviders, originalLlmProviders, t]);
 
   if (loading) {
     return (
       <div className="flex-1 flex items-center justify-center text-[var(--text-tertiary)]">
-        Loading settings...
+        {t("settings.loading", undefined, "Loading settings...")}
       </div>
     );
   }
@@ -328,7 +330,7 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
   if (!config) {
     return (
       <div className="flex-1 flex items-center justify-center text-red-400">
-        Failed to load settings
+        {t("settings.failedLoad", undefined, "Failed to load settings")}
       </div>
     );
   }
@@ -352,13 +354,13 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
   };
 
   const tabs = [
-    { id: "general", label: "General" },
-    { id: "servers", label: "Servers" },
-    { id: "packages", label: "Packages" },
-    { id: "plugins", label: "Plugins" },
-    { id: "providers", label: "Providers" },
-    { id: "security", label: "Security" },
-    { id: "advanced", label: "Advanced" },
+    { id: "general", label: t("settings.general", undefined, "General") },
+    { id: "servers", label: t("settings.servers", undefined, "Servers") },
+    { id: "packages", label: t("settings.packages", undefined, "Packages") },
+    { id: "plugins", label: t("settings.plugins", undefined, "Plugins") },
+    { id: "providers", label: t("settings.providers", undefined, "Providers") },
+    { id: "security", label: t("settings.security", undefined, "Security") },
+    { id: "advanced", label: t("settings.advanced", undefined, "Advanced") },
   ];
 
   return (
@@ -368,11 +370,11 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
         <button
           onClick={() => navigate("/")}
           className="text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-          title="Back"
+          title={t("common.back", undefined, "Back")}
         >
           <Icon path={mdiArrowLeft} size={0.8} />
         </button>
-        <h1 className="text-lg font-bold text-[var(--text-primary)]">Settings</h1>
+        <h1 className="text-lg font-bold text-[var(--text-primary)]">{t("common.settings", undefined, "Settings")}</h1>
         <div className="flex-1" />
         <button
           onClick={async () => {
@@ -382,24 +384,24 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
               const res = await fetch(`${getApiBase()}/api/restart`, { method: "POST" });
               const data = await res.json();
               if (data.ok) {
-                setMessage({ type: "success", text: "Server restarting…" });
+                setMessage({ type: "success", text: t("common.restarting", undefined, "Server restarting...") });
                 setTimeout(() => navigate("/"), 1500);
               } else {
-                setMessage({ type: "error", text: data.error || "Restart failed" });
+                setMessage({ type: "error", text: data.error || t("settings.restartFailed", undefined, "Restart failed") });
                 setRestarting(false);
               }
             } catch {
               // fetch fails when server exits — that's expected
-              setMessage({ type: "success", text: "Server restarting…" });
+              setMessage({ type: "success", text: t("common.restarting", undefined, "Server restarting...") });
               setTimeout(() => navigate("/"), 1500);
             }
           }}
           disabled={restarting || saving}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded bg-[var(--bg-tertiary)] hover:bg-[var(--bg-secondary)] text-[var(--text-secondary)] text-sm font-medium disabled:opacity-50 border border-[var(--border-secondary)]"
-          title="Restart server"
+          title={t("settings.restartServer", undefined, "Restart server")}
         >
           <Icon path={mdiRestart} size={0.6} />
-          {restarting ? "Restarting…" : "Restart"}
+          {restarting ? t("common.restarting", undefined, "Restarting...") : t("common.restart", undefined, "Restart")}
         </button>
         <button
           onClick={handleSave}
@@ -408,7 +410,7 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
           className="flex items-center gap-1.5 px-3 py-1.5 rounded bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium disabled:opacity-50"
         >
           <Icon path={mdiContentSave} size={0.6} />
-          {saving ? "Saving..." : "Save"}
+          {saving ? t("common.saving", undefined, "Saving...") : t("common.save", undefined, "Save")}
         </button>
       </div>
 
@@ -451,18 +453,30 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
           {/* General Tab */}
           {activeTab === "general" && (
             <>
+              <Section title={t("settings.interface", undefined, "Interface")}>
+                <p className="text-xs text-[var(--text-tertiary)] mb-2">
+                  {t("settings.interfaceDescription", undefined, "Choose the dashboard interface language. The selection is saved in this browser.")}
+                </p>
+                <SelectField
+                  label={t("settings.language", undefined, "Language")}
+                  value={language}
+                  options={LANGUAGE_OPTIONS}
+                  onChange={(v) => setLanguage(v as Language)}
+                />
+              </Section>
+
               <Section title="Server">
-                <NumberField label="HTTP Port" value={config.port} onChange={(v) => update((c) => { c.port = v; })} />
-                <NumberField label="Pi Gateway Port" value={config.piPort} onChange={(v) => update((c) => { c.piPort = v; })} />
-                <ToggleField label="Auto Shutdown" value={config.autoShutdown} onChange={(v) => update((c) => { c.autoShutdown = v; })} />
+                <NumberField label={t("settings.httpPort", undefined, "HTTP Port")} value={config.port} onChange={(v) => update((c) => { c.port = v; })} />
+                <NumberField label={t("settings.piGatewayPort", undefined, "Pi Gateway Port")} value={config.piPort} onChange={(v) => update((c) => { c.piPort = v; })} />
+                <ToggleField label={t("settings.autoShutdown", undefined, "Auto Shutdown")} value={config.autoShutdown} onChange={(v) => update((c) => { c.autoShutdown = v; })} />
                 {config.autoShutdown && (
                   <NumberField label="Idle Seconds Before Shutdown" value={config.shutdownIdleSeconds} onChange={(v) => update((c) => { c.shutdownIdleSeconds = v; })} />
                 )}
               </Section>
 
-              <Section title="Sessions">
+              <Section title={t("settings.sessions", undefined, "Sessions")}>
                 <SelectField
-                  label="+Session Strategy"
+                  label={t("settings.spawnStrategy", undefined, "+Session Strategy")}
                   value={config.spawnStrategy}
                   options={[{ value: "headless", label: "Headless" }, { value: "tmux", label: "Tmux" }]}
                   onChange={(v) => update((c) => { c.spawnStrategy = v; })}
@@ -529,7 +543,7 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
                   </p>
                 </div>
                 <div className="flex items-center justify-between">
-                  <label className="text-sm text-[var(--text-secondary)]">Default Model</label>
+                    <label className="text-sm text-[var(--text-secondary)]">{t("settings.defaultModel", undefined, "Default Model")}</label>
                   <ModelSelector
                     current={config.defaultModel || undefined}
                     models={availableModels}
@@ -553,14 +567,14 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
                 </div>
               </Section>
 
-              <Section title="Tunnel">
-                <ToggleField label="Enable Zrok Tunnel" value={config.tunnel.enabled} onChange={(v) => update((c) => { c.tunnel.enabled = v; })} />
+              <Section title={t("settings.tunnel", undefined, "Tunnel")}>
+                <ToggleField label={t("settings.enableZrokTunnel", undefined, "Enable Zrok Tunnel")} value={config.tunnel.enabled} onChange={(v) => update((c) => { c.tunnel.enabled = v; })} />
                 <div className="mt-3 pt-3 border-t border-[var(--border-secondary)] space-y-2">
                   <p className="text-xs text-[var(--text-tertiary)]">
                     Watchdog probes the public tunnel URL periodically and recycles the tunnel after consecutive failures (e.g. zrok edge returning 502).
                   </p>
                   <ToggleField
-                    label="Enable Watchdog"
+                    label={t("settings.enableWatchdog", undefined, "Enable Watchdog")}
                     value={config.tunnel.watchdog?.enabled ?? true}
                     onChange={(v) => update((c) => {
                       c.tunnel.watchdog = {
@@ -572,7 +586,7 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
                     })}
                   />
                   <NumberField
-                    label="Probe Interval (seconds)"
+                    label={t("settings.probeInterval", undefined, "Probe Interval (seconds)")}
                     value={Math.round((config.tunnel.watchdog?.intervalMs ?? 60000) / 1000)}
                     onChange={(v) => update((c) => {
                       c.tunnel.watchdog = {
@@ -596,7 +610,7 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
                     })}
                   />
                   <NumberField
-                    label="Probe Timeout (seconds)"
+                    label={t("settings.probeTimeout", undefined, "Probe Timeout (seconds)")}
                     value={Math.round((config.tunnel.watchdog?.probeTimeoutMs ?? 10000) / 1000)}
                     onChange={(v) => update((c) => {
                       c.tunnel.watchdog = {
@@ -613,8 +627,8 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
               {/* Configurable chat display (configurable-chat-display). */}
               <DisplayPrefsSection />
 
-              <Section title="Developer">
-                <ToggleField label="Dev Build on Reload" value={config.devBuildOnReload} onChange={(v) => update((c) => { c.devBuildOnReload = v; })} />
+              <Section title={t("settings.developer", undefined, "Developer")}>
+                <ToggleField label={t("settings.devBuildOnReload", undefined, "Dev Build on Reload")} value={config.devBuildOnReload} onChange={(v) => update((c) => { c.devBuildOnReload = v; })} />
               </Section>
 
               <DiagnosticsSection />
@@ -637,13 +651,13 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
           {/* Providers Tab */}
           {activeTab === "providers" && (
             <>
-              <Section title="Provider Authentication">
+              <Section title={t("settings.providerAuth", undefined, "Provider Authentication")}>
                 <ProviderAuthSection />
               </Section>
 
-              <Section title="LLM Providers">
+              <Section title={t("settings.llmProviders", undefined, "LLM Providers")}>
                 <p className="text-xs text-[var(--text-tertiary)] mb-3">
-                  Register custom OpenAI-compatible API endpoints for model access.
+                  {t("settings.llmProvidersDescription", undefined, "Register custom OpenAI-compatible API endpoints for model access.")}
                 </p>
                 {llmProviders.map((provider, index) => (
                   <LlmProviderCard
@@ -662,10 +676,10 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
                   className="flex items-center gap-1.5 text-sm text-[var(--accent-blue)] hover:text-blue-400 mt-1"
                 >
                   <Icon path={mdiPlus} size={0.6} />
-                  Add Provider
+                  {t("settings.addProvider", undefined, "Add Provider")}
                 </button>
               </Section>
-              <Section title="API Proxy">
+              <Section title={t("settings.apiProxy", undefined, "API Proxy")}>
                 <ModelProxySection
                   config={config.modelProxy ?? {}}
                   onChange={(patch) => update((c) => { c.modelProxy = { ...c.modelProxy, ...patch }; })}
@@ -679,9 +693,9 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
           {/* Security Tab */}
           {activeTab === "security" && (
             <>
-              <Section title="Authentication">
+              <Section title={t("settings.auth", undefined, "Authentication")}>
                 <p className="text-xs text-[var(--text-tertiary)] mb-3">
-                  Configure OAuth providers to protect external (tunnel) access. Localhost is always open.
+                  {t("settings.authDescription", undefined, "Configure OAuth providers to protect external (tunnel) access. Localhost is always open.")}
                 </p>
                 {["github", "google", "keycloak", "oidc"].map((key) => (
                   <ProviderSection
@@ -700,7 +714,7 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
                 ))}
                 <div className="mt-3">
                   <label className="block text-xs font-medium text-[var(--text-secondary)] mb-1">
-                    Allowed Users <span className="text-[var(--text-tertiary)]">(one per line: username, email, or *@domain)</span>
+                    {t("settings.allowedUsers", undefined, "Allowed Users")} <span className="text-[var(--text-tertiary)]">({t("settings.allowedUsersHint", undefined, "one per line: username, email, or *@domain")})</span>
                   </label>
                   <textarea
                     className="w-full bg-[var(--bg-secondary)] border border-[var(--border-secondary)] rounded px-2 py-1.5 text-sm text-[var(--text-primary)] font-mono resize-y"
@@ -718,7 +732,7 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
                 </div>
                 <div className="mt-3">
                   <label className="block text-xs font-medium text-[var(--text-secondary)] mb-1">
-                    Bypass URL Prefixes <span className="text-[var(--text-tertiary)]">(one per line — requests to these paths skip auth)</span>
+                    {t("settings.bypassUrls", undefined, "Bypass URL Prefixes")} <span className="text-[var(--text-tertiary)]">({t("settings.bypassUrlsHint", undefined, "one per line — requests to these paths skip auth")})</span>
                   </label>
                   <textarea
                     className="w-full bg-[var(--bg-secondary)] border border-[var(--border-secondary)] rounded px-2 py-1.5 text-sm text-[var(--text-primary)] font-mono resize-y"
@@ -764,16 +778,15 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
 
           {activeTab === "advanced" && (
             <>
-              <Section title="Chat Display">
+              <Section title={t("settings.chatDisplay", undefined, "Chat Display")}>
                 <p className="text-xs text-[var(--text-tertiary)] mb-2">
-                  Controls what is shown in the chat message stream.
+                  {t("settings.chatDisplayAdvancedDescription", undefined, "Controls what is shown in the chat message stream.")}
                 </p>
                 <DebugToolsToggle />
               </Section>
-              <Section title="Memory Limits">
+              <Section title={t("settings.memoryLimits", undefined, "Memory Limits")}>
                 <p className="text-xs text-[var(--text-tertiary)] mb-2">
-                  Controls for bounding server memory usage. Set to 0 to disable a limit.
-                  Requires server restart.
+                  {t("settings.memoryLimitsDescription", undefined, "Controls for bounding server memory usage. Set to 0 to disable a limit. Requires server restart.")}
                 </p>
                 <NumberField
                   label="Max Events Per Session"
@@ -800,12 +813,12 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
                   })}
                 />
               </Section>
-              <Section title="Background polling (OpenSpec)">
+              <Section title={t("settings.backgroundPolling", undefined, "Background polling (OpenSpec)")}>
                 <p className="text-xs text-[var(--text-tertiary)] mb-2">
                   Controls how aggressively the server polls <code>openspec list</code> and <code>openspec status</code> for each known directory. Longer interval → less CPU, slightly staler UI. Lower concurrency → smoother curve. Change detection <code>mtime</code> skips re-polling unchanged proposals (recommended).
                 </p>
                 <ToggleField
-                  label="Enable OpenSpec"
+                  label={t("settings.enableOpenSpec", undefined, "Enable OpenSpec")}
                   value={config.openspec?.enabled ?? DEFAULT_OPENSPEC_UI.enabled}
                   onChange={(v) => update((c) => {
                     if (!c.openspec) c.openspec = { ...DEFAULT_OPENSPEC_UI };
@@ -863,9 +876,9 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
                   );
                 })()}
               </Section>
-              <Section title="Editor (code-server)">
+              <Section title={t("settings.editor", undefined, "Editor (code-server)")}>
                 <p className="text-xs text-[var(--text-tertiary)] mb-2">
-                  Configure the embedded VS Code editor powered by code-server.
+                  {t("settings.editorDescription", undefined, "Configure the embedded VS Code editor powered by code-server.")}
                 </p>
                 <TextField
                   label="Binary Path (leave empty for auto-detect)"
@@ -916,10 +929,11 @@ export function SettingsPanel({ availableModels }: { availableModels?: Array<{ p
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
 function DebugToolsToggle() {
+  const { t } = useI18n();
   const [visible, setVisible] = useDebugToolsVisible();
   return (
     <ToggleField
-      label="Show debug events (raw events, flow:list-flows, resources_discover)"
+      label={t("settings.showDebugEvents", undefined, "Show debug events (raw events, flow:list-flows, resources_discover)")}
       value={visible}
       onChange={setVisible}
     />
@@ -928,6 +942,7 @@ function DebugToolsToggle() {
 
 // ── Display preferences (configurable-chat-display) ───────────────────────────────
 function DisplayPrefsSection() {
+  const { t } = useI18n();
   const { global } = useDisplayPrefsContext();
   const prefs = global ?? DISPLAY_PRESETS.standard;
 
@@ -951,24 +966,23 @@ function DisplayPrefsSection() {
   }, [patch]);
 
   return (
-    <Section title="Chat display">
+    <Section title={t("settings.chatDisplay", undefined, "Chat display")}>
       <p className="text-xs text-[var(--text-tertiary)] mb-2">
-        Hide chat elements you don’t need. Per-session overrides live in the
-        chat view’s “View” popover.
+        {t("settings.chatDisplayDescription", undefined, "Hide chat elements you don't need. Per-session overrides live in the chat view's View popover.")}
       </p>
-      <ToggleField label="Token stats bar" value={prefs.tokenStatsBar} onChange={(v) => patch({ tokenStatsBar: v })} />
-      <ToggleField label="Context usage bar" value={prefs.contextUsageBar} onChange={(v) => patch({ contextUsageBar: v })} />
-      <ToggleField label="Reasoning blocks" value={prefs.reasoning} onChange={(v) => patch({ reasoning: v })} />
-      <ToggleField label="Tool result bodies" value={prefs.toolResults} onChange={(v) => patch({ toolResults: v })} />
-      <ToggleField label="Turn metadata separators" value={prefs.turnMetadata} onChange={(v) => patch({ turnMetadata: v })} />
-      <ToggleField label="Debug events" value={prefs.debugTools} onChange={(v) => patch({ debugTools: v })} />
+      <ToggleField label={t("settings.tokenStatsBar", undefined, "Token stats bar")} value={prefs.tokenStatsBar} onChange={(v) => patch({ tokenStatsBar: v })} />
+      <ToggleField label={t("settings.contextUsageBar", undefined, "Context usage bar")} value={prefs.contextUsageBar} onChange={(v) => patch({ contextUsageBar: v })} />
+      <ToggleField label={t("settings.reasoningBlocks", undefined, "Reasoning blocks")} value={prefs.reasoning} onChange={(v) => patch({ reasoning: v })} />
+      <ToggleField label={t("settings.toolResultBodies", undefined, "Tool result bodies")} value={prefs.toolResults} onChange={(v) => patch({ toolResults: v })} />
+      <ToggleField label={t("settings.turnMetadata", undefined, "Turn metadata separators")} value={prefs.turnMetadata} onChange={(v) => patch({ turnMetadata: v })} />
+      <ToggleField label={t("settings.debugEvents", undefined, "Debug events")} value={prefs.debugTools} onChange={(v) => patch({ debugTools: v })} />
       <div className="pt-2">
-        <h3 className="text-xs font-semibold text-[var(--text-primary)] mb-2">Tool calls — show these types</h3>
-        <ToggleField label="Read" value={prefs.toolCalls.read} onChange={(v) => patch({ toolCalls: { read: v } })} />
-        <ToggleField label="Bash" value={prefs.toolCalls.bash} onChange={(v) => patch({ toolCalls: { bash: v } })} />
-        <ToggleField label="Edit / Write" value={prefs.toolCalls.edit} onChange={(v) => patch({ toolCalls: { edit: v } })} />
-        <ToggleField label="Agent" value={prefs.toolCalls.agent} onChange={(v) => patch({ toolCalls: { agent: v } })} />
-        <ToggleField label="Other" value={prefs.toolCalls.generic} onChange={(v) => patch({ toolCalls: { generic: v } })} />
+        <h3 className="text-xs font-semibold text-[var(--text-primary)] mb-2">{t("settings.toolCallsHeader", undefined, "Tool calls - show these types")}</h3>
+        <ToggleField label={t("settings.toolRead", undefined, "Read")} value={prefs.toolCalls.read} onChange={(v) => patch({ toolCalls: { read: v } })} />
+        <ToggleField label={t("settings.toolBash", undefined, "Bash")} value={prefs.toolCalls.bash} onChange={(v) => patch({ toolCalls: { bash: v } })} />
+        <ToggleField label={t("settings.toolEdit", undefined, "Edit / Write")} value={prefs.toolCalls.edit} onChange={(v) => patch({ toolCalls: { edit: v } })} />
+        <ToggleField label={t("settings.toolAgent", undefined, "Agent")} value={prefs.toolCalls.agent} onChange={(v) => patch({ toolCalls: { agent: v } })} />
+        <ToggleField label={t("settings.toolOther", undefined, "Other")} value={prefs.toolCalls.generic} onChange={(v) => patch({ toolCalls: { generic: v } })} />
       </div>
       <div className="pt-2">
         <button
@@ -976,7 +990,7 @@ function DisplayPrefsSection() {
           onClick={resetToDefaults}
           className="text-xs text-blue-400 hover:text-blue-300 underline"
         >
-          Reset to defaults
+          {t("settings.resetDefaults", undefined, "Reset to defaults")}
         </button>
       </div>
     </Section>
@@ -1010,6 +1024,7 @@ function TrustedNetworksSection({
   legacyTrustedNetworks: string[];
   onChange: (nets: string[]) => void;
 }) {
+  const { t } = useI18n();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [interfaces, setInterfaces] = useState<NetworkInterfaceInfo[]>([]);
   const [loading, setLoading] = useState(false);
@@ -1058,10 +1073,9 @@ function TrustedNetworksSection({
   };
 
   return (
-    <Section title="Trusted Networks">
+    <Section title={t("settings.trustedNetworks", undefined, "Trusted Networks")}>
       <p className="text-xs text-[var(--text-tertiary)] mb-2">
-        Devices matching these networks or hosts can access the dashboard without authentication.
-        Accepts exact IP (<code>10.0.0.5</code>), wildcard (<code>10.0.0.*</code>), or CIDR (<code>192.168.1.0/24</code>).
+        {t("settings.trustedNetworksDescription", undefined, "Devices matching these networks or hosts can access the dashboard without authentication. Accepts exact IP, wildcard, or CIDR.")}
       </p>
 
       {bypassHosts.length > 0 && (
@@ -1072,7 +1086,7 @@ function TrustedNetworksSection({
               <button
                 onClick={() => removeNetwork(net)}
                 className="text-red-400 hover:text-red-300 text-xs px-1 cursor-pointer"
-                title="Remove"
+                title={t("common.remove", undefined, "Remove")}
                 data-testid={`trusted-networks-remove-${net}`}
               >
                 ✕
@@ -1089,7 +1103,7 @@ function TrustedNetworksSection({
             className="text-xs px-2 py-1 rounded bg-[var(--bg-tertiary)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] cursor-pointer"
             data-testid="trusted-networks-add-local"
           >
-            {loading ? "Detecting…" : "+ Add Local Network"}
+            {loading ? t("settings.detecting", undefined, "Detecting...") : t("settings.addLocalNetwork", undefined, "+ Add Local Network")}
           </button>
           {dropdownOpen && interfaces.length > 0 && (
             <div className="absolute left-0 top-full mt-1 z-50 min-w-[260px] bg-[var(--bg-surface)] border border-[var(--border-primary)] rounded-lg shadow-xl py-1">
@@ -1125,7 +1139,7 @@ function TrustedNetworksSection({
           className="text-xs px-2 py-1 rounded bg-[var(--bg-tertiary)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
           data-testid="trusted-networks-manual-add"
         >
-          Add
+          {t("common.add", undefined, "Add")}
         </button>
       </div>
 
@@ -1140,13 +1154,14 @@ function TrustedNetworksSection({
       )}
 
       <p className="text-xs text-amber-400/80 mt-2">
-        ⚠ Anyone on a trusted network has full access to the dashboard without authentication. Only use on private networks you control.
+        {t("settings.trustedNetworksWarning", undefined, "Anyone on a trusted network has full access to the dashboard without authentication. Only use on private networks you control.")}
       </p>
     </Section>
   );
 }
 
 function ServersTab() {
+  const { t } = useI18n();
   const [knownServers, setKnownServers] = useState<import("@blackbelt-technology/pi-dashboard-shared/config.js").KnownServer[]>([]);
   const [loadCount, setLoadCount] = useState(0);
 
@@ -1162,10 +1177,10 @@ function ServersTab() {
 
   return (
     <>
-      <Section title="Known Servers">
+      <Section title={t("settings.knownServers", undefined, "Known Servers")}>
         <KnownServersSection onChange={() => setLoadCount((c) => c + 1)} />
       </Section>
-      <Section title="Network Discovery">
+      <Section title={t("settings.networkDiscovery", undefined, "Network Discovery")}>
         <NetworkDiscoverySection
           knownServers={knownServers}
           onServerAdded={() => setLoadCount((c) => c + 1)}
@@ -1239,6 +1254,7 @@ function ProviderSection({ providerKey, provider, onChange }: {
   provider?: ProviderConfig;
   onChange: (p: ProviderConfig | null) => void;
 }) {
+  const { t } = useI18n();
   const enabled = !!provider;
   const label = PROVIDER_LABELS[providerKey] || providerKey;
   const needsIssuer = NEEDS_ISSUER.has(providerKey);
@@ -1257,7 +1273,7 @@ function ProviderSection({ providerKey, provider, onChange }: {
           }}
           className={`text-xs px-2 py-0.5 rounded ${enabled ? "bg-red-600/20 text-red-400 hover:bg-red-600/30" : "bg-green-600/20 text-green-400 hover:bg-green-600/30"}`}
         >
-          {enabled ? "Remove" : "Enable"}
+          {enabled ? t("common.remove", undefined, "Remove") : t("common.enable", undefined, "Enable")}
         </button>
       </div>
       {enabled && (
@@ -1323,6 +1339,7 @@ const API_TYPE_OPTIONS = [
 // consolidate-packages-settings-ui.
 
 function GlobalPackagesBrowseAndDialogs() {
+  const { t } = useI18n();
   const installed = useInstalledPackages("global");
   const operations = usePackageOperations("global", undefined, installed.refresh);
   const [confirmInstall, setConfirmInstall] = useState<{ source: string; pkg?: NpmPackageResult } | null>(null);
@@ -1340,7 +1357,7 @@ function GlobalPackagesBrowseAndDialogs() {
 
   return (
     <>
-      <Section title="Browse Packages">
+      <Section title={t("common.browsePackages", undefined, "Browse Packages")}>
         <PackageBrowser
           scope="global"
           onViewReadme={setReadmePkg}
@@ -1385,6 +1402,7 @@ export function LlmProviderCard({ provider, onChange, onRemove }: {
   onChange: (p: LlmProvider) => void;
   onRemove: () => void;
 }) {
+  const { t } = useI18n();
   const [testState, setTestState] = useState<TestState>({ kind: "idle" });
 
   const handleChange = (update: LlmProvider) => {
@@ -1428,7 +1446,7 @@ export function LlmProviderCard({ provider, onChange, onRemove }: {
           <input
             type="text"
             className="bg-[var(--bg-secondary)] border border-[var(--border-secondary)] rounded px-2 py-0.5 text-sm font-medium text-[var(--text-primary)] w-48"
-            placeholder="Provider name"
+            placeholder={t("settings.providerName", undefined, "Provider name")}
             value={provider.name}
             onChange={(e) => onChange({ ...provider, name: e.target.value })}
             autoFocus
@@ -1442,8 +1460,8 @@ export function LlmProviderCard({ provider, onChange, onRemove }: {
             disabled={!canTest}
             title={
               !canTest && testState.kind !== "testing"
-                ? "Enter Base URL and API Key first"
-                : "Ping the provider's /models endpoint"
+                ? t("settings.baseUrlFirst", undefined, "Enter Base URL and API Key first")
+                : t("settings.pingModels", undefined, "Ping the provider's /models endpoint")
             }
             className="text-xs px-2 py-0.5 rounded bg-blue-600/20 text-blue-300 hover:bg-blue-600/30 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1"
             data-testid="test-provider-button"
@@ -1451,12 +1469,12 @@ export function LlmProviderCard({ provider, onChange, onRemove }: {
             {testState.kind === "testing" ? (
               <>
                 <Icon path={mdiLoading} size={0.45} className="animate-spin" />
-                Testing…
+                {t("common.testing", undefined, "Testing...")}
               </>
             ) : (
               <>
                 <Icon path={mdiPlay} size={0.45} />
-                Test
+                {t("common.test", undefined, "Test")}
               </>
             )}
           </button>
@@ -1465,7 +1483,7 @@ export function LlmProviderCard({ provider, onChange, onRemove }: {
             className="text-xs px-2 py-0.5 rounded bg-red-600/20 text-red-400 hover:bg-red-600/30 flex items-center gap-1"
           >
             <Icon path={mdiDelete} size={0.45} />
-            Remove
+            {t("common.remove", undefined, "Remove")}
           </button>
         </div>
       </div>
@@ -1502,6 +1520,7 @@ export function LlmProviderCard({ provider, onChange, onRemove }: {
 }
 
 function TestPill({ state }: { state: TestState }) {
+  const { t } = useI18n();
   if (state.kind === "testing") {
     return (
       <div
@@ -1510,12 +1529,14 @@ function TestPill({ state }: { state: TestState }) {
         data-state="testing"
       >
         <Icon path={mdiLoading} size={0.45} className="animate-spin" />
-        Testing…
+        {t("common.testing", undefined, "Testing...")}
       </div>
     );
   }
   if (state.kind === "ok") {
-    const label = state.modelCount > 0 ? `Connected · ${state.modelCount} models` : "Connected";
+    const label = state.modelCount > 0
+      ? t("settings.connectedModels", { count: state.modelCount }, `Connected · ${state.modelCount} models`)
+      : t("settings.connectedOnly", undefined, "Connected");
     return (
       <div
         className="flex items-center gap-1.5 text-xs text-green-400"

--- a/packages/client/src/components/StatusBar.tsx
+++ b/packages/client/src/components/StatusBar.tsx
@@ -4,6 +4,7 @@ import { mdiLoading, mdiFlash } from "@mdi/js";
 import { ModelSelector } from "./ModelSelector.js";
 import { ThinkingLevelSelector } from "./ThinkingLevelSelector.js";
 import type { ModelInfo, RoleInfo } from "@blackbelt-technology/pi-dashboard-shared/types.js";
+import { useI18n } from "../lib/i18n.js";
 
 interface Props {
   model?: string;
@@ -62,19 +63,20 @@ export function StatusBar({
   actions,
   leading,
 }: Props) {
+  const { t } = useI18n();
   let statusLabel: string | null = null;
   let statusIcon = mdiLoading;
   let toolHighlight = false;
 
   if (status === "streaming") {
     if (currentTool) {
-      statusLabel = `Running ${currentTool}…`;
+      statusLabel = t("status.runningTool", { tool: currentTool }, `Running ${currentTool}...`);
       statusIcon = mdiFlash;
       toolHighlight = true;
     } else if (streamingText) {
-      statusLabel = "Generating…";
+      statusLabel = t("status.generating", undefined, "Generating...");
     } else {
-      statusLabel = "Thinking…";
+      statusLabel = t("status.thinking", undefined, "Thinking...");
     }
   }
 

--- a/packages/client/src/components/UnifiedPackagesSection.tsx
+++ b/packages/client/src/components/UnifiedPackagesSection.tsx
@@ -36,24 +36,33 @@ import { PackageReadmeDialog } from "./PackageReadmeDialog.js";
 import { PinDirectoryDialog } from "./PinDirectoryDialog.js";
 import { WhatsNewDialog } from "./WhatsNewDialog.js";
 import { usePiChangelog } from "../hooks/usePiChangelog.js";
+import { useI18n } from "../lib/i18n.js";
 
 /** Single core package the breaking-change icon is wired for. v1 scope. */
 const PI_CORE_PKG = "@mariozechner/pi-coding-agent";
 
 type ProgressMap = Map<string, { phase: "start" | "output" | "complete" | "error"; message?: string }>;
 
-function relativeTime(iso: string): string {
+function relativeTime(iso: string, t: ReturnType<typeof useI18n>["t"]): string {
 	const then = new Date(iso).getTime();
 	if (isNaN(then)) return iso;
 	const diff = Math.floor((Date.now() - then) / 1000);
-	if (diff < 5) return "just now";
-	if (diff < 60) return `${diff}s ago`;
-	if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-	if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-	return `${Math.floor(diff / 86400)}d ago`;
+	if (diff < 5) return t("time.justNow", undefined, "just now");
+	if (diff < 60) return t("time.secondsAgo", { count: diff }, `${diff}s ago`);
+	if (diff < 3600) {
+		const count = Math.floor(diff / 60);
+		return t("time.minutesAgo", { count }, `${count}m ago`);
+	}
+	if (diff < 86400) {
+		const count = Math.floor(diff / 3600);
+		return t("time.hoursAgo", { count }, `${count}h ago`);
+	}
+	const count = Math.floor(diff / 86400);
+	return t("time.daysAgo", { count }, `${count}d ago`);
 }
 
 export function UnifiedPackagesSection() {
+	const { t } = useI18n();
 	// launchSource gates the Core sub-group. Under Electron, bundled
 	// node_modules/ is read-only — pi-version upgrades flow via
 	// electron-updater whole-app replacement. Recommended Extensions +
@@ -294,11 +303,11 @@ export function UnifiedPackagesSection() {
 	return (
 		<div>
 			<h2 className="text-sm font-semibold text-[var(--text-primary)] mb-3 pb-1 border-b border-[var(--border-secondary)] flex items-center justify-between">
-				<span>Pi Ecosystem</span>
+				<span>{t("settings.piEcosystem", undefined, "Pi Ecosystem")}</span>
 				<div className="flex items-center gap-2">
 					{status?.lastChecked && (
 						<span className="text-[10px] font-normal text-[var(--text-muted)]">
-							Last checked: {relativeTime(status.lastChecked)}
+								{t("settings.lastChecked", { time: relativeTime(status.lastChecked, t) }, `Last checked: ${relativeTime(status.lastChecked, t)}`)}
 						</span>
 					)}
 					<button
@@ -311,13 +320,13 @@ export function UnifiedPackagesSection() {
 						data-testid="unified-pkg-check-now"
 					>
 						<Icon path={isLoading || checkingUpdates ? mdiLoading : mdiRefresh} size={0.5} spin={isLoading || checkingUpdates} />
-						{isLoading || checkingUpdates ? "Checking..." : "Check Now"}
+							{isLoading || checkingUpdates ? t("common.checking", undefined, "Checking...") : t("common.checkNow", undefined, "Check Now")}
 					</button>
 				</div>
 			</h2>
 
 			<p className="text-xs text-[var(--text-tertiary)] mb-3">
-				Pi tooling, recommended extensions, and any other packages your pi loads.
+					{t("settings.piEcosystemDescription", undefined, "Pi tooling, recommended extensions, and any other packages your pi loads.")}
 			</p>
 
 			{error && (
@@ -328,9 +337,9 @@ export function UnifiedPackagesSection() {
 			)}
 
 			{/* ── Core sub-group ─────────────────────────────────────────── */}
-			{!hideCoreGroup && <SubGroupHeader title="Core" />}
+			{!hideCoreGroup && <SubGroupHeader title={t("settings.core", undefined, "Core")} />}
 			{!hideCoreGroup && (corePackages.length === 0 ? (
-				<EmptyHint>No pi ecosystem core packages detected.</EmptyHint>
+				<EmptyHint>{t("settings.noCorePackages", undefined, "No pi ecosystem core packages detected.")}</EmptyHint>
 			) : (
 				<>
 					{updatableCore.length > 1 && (
@@ -342,7 +351,7 @@ export function UnifiedPackagesSection() {
 								data-testid="pi-core-update-all"
 							>
 								<Icon path={coreUpdating.size > 0 ? mdiLoading : mdiArrowUpBold} size={0.55} spin={coreUpdating.size > 0} />
-								Update All ({updatableCore.length})
+									{t("common.updateAll", { count: updatableCore.length }, `Update All (${updatableCore.length})`)}
 							</button>
 						</div>
 					)}
@@ -376,17 +385,17 @@ export function UnifiedPackagesSection() {
 			))}
 
 			{/* ── Recommended Extensions sub-group ───────────────────────── */}
-			<SubGroupHeader title="Recommended Extensions" />
+			<SubGroupHeader title={t("settings.recommendedExtensions", undefined, "Recommended Extensions")} />
 			{recommended.length === 0 ? (
-				<EmptyHint>No recommended extensions installed.</EmptyHint>
+				<EmptyHint>{t("settings.noRecommendedExtensions", undefined, "No recommended extensions installed.")}</EmptyHint>
 			) : (
 				<div className="space-y-1 mb-4">{recommended.map(renderInstalledRow)}</div>
 			)}
 
 			{/* ── Other Packages sub-group ───────────────────────────────── */}
-			<SubGroupHeader title="Other Packages" />
+			<SubGroupHeader title={t("settings.otherPackages", undefined, "Other Packages")} />
 			{other.length === 0 ? (
-				<EmptyHint>Locally-developed and user-added packages will appear here.</EmptyHint>
+				<EmptyHint>{t("settings.otherPackagesHint", undefined, "Locally-developed and user-added packages will appear here.")}</EmptyHint>
 			) : (
 				<div className="space-y-1 mb-2">{other.map(renderInstalledRow)}</div>
 			)}

--- a/packages/client/src/lib/i18n.tsx
+++ b/packages/client/src/lib/i18n.tsx
@@ -1,0 +1,283 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+export type Language = "en" | "zh-CN";
+
+const STORAGE_KEY = "pi-dashboard-language";
+
+export const LANGUAGE_OPTIONS: Array<{ value: Language; label: string }> = [
+  { value: "en", label: "English" },
+  { value: "zh-CN", label: "简体中文" },
+];
+
+const normalizeLanguage = (value: string | null | undefined): Language | null => {
+  if (!value) return null;
+  const v = value.toLowerCase();
+  if (v === "zh" || v === "zh-cn" || v.startsWith("zh-hans")) return "zh-CN";
+  if (v === "en" || v.startsWith("en-")) return "en";
+  return null;
+};
+
+const envDefaultLanguage = normalizeLanguage((import.meta as any).env?.VITE_PI_DASHBOARD_DEFAULT_LANGUAGE);
+
+const detectInitialLanguage = (): Language => {
+  try {
+    const stored = normalizeLanguage(window.localStorage.getItem(STORAGE_KEY));
+    if (stored) return stored;
+  } catch {
+    /* ignore storage access failures */
+  }
+  if (envDefaultLanguage) return envDefaultLanguage;
+  const browserLanguage = normalizeLanguage(window.navigator.language);
+  return browserLanguage ?? "en";
+};
+
+const en: Record<string, string> = {};
+
+const zhCN: Record<string, string> = {
+  "common.add": "添加",
+  "common.back": "返回",
+  "common.browsePackages": "浏览包",
+  "common.checkNow": "立即检查",
+  "common.checking": "检查中...",
+  "common.connected": "已连接",
+  "common.connecting": "正在连接...",
+  "common.enable": "启用",
+  "common.failed": "失败",
+  "common.hidden": "隐藏",
+  "common.home": "主页",
+  "common.install": "安装",
+  "common.language": "语言",
+  "common.loading": "加载中...",
+  "common.remove": "移除",
+  "common.restart": "重启",
+  "common.restarting": "正在重启...",
+  "common.save": "保存",
+  "common.saving": "保存中...",
+  "common.search": "搜索",
+  "common.settings": "设置",
+  "common.test": "测试",
+  "common.testing": "测试中...",
+  "common.updateAll": "全部更新 ({count})",
+  "common.queued": "已排队",
+  "common.queuedCount": "{count} 个排队中",
+  "connection.connecting": "正在连接...",
+  "connection.authRequired": "会话已过期",
+  "connection.offline": "服务器离线",
+  "connection.signIn": "登录",
+  "landing.activeSessions": "{count} 个活跃会话",
+  "landing.addFolder": "添加文件夹",
+  "landing.addFolderCta": "添加文件夹...",
+  "landing.addFolderDescription": "把项目目录固定到侧栏，这样就能在里面启动 Pi 会话。",
+  "landing.credentialsConfigured": "凭据已配置",
+  "landing.openSettings": "打开设置",
+  "landing.pickSession": "从左侧选择一个会话继续",
+  "landing.pinnedFolders": "已固定 {count} 个文件夹",
+  "landing.selectSession": "选择一个会话开始",
+  "landing.setupCredentials": "配置凭据",
+  "landing.setupCredentialsDescription": "接入一个 LLM 提供商（Anthropic、OpenAI 等），让会话可以访问模型。",
+  "landing.startSession": "启动会话",
+  "landing.startSessionDescription": "+Session：在 {path} 中启动一个 Pi 会话。",
+  "landing.startSessionDescriptionFallback": "+Session：在已固定的文件夹中启动第一个 Pi 会话。",
+  "landing.step": "步骤 {step}",
+  "landing.stepsHint": "三个快速步骤，启动你的第一个会话。",
+  "landing.requiresCredentials": "需要先配置凭据",
+  "landing.requiresFolder": "需要先固定文件夹",
+  "landing.setCredentialsFirst": "请先配置凭据",
+  "landing.pinFolderFirst": "请先固定文件夹",
+  "landing.welcome": "欢迎使用 pi-dashboard",
+  "sessionList.addToWorkspace": "添加到工作区",
+  "sessionList.emptyWorkspace": "空工作区。请在文件夹操作里使用“+ 添加到工作区”分配文件夹。",
+  "sessionList.filterFolders": "按路径筛选文件夹",
+  "sessionList.folderPlaceholder": "文件夹...",
+  "sessionList.hiddenCount": "{count} 个已隐藏",
+  "sessionList.hideEnded": "隐藏已结束",
+  "sessionList.hideEndedCount": "隐藏 {count} 个已结束会话",
+  "sessionList.noActiveSessions": "没有活跃会话",
+  "sessionList.noSessionsMatch": "没有会话匹配搜索条件",
+  "sessionList.pinDirectory": "固定目录",
+  "sessionList.removeFromWorkspace": "从工作区移除",
+  "sessionList.searchSessions": "搜索会话",
+  "sessionList.sessionFailed": "+Session 失败",
+  "sessionList.sessionPlaceholder": "会话...",
+  "sessionList.settings": "设置",
+  "sessionList.showEnded": "{count} 个已结束",
+  "sessionList.showEndedCount": "显示 {count} 个已结束会话",
+  "sessionList.unpinDirectory": "取消固定目录",
+  "sessionList.viewReadme": "查看 README.md",
+  "command.compactDescription": "压缩会话上下文",
+  "command.forceStop": "强制停止 - 终止进程",
+  "command.inlineTerminal": "打开内联终端",
+  "command.killing": "正在终止进程...",
+  "command.newDescription": "启动新会话",
+  "command.placeholder": "输入消息、/命令、!shell 或 @文件...",
+  "command.previewDescription": "在会话内预览文件或 URL",
+  "command.reloadDescription": "重新加载扩展、技能、提示词和主题",
+  "command.send": "发送",
+  "command.stop": "停止",
+  "settings.advanced": "高级",
+  "settings.apiProxy": "API 代理",
+  "settings.auth": "认证",
+  "settings.authDescription": "配置 OAuth 提供商来保护外部（隧道）访问。本机 localhost 始终开放。",
+  "settings.autoShutdown": "自动关闭",
+  "settings.backgroundPolling": "后台轮询 (OpenSpec)",
+  "settings.browsePackages": "浏览包",
+  "settings.bypassUrls": "绕过认证的 URL 前缀",
+  "settings.bypassUrlsHint": "每行一个，请求这些路径时跳过认证",
+  "settings.chatDisplay": "聊天显示",
+  "settings.chatDisplayAdvancedDescription": "控制聊天消息流中显示哪些内容。",
+  "settings.chatDisplayDescription": "隐藏你不需要的聊天元素。单会话覆盖项在聊天视图的“View”弹窗里。",
+  "settings.contextUsageBar": "上下文用量条",
+  "settings.debugEvents": "调试事件",
+  "settings.defaultModel": "默认模型",
+  "settings.devBuildOnReload": "重新加载时开发构建",
+  "settings.developer": "开发者",
+  "settings.detecting": "检测中...",
+  "settings.editor": "编辑器 (code-server)",
+  "settings.editorDescription": "配置由 code-server 驱动的内置 VS Code 编辑器。",
+  "settings.enableOpenSpec": "启用 OpenSpec",
+  "settings.enableWatchdog": "启用看门狗",
+  "settings.enableZrokTunnel": "启用 Zrok 隧道",
+  "settings.failedLoad": "设置加载失败",
+  "settings.general": "常规",
+  "settings.httpPort": "HTTP 端口",
+  "settings.interface": "界面",
+  "settings.interfaceDescription": "切换仪表盘界面语言。选择会保存在当前浏览器中。",
+  "settings.language": "界面语言",
+  "settings.loading": "正在加载设置...",
+  "settings.llmProviders": "LLM 提供商",
+  "settings.llmProvidersDescription": "注册兼容 OpenAI 的自定义 API 端点来访问模型。",
+  "settings.memoryLimits": "内存限制",
+  "settings.memoryLimitsDescription": "限制服务器内存占用。设为 0 表示禁用限制。需要重启服务器。",
+  "settings.noChanges": "没有需要保存的更改",
+  "settings.packages": "包",
+  "settings.piGatewayPort": "Pi 网关端口",
+  "settings.plugins": "插件",
+  "settings.probeInterval": "探测间隔（秒）",
+  "settings.probeTimeout": "探测超时（秒）",
+  "settings.providers": "提供商",
+  "settings.providerAuth": "提供商认证",
+  "settings.restartFailed": "重启失败",
+  "settings.restartRequired": "已保存。部分更改需要重启服务器后生效。",
+  "settings.restartServer": "重启服务器",
+  "settings.saved": "设置已保存",
+  "settings.saveFailed": "保存设置失败",
+  "settings.security": "安全",
+  "settings.servers": "服务器",
+  "settings.sessions": "会话",
+  "settings.showDebugEvents": "显示调试事件（raw events、flow:list-flows、resources_discover）",
+  "settings.spawnStrategy": "+Session 策略",
+  "settings.tunnel": "隧道",
+  "settings.worktreeButtons": "在文件夹和 OpenSpec 行里显示 worktree 启动按钮",
+  "settings.tokenStatsBar": "Token 统计栏",
+  "settings.reasoningBlocks": "推理块",
+  "settings.toolResultBodies": "工具结果正文",
+  "settings.turnMetadata": "轮次元数据分隔符",
+  "settings.toolCallsHeader": "工具调用 - 显示这些类型",
+  "settings.toolRead": "读取",
+  "settings.toolBash": "Bash",
+  "settings.toolEdit": "编辑 / 写入",
+  "settings.toolAgent": "Agent",
+  "settings.toolOther": "其他",
+  "settings.resetDefaults": "恢复默认",
+  "settings.addProvider": "添加提供商",
+  "settings.addLocalNetwork": "+ 添加本地网络",
+  "settings.allowedUsers": "允许用户",
+  "settings.allowedUsersHint": "每行一个：用户名、邮箱或 *@domain",
+  "settings.trustedNetworks": "可信网络",
+  "settings.trustedNetworksDescription": "匹配这些网络或主机的设备无需认证即可访问仪表盘。支持精确 IP、通配符或 CIDR。",
+  "settings.trustedNetworksWarning": "可信网络中的任何人都能无需认证完整访问仪表盘。请只用于你控制的私有网络。",
+  "settings.knownServers": "已知服务器",
+  "settings.networkDiscovery": "网络发现",
+  "settings.core": "核心",
+  "settings.recommendedExtensions": "推荐扩展",
+  "settings.otherPackages": "其他包",
+  "settings.piEcosystem": "Pi 生态",
+  "settings.piEcosystemDescription": "Pi 工具链、推荐扩展，以及 Pi 当前加载的其他包。",
+  "settings.noCorePackages": "未检测到 Pi 生态核心包。",
+  "settings.noRecommendedExtensions": "尚未安装推荐扩展。",
+  "settings.otherPackagesHint": "本地开发和用户添加的包会显示在这里。",
+  "settings.lastChecked": "上次检查：{time}",
+  "settings.providerName": "提供商名称",
+  "settings.baseUrlFirst": "请先填写 Base URL 和 API Key",
+  "settings.pingModels": "请求提供商的 /models 端点",
+  "settings.connectedModels": "已连接 · {count} 个模型",
+  "settings.connectedOnly": "已连接",
+  "status.generating": "正在生成...",
+  "status.refreshOpenSpec": "刷新 OpenSpec 数据",
+  "status.runningTool": "正在运行 {tool}...",
+  "status.thinking": "正在思考...",
+  "extension.modules": "扩展模块",
+  "extension.noModules": "没有可用模块",
+  "extension.searchModules": "搜索模块...",
+  "shell.chatError": "聊天视图发生错误",
+  "shell.error": "Shell 发生错误",
+  "shell.reloadPage": "重新加载页面",
+  "packages.installed": "已安装包",
+  "packages.installing": "正在安装 {source}...",
+  "packages.noPackages": "没有找到包",
+  "packages.packageCount": "{count} 个包",
+  "packages.searchPlaceholder": "在 npm 上搜索 Pi 包...",
+  "time.daysAgo": "{count} 天前",
+  "time.hoursAgo": "{count} 小时前",
+  "time.justNow": "刚刚",
+  "time.minutesAgo": "{count} 分钟前",
+  "time.secondsAgo": "{count} 秒前",
+};
+
+const dictionaries: Record<Language, Record<string, string>> = {
+  en,
+  "zh-CN": zhCN,
+};
+
+type Vars = Record<string, string | number>;
+
+interface I18nContextValue {
+  language: Language;
+  setLanguage: (language: Language) => void;
+  t: (key: string, vars?: Vars, fallback?: string) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | null>(null);
+
+const fallbackI18n: I18nContextValue = {
+  language: "en",
+  setLanguage: () => {},
+  t: (_key, vars, fallback) => {
+    const template = fallback ?? _key;
+    if (!vars) return template;
+    return template.replace(/\{(\w+)\}/g, (_, name) => String(vars[name] ?? ""));
+  },
+};
+
+export function I18nProvider({ children }: { children: React.ReactNode }) {
+  const [language, setLanguageState] = useState<Language>(detectInitialLanguage);
+
+  useEffect(() => {
+    document.documentElement.lang = language;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, language);
+    } catch {
+      /* ignore storage access failures */
+    }
+  }, [language]);
+
+  const value = useMemo<I18nContextValue>(() => {
+    const translate = (key: string, vars?: Vars, fallback?: string) => {
+      const template = dictionaries[language][key] ?? fallback ?? key;
+      if (!vars) return template;
+      return template.replace(/\{(\w+)\}/g, (_, name) => String(vars[name] ?? ""));
+    };
+    return {
+      language,
+      setLanguage: setLanguageState,
+      t: translate,
+    };
+  }, [language]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  const context = useContext(I18nContext);
+  return context ?? fallbackI18n;
+}

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -4,6 +4,7 @@ import { Router } from "wouter";
 import App from "./App.js";
 import { ThemeProvider } from "./components/ThemeProvider.js";
 import { MobileProvider } from "./hooks/useMobile.js";
+import { I18nProvider } from "./lib/i18n.js";
 import "./index.css";
 // KaTeX styles for LaTeX math rendering in MarkdownContent.
 // See change: chat-markdown-local-images-and-math.
@@ -138,9 +139,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <UiPrimitiveProvider value={primitiveRegistry}>
       <Router>
         <ThemeProvider>
-          <MobileProvider>
-            <App />
-          </MobileProvider>
+          <I18nProvider>
+            <MobileProvider>
+              <App />
+            </MobileProvider>
+          </I18nProvider>
         </ThemeProvider>
       </Router>
     </UiPrimitiveProvider>


### PR DESCRIPTION
## What changed

- Added a lightweight dashboard i18n provider with English and Simplified Chinese support.
- Wrapped the web client in the provider and translated the core operator workflow: onboarding, session sidebar, chat composer, connection banners, Settings, provider setup, status labels, and package management.
- Added a language selector in Settings -> General -> Interface.
- Added `VITE_PI_DASHBOARD_DEFAULT_LANGUAGE=zh-CN` so deployments can start in Chinese while keeping English as the default for existing users.

## Notes

- Plugin-provided dynamic content, package names, model names, and command output remain unchanged.
- The language preference is stored in browser localStorage and falls back to English for missing keys.

## Validation

- `git diff --check`
- `npm run lint`
- `npm run build --workspace=@blackbelt-technology/pi-dashboard-web`
- `VITE_PI_DASHBOARD_DEFAULT_LANGUAGE=zh-CN npm run build --workspace=@blackbelt-technology/pi-dashboard-web`