### PR TITLE
feat(editor): start code-server with the right sidebar closed

### DIFF
--- a/packages/server/src/__tests__/editor-settings-seeding.test.ts
+++ b/packages/server/src/__tests__/editor-settings-seeding.test.ts
@@ -52,6 +52,7 @@ describe("editor settings seeding (writeVscodeUserSettings via setTheme)", () =>
     expect(s["update.mode"]).toBe("none");
     expect(s["extensions.autoCheckUpdates"]).toBe(false);
     expect(s["workbench.startupEditor"]).toBe("none");
+    expect(s["workbench.secondarySideBar.defaultVisibility"]).toBe("hidden");
     // theme keys also present
     expect(s["workbench.colorTheme"]).toBe("Default Dark Modern");
   });

--- a/packages/server/src/editor-manager.ts
+++ b/packages/server/src/editor-manager.ts
@@ -142,6 +142,7 @@ function writeVscodeUserSettings(dataDir: string, theme: "dark" | "light" = "dar
     "update.mode": "none",
     "extensions.autoCheckUpdates": false,
     "workbench.startupEditor": "none",
+    "workbench.secondarySideBar.defaultVisibility": "hidden",
     ...existing,
     "window.autoDetectColorScheme": false,
     "workbench.preferredDarkColorTheme": darkTheme,


### PR DESCRIPTION
Every time a user opens the built-in code-server editor, VS Code shows a right sidebar containing the Chat panel. On mobile or narrow windows, this cuts the available editor area by more than a third. Users have to close it manually on every fresh editor session.

This change seeds `workbench.secondarySideBar.defaultVisibility: "hidden"` in the User settings of every new editor instance, so the sidebar starts closed. Users who prefer the sidebar visible can re-enable it inside the editor and their preference persists.

Changes:
- Adds the setting in `writeVscodeUserSettings()`
- Adds a matching assertion in the settings seeding test