### PR TITLE
ci: fall back to clean install on npm optional-deps bug (npm/cli#4828)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,13 @@ jobs:
           node-version: 22
           cache: npm
 
-      - run: npm ci
+      # `npm ci` fails when package-lock.json omits a platform-specific
+      # optional binary for the runner OS (npm optional-deps bug, npm/cli#4828)
+      # — e.g. a lockfile generated on macOS lacks @rollup/rollup-linux-x64-gnu,
+      # so `npm ci` on ubuntu-latest cannot resolve it. Fall back to a clean
+      # install that re-resolves the full optional tree for this platform.
+      - name: Install dependencies
+        run: npm ci || (echo "npm ci failed (likely npm/cli#4828 optional-deps); retrying clean install" && rm -rf node_modules package-lock.json && npm install)
       - run: npm run lint
       # Hard-gates Tier A (error-severity) regressions; Tier B/C (warn) only annotate.
       - name: Biome static analysis (Tier A gate, warn-tier annotate)


### PR DESCRIPTION
## Problem

Every `develop` CI run has failed at `npm ci` since the lockfile was last regenerated on macOS:

```
npm error Cannot find module @rollup/rollup-linux-x64-gnu.
npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828).
```

`package-lock.json` generated on macOS omits the Linux-platform optional binaries (`@rollup/rollup-linux-x64-gnu`, the `@esbuild/linux-*` set, etc.). On `ubuntu-latest`, `npm ci` strictly installs from the lockfile and cannot resolve the missing Linux nodes → install dies before lint/test/build ever run.

## Fix

Keep `npm ci` on the happy path (strict + reproducible), but fall back to a clean re-resolve when it fails:

```yaml
run: npm ci || (… rm -rf node_modules package-lock.json && npm install)
```

This unblocks CI repo-wide without committing a disproportionate full-lockfile refresh (a clean regen bumps ~223 transitive versions / ~39k lockfile lines). The proper long-term fix is regenerating a cross-platform lockfile in a dedicated maintenance PR; this makes the gate resilient in the meantime.

Only `ci.yml` runs on PRs to `develop`, so this is the sole affected workflow.
