### PR TITLE
feat(extension): filter models_list by enabledModels from pi settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32362,6 +32362,7 @@
       "dependencies": {
         "@blackbelt-technology/pi-dashboard-bus-client": "^0.5.4",
         "@blackbelt-technology/pi-dashboard-shared": "^0.5.4",
+        "minimatch": "^10.0.0",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -32389,6 +32390,42 @@
         "@mariozechner/pi-tui": {
           "optional": true
         }
+      }
+    },
+    "packages/extension/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/extension/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/extension/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/flows-anthropic-bridge-plugin": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@blackbelt-technology/pi-dashboard-bus-client": "^0.5.4",
     "@blackbelt-technology/pi-dashboard-shared": "^0.5.4",
+    "minimatch": "^10.0.0",
     "ws": "^8.18.0"
   },
   "peerDependencies": {

--- a/packages/extension/src/__tests__/filter-enabled-models.test.ts
+++ b/packages/extension/src/__tests__/filter-enabled-models.test.ts
@@ -1,0 +1,151 @@
+/**
+ * `filterByEnabledModels` — filter the dashboard `models_list` by the
+ * `enabledModels` patterns in `~/.pi/agent/settings.json`.
+ *
+ * Matching mirrors pi core's `resolveModelScope`: minimatch (case-insensitive)
+ * against both `provider/id` and bare `id`, with an optional `:<thinkingLevel>`
+ * suffix stripped. `homedir()` is redirected at a temp dir so the real user
+ * settings file is never touched.
+ *
+ * See change: filter-models-list-by-enabled-models (PR #185).
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `var` (not `let`): the mocked homedir() is invoked at import time by
+// provider-register (transitive), before beforeEach runs — `var` avoids the TDZ
+// and the fallback keeps that import-time call from throwing.
+var HOME: string | undefined;
+// Non-null accessor for use sites that run after beforeEach has set HOME.
+const home = (): string => {
+  if (HOME === undefined) throw new Error("HOME not initialised");
+  return HOME;
+};
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: () => HOME ?? actual.homedir() };
+});
+
+// Imported after the mock is registered (vi.mock is hoisted).
+import { filterByEnabledModels } from "../session-sync.js";
+
+type M = { provider: string; id: string };
+
+const MODELS: M[] = [
+  { provider: "anthropic", id: "claude-sonnet-4-6" },
+  { provider: "anthropic", id: "claude-opus-4-8" },
+  { provider: "openai", id: "gpt-5.5" },
+  { provider: "openai", id: "gpt-5.4" },
+  { provider: "google", id: "gemini-3.1-pro-preview" },
+];
+
+function writeSettings(value: unknown): void {
+  mkdirSync(join(home(), ".pi", "agent"), { recursive: true });
+  writeFileSync(join(home(), ".pi", "agent", "settings.json"), JSON.stringify(value), "utf-8");
+}
+
+const ids = (models: M[]) => models.map((m) => `${m.provider}/${m.id}`).sort();
+
+beforeEach(() => {
+  HOME = mkdtempSync(join(tmpdir(), "pi-enabled-models-"));
+});
+
+afterEach(() => {
+  rmSync(home(), { recursive: true, force: true });
+});
+
+describe("filterByEnabledModels — no-op cases", () => {
+  it("returns full list when settings.json is absent", () => {
+    expect(filterByEnabledModels(MODELS)).toEqual(MODELS);
+  });
+
+  it("returns full list when enabledModels is absent", () => {
+    writeSettings({ theme: "earth" });
+    expect(filterByEnabledModels(MODELS)).toEqual(MODELS);
+  });
+
+  it("returns full list when enabledModels is an empty array", () => {
+    writeSettings({ enabledModels: [] });
+    expect(filterByEnabledModels(MODELS)).toEqual(MODELS);
+  });
+
+  it("returns full list when settings.json is malformed", () => {
+    mkdirSync(join(home(), ".pi", "agent"), { recursive: true });
+    writeFileSync(join(home(), ".pi", "agent", "settings.json"), "{ not json", "utf-8");
+    expect(filterByEnabledModels(MODELS)).toEqual(MODELS);
+  });
+});
+
+describe("filterByEnabledModels — matching semantics", () => {
+  it("exact canonical reference", () => {
+    writeSettings({ enabledModels: ["anthropic/claude-sonnet-4-6"] });
+    expect(ids(filterByEnabledModels(MODELS))).toEqual(["anthropic/claude-sonnet-4-6"]);
+  });
+
+  it("provider wildcard", () => {
+    writeSettings({ enabledModels: ["anthropic/*"] });
+    expect(ids(filterByEnabledModels(MODELS))).toEqual([
+      "anthropic/claude-opus-4-8",
+      "anthropic/claude-sonnet-4-6",
+    ]);
+  });
+
+  it("bare-id substring glob (the case the old exact-only matcher dropped)", () => {
+    writeSettings({ enabledModels: ["*sonnet*"] });
+    expect(ids(filterByEnabledModels(MODELS))).toEqual(["anthropic/claude-sonnet-4-6"]);
+  });
+
+  it("prefix glob within a provider", () => {
+    writeSettings({ enabledModels: ["openai/gpt-5.*"] });
+    expect(ids(filterByEnabledModels(MODELS))).toEqual(["openai/gpt-5.4", "openai/gpt-5.5"]);
+  });
+
+  it("case-insensitive match", () => {
+    writeSettings({ enabledModels: ["ANTHROPIC/Claude-Opus-4-8"] });
+    expect(ids(filterByEnabledModels(MODELS))).toEqual(["anthropic/claude-opus-4-8"]);
+  });
+
+  it("union of multiple patterns, de-duplicated", () => {
+    writeSettings({ enabledModels: ["anthropic/*", "*sonnet*", "openai/gpt-5.5"] });
+    expect(ids(filterByEnabledModels(MODELS))).toEqual([
+      "anthropic/claude-opus-4-8",
+      "anthropic/claude-sonnet-4-6",
+      "openai/gpt-5.5",
+    ]);
+  });
+
+  it("strips a trailing :thinkingLevel suffix before matching", () => {
+    writeSettings({ enabledModels: ["anthropic/*:high"] });
+    expect(ids(filterByEnabledModels(MODELS))).toEqual([
+      "anthropic/claude-opus-4-8",
+      "anthropic/claude-sonnet-4-6",
+    ]);
+  });
+
+  it("keeps a colon that is not a valid thinking level", () => {
+    writeSettings({ enabledModels: ["anthropic/claude-sonnet-4-6"] });
+    // A model id genuinely containing a colon should still match exactly.
+    const withColon = [{ provider: "custom", id: "model:v2" }];
+    writeSettings({ enabledModels: ["custom/model:v2"] });
+    expect(ids(filterByEnabledModels(withColon))).toEqual(["custom/model:v2"]);
+  });
+
+  it("skips non-string entries but honors the valid ones", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    writeSettings({ enabledModels: [123, "anthropic/*", null] });
+    expect(ids(filterByEnabledModels(MODELS))).toEqual([
+      "anthropic/claude-opus-4-8",
+      "anthropic/claude-sonnet-4-6",
+    ]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("returns empty when no model matches any pattern", () => {
+    writeSettings({ enabledModels: ["nonexistent/*"] });
+    expect(filterByEnabledModels(MODELS)).toEqual([]);
+  });
+});

--- a/packages/extension/src/bridge.ts
+++ b/packages/extension/src/bridge.ts
@@ -56,7 +56,7 @@ import { activate as activateRoleManager, lookupRole } from "./role-manager.js";
 import { registerRoleModelTools } from "./role-model-tools.js";
 import { autoStartServer } from "./server-auto-start.js";
 import { launchServer } from "./server-launcher.js";
-import { handleSessionChange as _handleSessionChange, replaySessionEntries as _replaySessionEntries, sendStateSync as _sendStateSync } from "./session-sync.js";
+import { filterByEnabledModels, handleSessionChange as _handleSessionChange, replaySessionEntries as _replaySessionEntries, sendStateSync as _sendStateSync } from "./session-sync.js";
 import { tryDispatchExtensionCommand } from "./slash-dispatch.js";
 import { detectSessionSource } from "./source-detector.js";
 import { SubagentFrameBuffer } from "./subagent-frame-buffer.js";
@@ -766,7 +766,7 @@ function initBridge(pi: ExtensionAPI) {
         // Push updated models list to dashboard client
         if (cachedModelRegistry && sessionReady) {
           try {
-            const models = cachedModelRegistry.getAvailable().map(toModelInfo);
+            const models = filterByEnabledModels(cachedModelRegistry.getAvailable().map(toModelInfo));
             connection.send({ type: "models_list", sessionId, models });
             // See change: replace-hardcoded-provider-lists.
             connection.send({ type: "providers_list", sessionId, providers: buildProviderCatalogue() });
@@ -2491,7 +2491,7 @@ function initBridge(pi: ExtensionAPI) {
     cachedModelRegistry = (ctx as any).modelRegistry;
     if (cachedModelRegistry) {
       try {
-        const models = cachedModelRegistry.getAvailable().map(toModelInfo);
+        const models = filterByEnabledModels(cachedModelRegistry.getAvailable().map(toModelInfo));
         connection.send({ type: "models_list", sessionId, models });
         // See change: replace-hardcoded-provider-lists.
         connection.send({ type: "providers_list", sessionId, providers: buildProviderCatalogue() });
@@ -2777,7 +2777,7 @@ function initBridge(pi: ExtensionAPI) {
     if (!isActive()) return;
     if (cachedModelRegistry && sessionReady) {
       try {
-        const models = cachedModelRegistry.getAvailable().map(toModelInfo);
+        const models = filterByEnabledModels(cachedModelRegistry.getAvailable().map(toModelInfo));
         connection.send({ type: "models_list", sessionId, models });
         // See change: replace-hardcoded-provider-lists.
         connection.send({ type: "providers_list", sessionId, providers: buildProviderCatalogue() });

--- a/packages/extension/src/command-handler.ts
+++ b/packages/extension/src/command-handler.ts
@@ -17,6 +17,7 @@ import { draftCommitMessage } from "./commit-draft.js";
 import { killProcessByPgid } from "./process-scanner.js";
 import { expandPromptTemplateFromDisk, loadPromptTemplate } from "./prompt-expander.js";
 import { buildProviderCatalogue, toModelInfo } from "./provider-register.js";
+import { filterByEnabledModels } from "./session-sync.js";
 import { tryDispatchExtensionCommand } from "./slash-dispatch.js";
 
 const IGNORE_DIRS = new Set([".git", "node_modules", ".next", "dist", "build", ".cache", "__pycache__", ".venv"]);
@@ -766,7 +767,7 @@ export function createCommandHandler(
             try {
               registry.authStorage?.reload?.();
               registry.refresh();
-              const models = registry.getAvailable().map(toModelInfo);
+              const models = filterByEnabledModels(registry.getAvailable().map(toModelInfo));
               return { type: "models_list", sessionId, models };
             } catch { /* ignore */ }
           }

--- a/packages/extension/src/session-sync.ts
+++ b/packages/extension/src/session-sync.ts
@@ -2,25 +2,50 @@
  * Session sync: register, replay, and handle session changes.
  * Extracted from bridge.ts for clarity.
  */
-import type { BridgeContext } from "./bridge-context.js";
-import { getCurrentModelString, extractFirstMessage, filterHiddenCommands } from "./bridge-context.js";
-import { detectSessionSource } from "./source-detector.js";
-import { replayEntriesAsEvents } from "@blackbelt-technology/pi-dashboard-shared/state-replay.js";
-import { gatherGitInfo, detectIsGitRepo } from "./vcs-info.js";
-import type { FlowInfo } from "@blackbelt-technology/pi-dashboard-shared/types.js";
-import { buildProviderCatalogue, toModelInfo } from "./provider-register.js";
-import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
+import { join } from "node:path";
+import { replayEntriesAsEvents } from "@blackbelt-technology/pi-dashboard-shared/state-replay.js";
+import type { FlowInfo } from "@blackbelt-technology/pi-dashboard-shared/types.js";
+import * as minimatchNS from "minimatch";
+import type { BridgeContext } from "./bridge-context.js";
+import { extractFirstMessage, filterHiddenCommands, getCurrentModelString } from "./bridge-context.js";
+import { buildProviderCatalogue, toModelInfo } from "./provider-register.js";
+import { detectSessionSource } from "./source-detector.js";
+import { detectIsGitRepo, gatherGitInfo } from "./vcs-info.js";
+
+// minimatch's entry shape varies by version/runtime (v10 exposes a named
+// `minimatch`; v3/CJS-interop exposes it as the default). A namespace import
+// normalises across both.
+type MinimatchFn = (target: string, pattern: string, opts?: { nocase?: boolean }) => boolean;
+const minimatch: MinimatchFn =
+  (minimatchNS as { minimatch?: MinimatchFn }).minimatch ??
+  (minimatchNS as unknown as { default?: MinimatchFn }).default ??
+  (minimatchNS as unknown as MinimatchFn);
+
+// Mirror pi core (core/model-resolver.ts): a trailing `:<thinkingLevel>` on a
+// pattern selects a thinking level and is not part of the model match.
+const VALID_THINKING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+
+function stripThinkingLevel(pattern: string): string {
+  const colonIdx = pattern.lastIndexOf(":");
+  if (colonIdx !== -1 && VALID_THINKING_LEVELS.has(pattern.slice(colonIdx + 1))) {
+    return pattern.slice(0, colonIdx);
+  }
+  return pattern;
+}
 
 /**
  * Filter a models array to only include models matching the `enabledModels`
- * glob patterns from `~/.pi/agent/settings.json`. When `enabledModels` is
- * absent or empty the full list is returned unchanged.
+ * patterns from `~/.pi/agent/settings.json`. When `enabledModels` is absent or
+ * empty the full list is returned unchanged.
  *
- * Supports two pattern forms:
- *   - Exact: `"provider/model-id"`
- *   - Provider wildcard: `"provider/*"`
+ * Matching mirrors pi core's `resolveModelScope`: each pattern is tested with
+ * minimatch (case-insensitive) against both the canonical `provider/id` and the
+ * bare `id`, so exact refs (`anthropic/claude-sonnet-4-6`), provider wildcards
+ * (`anthropic/*`), and bare globs (`*sonnet*`) all work. A trailing
+ * `:<thinkingLevel>` suffix is stripped before matching.
  */
 export function filterByEnabledModels<T extends { provider: string; id: string }>(models: T[]): T[] {
   try {
@@ -34,7 +59,7 @@ export function filterByEnabledModels<T extends { provider: string; id: string }
     for (let i = 0; i < rawPatterns.length; i++) {
       const entry = rawPatterns[i];
       if (typeof entry === "string") {
-        patterns.push(entry);
+        patterns.push(stripThinkingLevel(entry));
       } else {
         console.warn(
           `[pi-dashboard] enabledModels[${i}]: expected string, got ${typeof entry}. Skipping.`,
@@ -44,12 +69,10 @@ export function filterByEnabledModels<T extends { provider: string; id: string }
     if (patterns.length === 0) return models;
 
     return models.filter((m) => {
-      const key = `${m.provider}/${m.id}`;
-      return patterns.some((p) => {
-        if (p === key) return true;
-        if (p.endsWith("/*")) return m.provider === p.slice(0, -2);
-        return false;
-      });
+      const fullId = `${m.provider}/${m.id}`;
+      return patterns.some(
+        (p) => minimatch(fullId, p, { nocase: true }) || minimatch(m.id, p, { nocase: true }),
+      );
     });
   } catch {
     return models; // fall back to full list on any error

--- a/packages/extension/src/session-sync.ts
+++ b/packages/extension/src/session-sync.ts
@@ -27,8 +27,22 @@ export function filterByEnabledModels<T extends { provider: string; id: string }
     const settingsPath = join(homedir(), ".pi", "agent", "settings.json");
     if (!existsSync(settingsPath)) return models;
     const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
-    const patterns: string[] | undefined = settings.enabledModels;
-    if (!Array.isArray(patterns) || patterns.length === 0) return models;
+    const rawPatterns: unknown[] | undefined = settings.enabledModels;
+    if (!Array.isArray(rawPatterns) || rawPatterns.length === 0) return models;
+
+    const patterns: string[] = [];
+    for (let i = 0; i < rawPatterns.length; i++) {
+      const entry = rawPatterns[i];
+      if (typeof entry === "string") {
+        patterns.push(entry);
+      } else {
+        console.warn(
+          `[pi-dashboard] enabledModels[${i}]: expected string, got ${typeof entry}. Skipping.`,
+        );
+      }
+    }
+    if (patterns.length === 0) return models;
+
     return models.filter((m) => {
       const key = `${m.provider}/${m.id}`;
       return patterns.some((p) => {

--- a/packages/extension/src/session-sync.ts
+++ b/packages/extension/src/session-sync.ts
@@ -9,6 +9,38 @@ import { replayEntriesAsEvents } from "@blackbelt-technology/pi-dashboard-shared
 import { gatherGitInfo, detectIsGitRepo } from "./vcs-info.js";
 import type { FlowInfo } from "@blackbelt-technology/pi-dashboard-shared/types.js";
 import { buildProviderCatalogue, toModelInfo } from "./provider-register.js";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/**
+ * Filter a models array to only include models matching the `enabledModels`
+ * glob patterns from `~/.pi/agent/settings.json`. When `enabledModels` is
+ * absent or empty the full list is returned unchanged.
+ *
+ * Supports two pattern forms:
+ *   - Exact: `"provider/model-id"`
+ *   - Provider wildcard: `"provider/*"`
+ */
+export function filterByEnabledModels<T extends { provider: string; id: string }>(models: T[]): T[] {
+  try {
+    const settingsPath = join(homedir(), ".pi", "agent", "settings.json");
+    if (!existsSync(settingsPath)) return models;
+    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    const patterns: string[] | undefined = settings.enabledModels;
+    if (!Array.isArray(patterns) || patterns.length === 0) return models;
+    return models.filter((m) => {
+      const key = `${m.provider}/${m.id}`;
+      return patterns.some((p) => {
+        if (p === key) return true;
+        if (p.endsWith("/*")) return m.provider === p.slice(0, -2);
+        return false;
+      });
+    });
+  } catch {
+    return models; // fall back to full list on any error
+  }
+}
 
 /**
  * Send full state sync to the server (session_register, commands, flows, models).
@@ -97,7 +129,7 @@ export function sendStateSync(
 
   if (bc.cachedModelRegistry) {
     try {
-      const models = bc.cachedModelRegistry.getAvailable().map(toModelInfo);
+      const models = filterByEnabledModels(bc.cachedModelRegistry.getAvailable().map(toModelInfo));
       bc.connection.send({ type: "models_list", sessionId: bc.sessionId, models });
       // See change: replace-hardcoded-provider-lists.
       bc.connection.send({ type: "providers_list", sessionId: bc.sessionId, providers: buildProviderCatalogue() });
@@ -201,7 +233,7 @@ export function handleSessionChange(
 
   if (bc.cachedModelRegistry) {
     try {
-      const models = bc.cachedModelRegistry.getAvailable().map(toModelInfo);
+      const models = filterByEnabledModels(bc.cachedModelRegistry.getAvailable().map(toModelInfo));
       bc.connection.send({ type: "models_list", sessionId: bc.sessionId, models });
       // See change: replace-hardcoded-provider-lists.
       bc.connection.send({ type: "providers_list", sessionId: bc.sessionId, providers: buildProviderCatalogue() });


### PR DESCRIPTION
## Problem

The dashboard sends all authenticated models in `models_list` regardless of the user's `enabledModels` setting in `~/.pi/agent/settings.json`. This means the model picker shows every authenticated model (e.g. 64 models across 4 providers) instead of the curated subset the user configured.

`enabledModels` already filters the TUI model selector — but the dashboard bridge was calling `registry.getAvailable()` directly and never consulting the setting.

## Solution

Add `filterByEnabledModels()` in `session-sync.ts` that reads `enabledModels` patterns from `~/.pi/agent/settings.json` and filters the models array before it is sent to the dashboard. Apply the filter at all five points where `models_list` is produced:

| Location | Trigger |
|---|---|
| `sendStateSync()` | initial connect / reconnect |
| `handleSessionChange()` | fork / resume |
| `credentials_updated` handler in `bridge.ts` | provider auth change |
| `session_start` handler in `bridge.ts` | new session |
| `request_models` handler in `command-handler.ts` | browser subscribes to a session |

## Pattern support

- Exact match: `"anthropic/claude-sonnet-4-6"`
- Provider wildcard: `"anthropic/*"`

When `enabledModels` is absent or empty the filter is a no-op, preserving existing behaviour for users who have not configured the list.