### PR TITLE
fix: cache ctx.cwd to prevent stale-context crash in polling timers

### DIFF
--- a/packages/extension/src/bridge.ts
+++ b/packages/extension/src/bridge.ts
@@ -177,6 +177,7 @@ function initBridge(pi: ExtensionAPI) {
   let lastSessionFile: string | undefined;
   let lastSessionDir: string | undefined;
   let lastFirstMessage: string | undefined;
+  let cachedCwd: string | undefined;
   let pendingDefaultModel: string | null = null; // non-null if default model not yet applied (custom provider not ready)
 
   /** Try to apply the default model from config. Returns the model string if not found (pending), null if applied or no default. */
@@ -2207,10 +2208,13 @@ function initBridge(pi: ExtensionAPI) {
     getBridgeState().timers!.push(heartbeatTimer);
 
     // Start git + name/model polling
+    cachedCwd = ctx.cwd;
     gitPollTimer = setInterval(() => {
       if (!isActive()) return;
-      sendGitInfoIfChanged(ctx.cwd);
-      sendCwdMissingIfChanged(ctx.cwd);
+      if (cachedCwd) {
+        sendGitInfoIfChanged(cachedCwd);
+        sendCwdMissingIfChanged(cachedCwd);
+      }
       sendSessionNameIfChanged();
       sendModelUpdateIfChanged();
     }, GIT_POLL_INTERVAL);
@@ -2271,10 +2275,15 @@ function initBridge(pi: ExtensionAPI) {
 
     // Restart polling timers
     if (gitPollTimer) clearInterval(gitPollTimer);
+    cachedCwd = ctx.cwd;
     gitPollTimer = setInterval(() => {
-      sendGitInfoIfChanged(ctx.cwd);
-      sendCwdMissingIfChanged(ctx.cwd);
+      if (!isActive()) return;
+      if (cachedCwd) {
+        sendGitInfoIfChanged(cachedCwd);
+        sendCwdMissingIfChanged(cachedCwd);
+      }
     }, GIT_POLL_INTERVAL);
+    getBridgeState().timers!.push(gitPollTimer);
   }
 
   // session_switch and session_fork events removed in pi 0.65.0.


### PR DESCRIPTION
fix #195 

ctx.cwd is a guarded getter on ExtensionRunner that throws after session replacement (newSession/fork/switchSession/reload). The git poll timers in bridge.ts captured the live ctx and read ctx.cwd on each tick, but after a session replacement the old ctx becomes stale and the getter throws an uncaught exception that crashes the host process.

Fix:
- Cache ctx.cwd into a local cachedCwd variable at session start and session change, then use the cached value in setInterval callbacks.
- Add missing isActive() guard to the handleSessionChange git poll timer.
- Track handleSessionChange's timer in getBridgeState().timers so it gets cleaned up on bridge teardown.