### PR TITLE
docs(openspec): propose fix-openspec-config-read-bundled-node

### DIFF
--- a/openspec/changes/fix-openspec-config-read-bundled-node/.openspec.yaml
+++ b/openspec/changes/fix-openspec-config-read-bundled-node/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/fix-openspec-config-read-bundled-node/design.md
+++ b/openspec/changes/fix-openspec-config-read-bundled-node/design.md
@@ -44,13 +44,13 @@ Edge case — server running under `ELECTRON_RUN_AS_NODE` (the `execpath-fallbac
 
 **Why over alternatives:** deterministic — the interpreter is supplied explicitly, independent of PATH contents or install topology. Mirrors the already-proven Windows path (single code path, less divergence). The shebang approach is exactly what fails today.
 
-### Decision 2 — Seed a real `node` dir into `buildSpawnEnv` (defense-in-depth, secondary)
+### Decision 2 — Seed a real `node` dir into `buildSpawnEnv` — TRIED, then REVERTED as redundant
 
-Add the resolved node bin dir (and the managed `~/.pi-dashboard/node/bin`, when present) to the PATH `buildSpawnEnv` constructs, so any *other* shebang-based child spawn also resolves `node`.
+Originally proposed as defense-in-depth: add the managed `~/.pi-dashboard/node/bin` to the PATH `buildSpawnEnv` constructs, so any *other* shebang-based child spawn also resolves `node`.
 
-**Why secondary, not primary:** it does not help the `execpath-fallback` topology (no real `node` dir exists to seed) and it still relies on PATH inheritance. Useful breadth (covers CLIs we don't node-wrap) but insufficient alone. Ship alongside Decision 1, not instead of it.
+**Outcome: reverted (commit `fix(ci): revert redundant buildSpawnEnv managed-node prepend`).** It was redundant — every caller already guarantees a real node dir on the child PATH: `process-manager` wraps with `prependManagedNodeToPath` (from `embed-managed-node-runtime`), and `server-launcher` / electron `launch-source` build the resolver with `processExecPath = pick.nodeBin` (the picked real node), so `buildSpawnEnv` already prepends its dir. It was also off the actual fix path — the openspec spawn goes through the runner's `toArgv` node-wrap (Decision 1), not `buildSpawnEnv`. And the extra `existsSync`/`os.homedir()` widened a pre-existing cross-file HOME-mutation race, flaking `process-manager-managed-path.test.ts` in CI.
 
-**Alternative rejected:** *only* fix `buildSpawnEnv`. Rejected because it leaves the shebang dependency intact and fails when the real node dir is absent.
+**Net:** Decision 1 (node-wrap by absolute node path) is the sole fix; it removes the PATH dependency entirely, so seeding PATH was unnecessary. Decision 2 is retained here only as a rejected-alternative record.
 
 ### Decision 3 — Surface CLI-read failure instead of degrading to empty
 
@@ -65,7 +65,7 @@ Stop collapsing a failed `openspec config list` into an empty profile.
 ## Risks / Trade-offs
 
 - **Resolving `.js` over the `.bin` symlink could change `source` in resolution trails / break tests asserting the `.bin` path.** → Update fixtures; keep managed-bin as a lower-priority fallback so behavior degrades sensibly.
-- **`registry.resolve("node")` might itself fail in a degraded bundle.** → Node-wrap falls back to `process.execPath`; when that is the Electron binary, set `ELECTRON_RUN_AS_NODE=1` on the child spawn so it still runs as node.
+- **`registry.resolve("node")` might itself fail in a degraded bundle.** → Node-wrap falls back to `process.execPath`; when that is the Electron binary, the runner's `buildSpawnEnvForArgv` sets `ELECTRON_RUN_AS_NODE=1` on the child spawn so it still runs as node.
 - **Returning an HTTP error from `GET /config` could surface a scarier UI than today's silent empty.** → Intended: a clear "couldn't read config" beats a wrong "not found." Client must render it as recoverable (retry), not fatal.
 - **Windows regression risk** from touching shared `nodeScriptToArgv`. → The change generalizes the unix branch only; the Windows branch keeps its exact existing shape. Cover with a unix + win32 argv test matrix.
 - **Legacy managed-node topology** (`~/.pi-dashboard/node/bin`) not covered by `pickNodeForServer`. → Decision 2 explicitly seeds it; Decision 1 makes it moot when a real node resolves.

--- a/openspec/changes/fix-openspec-config-read-bundled-node/design.md
+++ b/openspec/changes/fix-openspec-config-read-bundled-node/design.md
@@ -1,0 +1,83 @@
+## Context
+
+The global OpenSpec profile section in the dashboard Settings panel renders "not found" / fails to load the current profile when the dashboard runs as a bundled Electron app on macOS (confirmed) and Windows (same bug class, partly mitigated). The `openspec` CLI is installed, resolvable, and its global config is correct.
+
+Reproduced root cause on the affected macOS machine:
+
+```
+env -i HOME=… ~/.pi-dashboard/node_modules/.bin/openspec config list --json
+  → env: node: No such file or directory   exit=127
+(normal shell PATH) same command             → valid JSON, exit=0
+```
+
+The managed `openspec` bin is a `#!/usr/bin/env node` shebang script. It executes only when a binary literally named `node` is on the spawning process's PATH. Two facts about the current spawn machinery make that fragile in the bundle:
+
+- **Unix has no node-wrap.** `nodeScriptToArgv` in `packages/shared/src/tool-registry/definitions.ts` node-wraps `.js` entry points **only on Windows** (`[node.exe, script.js]`). On unix it returns `[resolvedPath]` and trusts the `#!/usr/bin/env node` shebang.
+- **The child PATH may lack a real `node`.** Electron spawns the server via `spawnFromSource`, whose env is built by `ToolResolver.buildSpawnEnv`. That prepends `MANAGED_BIN` (`~/.pi-dashboard/node_modules/.bin` — has `openspec`/`pi` symlinks, no `node`) and `dirname(pick.nodeBin)`. `pickNodeForServer` returns a real `<resources>/node/bin/node` in a healthy immutable bundle (so `node` IS on PATH), but on the `execpath-fallback` path returns the Electron binary (dir has `Electron`, not `node`), and `buildSpawnEnv` additionally **strips** `ELECTRON_RUN_AS_NODE` from children and never seeds `~/.pi-dashboard/node/bin`. So across install topologies (healthy bundle / corrupted-bundle fallback / legacy managed), a child `openspec` spawn is not guaranteed a resolvable `node`.
+
+When the spawn dies (exit 127), `configListOrAsync` unwraps the failure to `null` **silently**; `GET /api/openspec/config` returns `200 { profile:"custom", workflows:[] }`; the Settings panel cannot match that to a real profile and shows "not found."
+
+## Goals / Non-Goals
+
+**Goals:**
+- Managed Node-script CLIs (`openspec`, `pi`) execute from the bundled Electron server regardless of whether a binary named `node` is on the child PATH — deterministically, not by luck of install topology.
+- A CLI-read failure for the global config is distinguishable from a genuinely empty profile, so the Settings UI can show a real error state instead of a fake-empty "not found."
+- Preserve the existing Windows node-wrap behavior with no regression.
+
+**Non-Goals:**
+- Changing the on-disk config format, the config path (`~/.config/openspec/config.json`), or the pinned openspec CLI version.
+- Reworking `pickNodeForServer` / immutable-bundle architecture.
+- Fixing the separate (already-understood) UX gap that per-project OpenSpec UI is hidden in projects without an `openspec/` dir — out of scope here.
+
+## Decisions
+
+### Decision 1 — Node-wrap unix Node-script executor spawns (primary fix)
+
+Extend the executor resolution so `openspec` and `pi` spawns produce `[<real node>, <entry>.js]` on **unix as well as Windows**, removing the dependency on the `#!/usr/bin/env node` shebang finding `node` on PATH.
+
+Two coordinated pieces:
+
+1. **Resolve the `.js` entry, not the `.bin` symlink.** The managed-bin strategy currently resolves `~/.pi-dashboard/node_modules/.bin/openspec` (a shebang symlink). For node-wrapping, the resolved path must be the actual `bin/openspec.js`. Prefer the `bare-import` / `managedModule` strategies (which resolve `bin/openspec.js` directly) ahead of the `.bin` symlink on unix, OR dereference the symlink to its `.js` target before `toArgv`.
+2. **Generalize `nodeScriptToArgv` to node-wrap `.js` on unix.** When the resolved path matches `/\.js$/`, return `[nodePath, resolvedPath]` on every platform. `nodePath` comes from `registry.resolve("node")`; fall back to `process.execPath` only when it is a real `node`.
+
+Edge case — server running under `ELECTRON_RUN_AS_NODE` (the `execpath-fallback`): `process.execPath` is the Electron binary, which behaves as `node` only with `ELECTRON_RUN_AS_NODE=1`. If the node-wrap has to fall back to `process.execPath` in that state, the spawn env for that child must set `ELECTRON_RUN_AS_NODE=1`. Preferred: ensure `registry.resolve("node")` yields the bundled/managed **real** node so this fallback is never hit.
+
+**Why over alternatives:** deterministic — the interpreter is supplied explicitly, independent of PATH contents or install topology. Mirrors the already-proven Windows path (single code path, less divergence). The shebang approach is exactly what fails today.
+
+### Decision 2 — Seed a real `node` dir into `buildSpawnEnv` (defense-in-depth, secondary)
+
+Add the resolved node bin dir (and the managed `~/.pi-dashboard/node/bin`, when present) to the PATH `buildSpawnEnv` constructs, so any *other* shebang-based child spawn also resolves `node`.
+
+**Why secondary, not primary:** it does not help the `execpath-fallback` topology (no real `node` dir exists to seed) and it still relies on PATH inheritance. Useful breadth (covers CLIs we don't node-wrap) but insufficient alone. Ship alongside Decision 1, not instead of it.
+
+**Alternative rejected:** *only* fix `buildSpawnEnv`. Rejected because it leaves the shebang dependency intact and fails when the real node dir is absent.
+
+### Decision 3 — Surface CLI-read failure instead of degrading to empty
+
+Stop collapsing a failed `openspec config list` into an empty profile.
+
+- The `GET /api/openspec/config` handler switches from `configListOrAsync(..., null)` to the `Result`-returning `configListAsync(...)`, inspects `.ok`, and on failure returns a distinct signal (e.g. HTTP 502/503 or `{ success:false, error:"openspec config read failed" }`) rather than a `200` with `workflows:[]`.
+- The empty-vs-failure distinction propagates through `fetchGlobalOpenSpecConfig` so the Settings panel renders a "couldn't read OpenSpec config" state, separate from a genuine empty/custom profile.
+- Keep the successful-read behavior intact, including the `custom`+expanded-set → `expanded` alias mapping.
+
+**Why:** without this, even a correct exec fix leaves the diagnosis-hostile masking in place; any future CLI failure would again silently present as "not found." This is the defect that made the original bug invisible.
+
+## Risks / Trade-offs
+
+- **Resolving `.js` over the `.bin` symlink could change `source` in resolution trails / break tests asserting the `.bin` path.** → Update fixtures; keep managed-bin as a lower-priority fallback so behavior degrades sensibly.
+- **`registry.resolve("node")` might itself fail in a degraded bundle.** → Node-wrap falls back to `process.execPath`; when that is the Electron binary, set `ELECTRON_RUN_AS_NODE=1` on the child spawn so it still runs as node.
+- **Returning an HTTP error from `GET /config` could surface a scarier UI than today's silent empty.** → Intended: a clear "couldn't read config" beats a wrong "not found." Client must render it as recoverable (retry), not fatal.
+- **Windows regression risk** from touching shared `nodeScriptToArgv`. → The change generalizes the unix branch only; the Windows branch keeps its exact existing shape. Cover with a unix + win32 argv test matrix.
+- **Legacy managed-node topology** (`~/.pi-dashboard/node/bin`) not covered by `pickNodeForServer`. → Decision 2 explicitly seeds it; Decision 1 makes it moot when a real node resolves.
+
+## Migration Plan
+
+- Pure code change; no data migration, no config-format change. Ships in the normal release + Electron bundle rebuild.
+- Rollback: revert the `definitions.ts` / `binary-lookup.ts` / `openspec-routes.ts` edits; on-disk config untouched, so no state cleanup.
+- Validation gate: post-fix, `env -i HOME="$HOME" <bundled server env> openspec config list` succeeds, and the Settings panel loads `expanded` (10 workflows) on the confirmed config.
+
+## Open Questions
+
+- Does the affected user's install resolve to the healthy immutable bundle (`<resources>/node/bin/node`) or the `execpath-fallback`? Verifying `pickNodeForServer`'s result on that machine tells us whether Decision 1's node resolution needs the `ELECTRON_RUN_AS_NODE` fallback branch in practice or only for safety.
+- Should the config-read error be a hard HTTP error (502/503) or a `200` with an explicit `{ readError: true }` flag? Trade-off between HTTP semantics and client-handling simplicity — settle before implementing the route + client edits.
+- Should the node-wrap generalization apply to every Node-script executor in the registry (broadest fix) or only `openspec`/`pi` (narrowest, lowest regression risk)?

--- a/openspec/changes/fix-openspec-config-read-bundled-node/proposal.md
+++ b/openspec/changes/fix-openspec-config-read-bundled-node/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+The global OpenSpec profile section in the dashboard Settings panel shows "not found" / fails to load the current profile when the dashboard runs as a **bundled Electron app on macOS (and Windows)** — even though the `openspec` CLI is installed, resolvable, and its global config (`~/.config/openspec/config.json`) is correct.
+
+Confirmed root cause (reproduced on an affected macOS machine):
+
+```
+env -i HOME=… ~/.pi-dashboard/node_modules/.bin/openspec config list --json
+  → env: node: No such file or directory
+  → exit=127
+
+(normal shell PATH) same command
+  → valid JSON, exit=0
+```
+
+The managed `openspec` bin is a `#!/usr/bin/env node` shebang script. It runs only when a binary literally named `node` is on the spawning process's PATH. The chain that breaks:
+
+1. Electron (GUI-launched) spawns the dashboard server under `ELECTRON_RUN_AS_NODE`, so `process.execPath` is the Electron binary (named `Electron`, not `node`).
+2. `ToolResolver.buildSpawnEnv` prepends `MANAGED_BIN` (`~/.pi-dashboard/node_modules/.bin` — holds `openspec`/`pi` symlinks, no `node`) and `dirname(execPath)` (the Electron `MacOS` dir — no file named `node`) to the child PATH. Neither seeds a real `node`.
+3. The server spawns `openspec` via the shared runner. On **unix**, `nodeScriptToArgv` returns `[".bin/openspec"]` and trusts the shebang; on **Windows** the same helper already node-wraps `.js` scripts (`[node.exe, script.js]`). So Windows is protected against the shim/interpreter problem, unix is not.
+4. `/usr/bin/env node` finds no `node` → exit 127.
+5. `configListOrAsync` unwraps any failure to `null` **silently** (no 500, no log line, no toast).
+6. `GET /api/openspec/config` returns `200 { profile:"custom", workflows:[] }`. The Settings panel cannot reconcile the empty set with a real profile and renders "not found / won't load the current profile."
+
+The dashboard works in dev/Linux because the server is launched from a terminal with a full shell PATH (and usually a real `node` from nvm/homebrew on it). The bundled-Electron child-spawn PATH is stripped, exposing the shebang gap.
+
+Two independent defects fall out of this:
+
+- **Exec gap (trigger):** unix `openspec`/`pi` spawns depend on a `node` interpreter the bundled server's child PATH does not guarantee.
+- **Diagnosability (why it presents as "not found"):** `configListOrAsync` collapses exit-127 (and every other CLI failure) into an empty config with no signal, so a *read failure* is indistinguishable from a *genuinely empty profile*.
+
+## What Changes
+
+- **Fix the unix exec gap.** Make the runner spawn openspec (and other managed Node-script CLIs) so a real `node` interpreter is guaranteed, rather than relying on the `#!/usr/bin/env node` shebang. Candidate approaches (to be settled in `design.md`):
+  - Extend `nodeScriptToArgv` to node-wrap `.js` entry points on **unix as well as Windows** — resolve `bin/openspec.js` (not the `.bin` symlink) and spawn `[<resolved node>, openspec.js]` via the registry's `node` resolution.
+  - And/or ensure `buildSpawnEnv` seeds a **real node bin dir** (`<resources>/node/bin` or `~/.pi-dashboard/node/bin`) onto the child PATH so `env node` resolves.
+- **Fix the silent degradation.** `configListOrAsync` (and the `GET /api/openspec/config` handler) must distinguish a CLI-read failure from an empty profile, so the Settings panel can render a real error state ("couldn't read OpenSpec config") instead of a fake-empty "not found."
+- No change to the on-disk config format, the config path (`~/.config/openspec/config.json`), or the openspec CLI version pinning.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `tool-resolution`: managed Node-script executors (`openspec`, `pi`) SHALL be spawnable without relying on a `#!/usr/bin/env node` shebang finding `node` on the child PATH — the interpreter is resolved and supplied explicitly (parity with the existing Windows node-wrap), OR a real `node` bin dir is guaranteed on the spawn env.
+- `openspec-profile-settings`: the global config read SHALL propagate CLI-read failures as a distinct error state to the Settings UI rather than degrading to an empty (`workflows: []`) profile that renders as "not found."
+
+## Impact
+
+- `packages/shared/src/tool-registry/definitions.ts` — `nodeScriptToArgv` unix branch (node-wrap `.js` on unix), and/or openspec/pi executor strategy ordering to resolve `bin/openspec.js` over the `.bin` symlink.
+- `packages/shared/src/platform/binary-lookup.ts` — optionally `buildSpawnEnv` to seed a real node bin dir onto the child PATH.
+- `packages/shared/src/platform/openspec.ts` — `configListOrAsync` (and callers) to surface failure vs. empty distinctly.
+- `packages/server/src/routes/openspec-routes.ts` — `GET /api/openspec/config` to return an error state on read failure instead of masking it as an empty profile.
+- `packages/client/src/lib/openspec-config-api.ts` + Settings panel — render a "couldn't read config" state distinct from an empty/custom profile.
+- Platform-specific: reproduced on bundled Electron macOS; Windows shares the shebang class of bug but is already partially mitigated by the existing node-wrap — verify no regression.
+
+## Verification
+
+- Repro (pre-fix): `env -i HOME="$HOME" ~/.pi-dashboard/node_modules/.bin/openspec config list --json` → `exit=127`, `env: node: No such file`.
+- Post-fix: the bundled Electron server's openspec spawn succeeds with a stripped GUI PATH; the Settings panel loads the correct profile (`expanded` for the confirmed config: 10 workflows persisted as `custom` + expanded set).
+- A CLI-read failure surfaces as a distinct error state in Settings, never as a silent empty profile.

--- a/openspec/changes/fix-openspec-config-read-bundled-node/specs/openspec-profile-config/spec.md
+++ b/openspec/changes/fix-openspec-config-read-bundled-node/specs/openspec-profile-config/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Global config read distinguishes CLI failure from empty profile
+
+The global OpenSpec config read (`GET /api/openspec/config` and its `configListOrAsync` backing) SHALL distinguish a CLI-read failure from a genuinely empty/custom profile. A failed `openspec config list` spawn SHALL NOT be silently unwrapped into a `{ profile: "custom", workflows: [] }` payload. The Settings panel SHALL be able to render a distinct "couldn't read OpenSpec config" error state rather than a fake-empty profile that presents as "not found."
+
+#### Scenario: CLI read failure surfaces as an error state
+
+- **WHEN** `openspec config list --json` fails to execute (e.g. exit 127 because the interpreter is unresolvable, or any non-zero exit / spawn error)
+- **THEN** the config read SHALL report a failure signal distinct from a successful empty result
+- **AND** the Settings panel SHALL render an error state ("couldn't read OpenSpec config"), NOT an empty `custom` profile with zero workflows
+
+#### Scenario: Successful read still maps expanded alias
+
+- **WHEN** `openspec config list --json` succeeds and returns `profile: "custom"` with exactly the expanded workflow set
+- **THEN** the read SHALL continue to surface the `expanded` alias to the Settings UI as before

--- a/openspec/changes/fix-openspec-config-read-bundled-node/specs/tool-registry/spec.md
+++ b/openspec/changes/fix-openspec-config-read-bundled-node/specs/tool-registry/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Node-script executors spawn without shebang interpreter dependency
+
+Managed Node-script executors (`openspec`, `pi`) SHALL be spawnable without relying on a `#!/usr/bin/env node` shebang finding a `node` binary on the child process's PATH. The registry's `toArgv` for these executors SHALL supply the Node interpreter explicitly (resolving the `.js` entry point plus a resolved `node`), OR the spawn environment SHALL be guaranteed to contain a real `node` bin directory. This behavior SHALL hold on unix (macOS/Linux) with parity to the existing Windows node-wrap, so a GUI-launched (Electron) server with a stripped PATH can still execute the CLI.
+
+#### Scenario: Unix openspec spawn with a stripped child PATH
+
+- **WHEN** the dashboard server spawns `openspec` on unix from a process whose PATH contains no binary named `node` (e.g. an Electron-launched server under `ELECTRON_RUN_AS_NODE`)
+- **THEN** the resolved spawn argv SHALL invoke a real `node` interpreter against the resolved `bin/openspec.js` (not the bare `.bin/openspec` shebang symlink), OR the spawn env SHALL include a real `node` bin directory
+- **AND** the CLI SHALL execute successfully instead of failing with exit 127 / `env: node: No such file or directory`
+
+#### Scenario: Windows node-wrap parity preserved
+
+- **WHEN** the same executor is resolved on Windows to a `.js` entry point
+- **THEN** the existing `[node.exe, script.js]` node-wrap SHALL remain in effect with no regression

--- a/openspec/changes/fix-openspec-config-read-bundled-node/tasks.md
+++ b/openspec/changes/fix-openspec-config-read-bundled-node/tasks.md
@@ -1,36 +1,36 @@
 ## 1. Reproduce & pin topology
 
-- [ ] 1.1 Add a failing unit test in `packages/shared/src/tool-registry/__tests__/` asserting that resolving `openspec` on unix yields a node-wrapped argv (`[<node>, .../bin/openspec.js]`), NOT the bare `.bin/openspec` shebang symlink. Test must fail against current code.
-- [ ] 1.2 On the affected macOS bundle, capture `pickNodeForServer` result (bundled `<resources>/node/bin/node` vs `execpath-fallback`) to confirm whether the `ELECTRON_RUN_AS_NODE` fallback branch is exercised in practice (resolves Open Question 1 in design.md).
+- [x] 1.1 Add a failing unit test in `packages/shared/src/tool-registry/__tests__/` asserting that resolving `openspec` on unix yields a node-wrapped argv (`[<node>, .../bin/openspec.js]`), NOT the bare `.bin/openspec` shebang symlink. Test must fail against current code. (`openspec-unix-node-wrap.test.ts`)
+- [ ] 1.2 (DEFERRED — needs affected macOS bundle) On the affected macOS bundle, capture `pickNodeForServer` result (bundled `<resources>/node/bin/node` vs `execpath-fallback`) to confirm whether the `ELECTRON_RUN_AS_NODE` fallback branch is exercised in practice (resolves Open Question 1 in design.md). Fallback implemented defensively regardless (runner sets `ELECTRON_RUN_AS_NODE=1` when node-wrap lands on the Electron `process.execPath`).
 
 ## 2. Node-wrap unix Node-script executor spawns (Decision 1)
 
-- [ ] 2.1 In `packages/shared/src/tool-registry/definitions.ts`, generalize `nodeScriptToArgv` to node-wrap `.js` resolved paths on unix as well as win32: when `/\.js$/` matches, return `[nodePath, resolvedPath]`; `nodePath` from `registry.resolve("node")`, falling back to `process.execPath` only when it is a real node.
-- [ ] 2.2 Ensure the resolved openspec/pi path is the `.js` entry, not the `.bin` shebang symlink: order `bare-import` / `managedModule` strategies ahead of `managedBin` on unix, OR dereference the `.bin` symlink to its `.js` target before `toArgv`.
-- [ ] 2.3 Handle the `ELECTRON_RUN_AS_NODE` edge: when the node-wrap falls back to `process.execPath` and that is the Electron binary, set `ELECTRON_RUN_AS_NODE=1` on that child spawn's env so it runs as node.
-- [ ] 2.4 Preserve the existing Windows `[node.exe, script.js]` branch byte-for-byte (no regression).
+- [x] 2.1 In `packages/shared/src/tool-registry/definitions.ts`, generalize `nodeScriptToArgv` to node-wrap `.js` resolved paths on unix as well as win32: when `/\.js$/` matches, return `[nodePath, resolvedPath]`; `nodePath` from `registry.resolve("node")`, falling back to `process.execPath` only when it is a real node.
+- [x] 2.2 Ensure the resolved openspec/pi path is the `.js` entry, not the `.bin` shebang symlink: dereference the `.bin` symlink to its `.js` target (`resolveJsScript` via `realpathSync`, unix-only) before `toArgv`. (`bare-import` already ordered ahead of `managedBin` on unix.)
+- [x] 2.3 Handle the `ELECTRON_RUN_AS_NODE` edge: when the node-wrap falls back to `process.execPath` and that is the Electron binary, set `ELECTRON_RUN_AS_NODE=1` on that child spawn's env so it runs as node. (Done in `runner.ts::buildSpawnEnvForArgv`.)
+- [x] 2.4 Preserve the existing Windows `[node.exe, script.js]` branch byte-for-byte (no regression). (`resolveJsScript` skips the deref on win32; `node-script-toargv-fallback.test.ts` still green.)
 
 ## 3. Seed real node dir into buildSpawnEnv (Decision 2, defense-in-depth)
 
-- [ ] 3.1 In `packages/shared/src/platform/binary-lookup.ts`, extend `buildSpawnEnv` to prepend the resolved node bin dir and, when present, the managed `~/.pi-dashboard/node/bin` to the child PATH.
-- [ ] 3.2 Guard against duplicate PATH entries (reuse the existing `currentPath.includes(dir)` pattern).
+- [x] 3.1 In `packages/shared/src/platform/binary-lookup.ts`, extend `buildSpawnEnv` to prepend the resolved node bin dir and, when present, the managed `~/.pi-dashboard/node/bin` to the child PATH. (Existing `nodeBin` from `processExecPath` kept; added `getManagedNodeBinDir` when `isManagedNodePresent`.)
+- [x] 3.2 Guard against duplicate PATH entries (reuse the existing `currentPath.includes(dir)` pattern).
 
 ## 4. Surface CLI-read failure instead of empty degradation (Decision 3)
 
-- [ ] 4.1 In `packages/server/src/routes/openspec-routes.ts`, change `GET /api/openspec/config` to use `configListAsync` (Result), inspect `.ok`, and on failure return a distinct signal instead of `200 { workflows: [] }` (settle HTTP-error vs `{ readError: true }` per design Open Question 2).
-- [ ] 4.2 Keep the successful-read path intact, including the `custom` + expanded-set → `expanded` alias mapping.
-- [ ] 4.3 In `packages/client/src/lib/openspec-config-api.ts`, propagate the failure signal from `fetchGlobalOpenSpecConfig` distinctly from an empty/custom profile.
-- [ ] 4.4 In the Settings panel, render a recoverable "couldn't read OpenSpec config" error state (with retry) distinct from a genuine empty/custom profile.
+- [x] 4.1 In `packages/server/src/routes/openspec-routes.ts`, change `GET /api/openspec/config` to use `configListAsync` (Result), inspect `.ok`, and on failure return a distinct signal instead of `200 { workflows: [] }`. **Open Question 2 settled: HTTP `502 { success:false, error }`** (client already throws on `!res.ok`). Failed reads are NOT cached (retry re-attempts).
+- [x] 4.2 Keep the successful-read path intact, including the `custom` + expanded-set → `expanded` alias mapping.
+- [x] 4.3 Propagate the failure signal from `fetchGlobalOpenSpecConfig` distinctly from an empty/custom profile. Satisfied by existing client code: `fetchGlobalOpenSpecConfig` `throw`s on the 502 (`!res.ok`), which is distinct from a resolved empty/custom config.
+- [x] 4.4 Render a recoverable "couldn't read OpenSpec config" error state (with retry). Satisfied by the existing `OpenSpecProfileSection` `loadStatus === "error"` path + `profile-load-retry` button (added by `fix-openspec-profile-load-race`) — now reached because the server returns 502 on read failure instead of a fake-empty profile.
 
 ## 5. Tests & verification
 
-- [ ] 5.1 Make task 1.1's test pass; add a unix + win32 argv matrix test for `nodeScriptToArgv` covering `.js` node-wrap and non-`.js` passthrough.
-- [ ] 5.2 Add a test that a stripped-PATH spawn of the resolved openspec argv executes successfully (no `env: node` / exit 127) — mock or integration per existing test conventions.
-- [ ] 5.3 Add a route test: `GET /api/openspec/config` returns the error state (not empty profile) when the CLI read fails, and returns `expanded` for a `custom`+expanded-set config on success.
-- [ ] 5.4 Run `npm test 2>&1 | tee /tmp/pi-test.log` and confirm no failures (`grep -nE 'FAIL|Error|✗' /tmp/pi-test.log`).
-- [ ] 5.5 Manual bundle check: rebuild the Electron bundle, open Settings on macOS, confirm the OpenSpec profile loads (`expanded`, 10 workflows) instead of "not found."
+- [x] 5.1 Make task 1.1's test pass; add a unix + win32 argv matrix test for `nodeScriptToArgv` covering `.js` node-wrap and non-`.js` passthrough. (`node-script-argv-matrix.test.ts`)
+- [x] 5.2 Add a test that a stripped-PATH spawn of the resolved openspec argv executes successfully (no `env: node` / exit 127). (`node-script-argv-matrix.test.ts` — real spawn with `env: { PATH: "" }`.)
+- [x] 5.3 Add a route test: `GET /api/openspec/config` returns the error state (not empty profile) when the CLI read fails, and returns `expanded` for a `custom`+expanded-set config on success. (`openspec-profile-routes.test.ts` — new 502 + no-cache tests; expanded-alias test pre-existing.)
+- [x] 5.4 Run `npm test` — no failures in touched areas. Only pre-existing failures are `@blackbelt-technology/pi-image-fit-extension` (`Jimp is not a constructor`, untouched package).
+- [ ] 5.5 (DEFERRED — needs affected macOS bundle) Manual bundle check: rebuild the Electron bundle, open Settings on macOS, confirm the OpenSpec profile loads (`expanded`, 10 workflows) instead of "not found."
 
 ## 6. Land
 
-- [ ] 6.1 Run the code-review gate (`npx tsx .pi/skills/implement/scripts/review-changes.ts`) and address Critical/Warning items.
-- [ ] 6.2 Full rebuild + restart per the build matrix (shared/server change → restart; client change → `npm run build` + restart), then reload pi sessions.
+- [x] 6.1 Run the code-review gate (`npx tsx .pi/skills/implement/scripts/review-changes.ts`). CodeRabbit CLI not installed on this host → advisory gate warned-and-continued (exit 0), deferred to a later cycle per the documented rate-limit/missing-CLI behavior. No Critical/Warning items to address from the gate.
+- [ ] 6.2 (DEFERRED — worktree-isolated) Full rebuild + restart per the build matrix. Per AGENTS.md, `full-rebuild.ts` deploys the checked-out dev version to the local running instance and is NOT run for worktree / Docker-isolated work. Changes touch `shared` + `server` (→ restart) and no client source (client fix reuses the existing error state) — deploy happens at merge/release, not from this worktree.

--- a/openspec/changes/fix-openspec-config-read-bundled-node/tasks.md
+++ b/openspec/changes/fix-openspec-config-read-bundled-node/tasks.md
@@ -1,0 +1,36 @@
+## 1. Reproduce & pin topology
+
+- [ ] 1.1 Add a failing unit test in `packages/shared/src/tool-registry/__tests__/` asserting that resolving `openspec` on unix yields a node-wrapped argv (`[<node>, .../bin/openspec.js]`), NOT the bare `.bin/openspec` shebang symlink. Test must fail against current code.
+- [ ] 1.2 On the affected macOS bundle, capture `pickNodeForServer` result (bundled `<resources>/node/bin/node` vs `execpath-fallback`) to confirm whether the `ELECTRON_RUN_AS_NODE` fallback branch is exercised in practice (resolves Open Question 1 in design.md).
+
+## 2. Node-wrap unix Node-script executor spawns (Decision 1)
+
+- [ ] 2.1 In `packages/shared/src/tool-registry/definitions.ts`, generalize `nodeScriptToArgv` to node-wrap `.js` resolved paths on unix as well as win32: when `/\.js$/` matches, return `[nodePath, resolvedPath]`; `nodePath` from `registry.resolve("node")`, falling back to `process.execPath` only when it is a real node.
+- [ ] 2.2 Ensure the resolved openspec/pi path is the `.js` entry, not the `.bin` shebang symlink: order `bare-import` / `managedModule` strategies ahead of `managedBin` on unix, OR dereference the `.bin` symlink to its `.js` target before `toArgv`.
+- [ ] 2.3 Handle the `ELECTRON_RUN_AS_NODE` edge: when the node-wrap falls back to `process.execPath` and that is the Electron binary, set `ELECTRON_RUN_AS_NODE=1` on that child spawn's env so it runs as node.
+- [ ] 2.4 Preserve the existing Windows `[node.exe, script.js]` branch byte-for-byte (no regression).
+
+## 3. Seed real node dir into buildSpawnEnv (Decision 2, defense-in-depth)
+
+- [ ] 3.1 In `packages/shared/src/platform/binary-lookup.ts`, extend `buildSpawnEnv` to prepend the resolved node bin dir and, when present, the managed `~/.pi-dashboard/node/bin` to the child PATH.
+- [ ] 3.2 Guard against duplicate PATH entries (reuse the existing `currentPath.includes(dir)` pattern).
+
+## 4. Surface CLI-read failure instead of empty degradation (Decision 3)
+
+- [ ] 4.1 In `packages/server/src/routes/openspec-routes.ts`, change `GET /api/openspec/config` to use `configListAsync` (Result), inspect `.ok`, and on failure return a distinct signal instead of `200 { workflows: [] }` (settle HTTP-error vs `{ readError: true }` per design Open Question 2).
+- [ ] 4.2 Keep the successful-read path intact, including the `custom` + expanded-set → `expanded` alias mapping.
+- [ ] 4.3 In `packages/client/src/lib/openspec-config-api.ts`, propagate the failure signal from `fetchGlobalOpenSpecConfig` distinctly from an empty/custom profile.
+- [ ] 4.4 In the Settings panel, render a recoverable "couldn't read OpenSpec config" error state (with retry) distinct from a genuine empty/custom profile.
+
+## 5. Tests & verification
+
+- [ ] 5.1 Make task 1.1's test pass; add a unix + win32 argv matrix test for `nodeScriptToArgv` covering `.js` node-wrap and non-`.js` passthrough.
+- [ ] 5.2 Add a test that a stripped-PATH spawn of the resolved openspec argv executes successfully (no `env: node` / exit 127) — mock or integration per existing test conventions.
+- [ ] 5.3 Add a route test: `GET /api/openspec/config` returns the error state (not empty profile) when the CLI read fails, and returns `expanded` for a `custom`+expanded-set config on success.
+- [ ] 5.4 Run `npm test 2>&1 | tee /tmp/pi-test.log` and confirm no failures (`grep -nE 'FAIL|Error|✗' /tmp/pi-test.log`).
+- [ ] 5.5 Manual bundle check: rebuild the Electron bundle, open Settings on macOS, confirm the OpenSpec profile loads (`expanded`, 10 workflows) instead of "not found."
+
+## 6. Land
+
+- [ ] 6.1 Run the code-review gate (`npx tsx .pi/skills/implement/scripts/review-changes.ts`) and address Critical/Warning items.
+- [ ] 6.2 Full rebuild + restart per the build matrix (shared/server change → restart; client change → `npm run build` + restart), then reload pi sessions.

--- a/openspec/changes/fix-openspec-config-read-bundled-node/tasks.md
+++ b/openspec/changes/fix-openspec-config-read-bundled-node/tasks.md
@@ -12,8 +12,8 @@
 
 ## 3. Seed real node dir into buildSpawnEnv (Decision 2, defense-in-depth)
 
-- [x] 3.1 In `packages/shared/src/platform/binary-lookup.ts`, extend `buildSpawnEnv` to prepend the resolved node bin dir and, when present, the managed `~/.pi-dashboard/node/bin` to the child PATH. (Existing `nodeBin` from `processExecPath` kept; added `getManagedNodeBinDir` when `isManagedNodePresent`.)
-- [x] 3.2 Guard against duplicate PATH entries (reuse the existing `currentPath.includes(dir)` pattern).
+- [x] 3.1 Defense-in-depth (real node bin dir on child PATH): **already provided by existing code**, no new `buildSpawnEnv` change needed. `process-manager.buildSpawnEnv` wraps `resolver.buildSpawnEnv` with `prependManagedNodeToPath` (seeds `~/.pi-dashboard/node/bin` at PATH head); `server-launcher` + `electron/launch-source` construct the resolver with `processExecPath: pick.nodeBin` (the picked real node), so `dirname(nodeBin)` is already prepended. A duplicate prepend inside the shared `ToolResolver.buildSpawnEnv` was implemented then **reverted** — it was redundant and its extra `existsSync`/`os.homedir()` widened a pre-existing cross-file `HOME`-mutation race that flaked `process-manager-managed-path.test.ts` in CI. The real fix is Decision 1 (node-wrap via the runner, which does not use `buildSpawnEnv`).
+- [x] 3.2 Duplicate-PATH guard: existing `prependManagedNodeToPath` already dedups via `currentPath.split(delimiter).includes(dir)`; no change needed.
 
 ## 4. Surface CLI-read failure instead of empty degradation (Decision 3)
 

--- a/packages/server/src/__tests__/openspec-profile-routes.test.ts
+++ b/packages/server/src/__tests__/openspec-profile-routes.test.ts
@@ -8,8 +8,9 @@
  * The shared platform/openspec module is mocked so no real `openspec` CLI
  * runs and no global config file is touched.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
 import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerOpenSpecRoutes } from "../routes/openspec-routes.js";
 
 const PASSTHRU_GUARD = async () => {};
@@ -21,8 +22,12 @@ const mock = {
   writeOpenSpecConfigFile: vi.fn(),
   globalWorkflows: ["propose", "explore", "apply", "archive"] as string[],
   globalProfile: "core" as string | undefined,
-  // null => simulate a failed/unparseable `openspec config list`.
+  // null => `openspec config list` succeeded (exit 0) but produced null/
+  // unparseable JSON (a successful-but-empty read, NOT a spawn failure).
   configListResult: undefined as Record<string, unknown> | null | undefined,
+  // true => the CLI spawn/exit itself failed (e.g. exit 127 under a stripped
+  // bundled-Electron PATH). Distinct from configListResult=null.
+  configListFails: false,
   configListAsyncCalls: 0,
 };
 
@@ -40,6 +45,13 @@ vi.mock("../directory-service.js", () => ({
 
 vi.mock("@blackbelt-technology/pi-dashboard-shared/platform/openspec.js", () => ({
   configListOr: () => ({ workflows: mock.globalWorkflows }),
+  // Result-returning variant used by GET /api/openspec/config so a spawn/exit
+  // failure surfaces as a 502 instead of a silently-empty profile.
+  configListAsync: async () => {
+    mock.configListAsyncCalls += 1;
+    if (mock.configListFails) return { ok: false, error: { kind: "exit", code: 127, signal: null, stdout: "", stderr: "" } };
+    return { ok: true, value: currentConfigListValue() };
+  },
   configListOrAsync: async () => {
     mock.configListAsyncCalls += 1;
     return currentConfigListValue();
@@ -73,6 +85,7 @@ describe("openspec profile-config REST routes", () => {
     mock.globalWorkflows = ["propose", "explore", "apply", "archive"];
     mock.globalProfile = "core";
     mock.configListResult = undefined;
+    mock.configListFails = false;
     mock.configListAsyncCalls = 0;
     signatures = {};
     sessionCwds = ["/proj/a"];
@@ -351,8 +364,8 @@ describe("openspec profile-config REST routes", () => {
     expect(mock.configListAsyncCalls).toBe(1);
   });
 
-  it("GET config returns safe defaults when the CLI read fails", async () => {
-    mock.configListResult = null; // simulate failed/unparseable `openspec config list`
+  it("GET config returns safe defaults on a successful-but-empty read (exit 0, null JSON)", async () => {
+    mock.configListResult = null; // CLI exit 0 but null/unparseable JSON
     await setup();
     const res = await fastify.inject({ method: "GET", url: "/api/openspec/config?cwd=/proj/a" });
     expect(res.statusCode).toBe(200);
@@ -360,6 +373,29 @@ describe("openspec profile-config REST routes", () => {
     expect(body.data.profile).toBe("custom");
     expect(body.data.delivery).toBe("both");
     expect(body.data.workflows).toEqual([]);
+  });
+
+  // The bundled-Electron bug: a stripped child PATH makes the openspec spawn
+  // exit 127. That MUST surface as a distinct error state, not a fake-empty
+  // "custom" profile that the Settings panel renders as "not found."
+  // See change: fix-openspec-config-read-bundled-node.
+  it("GET config returns a 502 error state (not an empty profile) when the CLI spawn fails", async () => {
+    mock.configListFails = true;
+    await setup();
+    const res = await fastify.inject({ method: "GET", url: "/api/openspec/config?cwd=/proj/a" });
+    expect(res.statusCode).toBe(502);
+    const body = JSON.parse(res.payload);
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/read failed/i);
+  });
+
+  it("GET config does not cache a failed read (retry re-attempts the CLI)", async () => {
+    mock.configListFails = true;
+    await setup();
+    await fastify.inject({ method: "GET", url: "/api/openspec/config?cwd=/proj/a" });
+    await fastify.inject({ method: "GET", url: "/api/openspec/config?cwd=/proj/a" });
+    // Both requests re-ran the CLI — the 502 path never populates the cache.
+    expect(mock.configListAsyncCalls).toBe(2);
   });
 
   it("excludes the global config dir's parent (~/.config) even though it has openspec/", async () => {

--- a/packages/server/src/routes/openspec-routes.ts
+++ b/packages/server/src/routes/openspec-routes.ts
@@ -1,31 +1,33 @@
 /**
  * OpenSpec and Pi Resources REST API routes (localhost-only).
  */
-import type { FastifyInstance } from "fastify";
-import type { SessionManager } from "../memory-session-manager.js";
-import type { PreferencesStore } from "../preferences-store.js";
-import { hasOpenSpecRoot, type DirectoryService } from "../directory-service.js";
-import type { ApiResponse, OpenSpecConfig } from "@blackbelt-technology/pi-dashboard-shared/types.js";
+
+import fs from "node:fs/promises";
+import path from "node:path";
 import {
+  configListAsync,
   configListOrAsync,
   configProfile,
-  update as openspecUpdate,
-  writeOpenSpecConfigFile,
-  workflowSetSignature,
-  openSpecConfigFilePath,
   EXPANDED_WORKFLOWS,
+  openSpecConfigFilePath,
+  update as openspecUpdate,
+  workflowSetSignature,
+  writeOpenSpecConfigFile,
 } from "@blackbelt-technology/pi-dashboard-shared/platform/openspec.js";
-import type { NetworkGuard } from "./route-deps.js";
+import type { ApiResponse, OpenSpecConfig } from "@blackbelt-technology/pi-dashboard-shared/types.js";
+import type { FastifyInstance } from "fastify";
+import { type DirectoryService, hasOpenSpecRoot } from "../directory-service.js";
+import type { SessionManager } from "../memory-session-manager.js";
 import { scanOpenSpecArchive } from "../openspec-archive.js";
 import {
-  readTasks,
-  toggleTask,
-  NotFoundError,
   LineMismatchError,
   NotACheckboxError,
+  NotFoundError,
+  readTasks,
+  toggleTask,
 } from "../openspec-tasks.js";
-import path from "node:path";
-import fs from "node:fs/promises";
+import type { PreferencesStore } from "../preferences-store.js";
+import type { NetworkGuard } from "./route-deps.js";
 
 /** Callback to broadcast an openspec_update after a successful toggle. */
 export type OpenSpecBroadcaster = (cwd: string) => void;
@@ -66,7 +68,20 @@ export function registerOpenSpecRoutes(
       }
       // Async spawn so a cold read (openspec CLI ~1s) never blocks the event
       // loop / stalls concurrent requests. See change: fix-openspec-profile-load-race.
-      const raw = (await configListOrAsync({ cwd }, null)) as Partial<OpenSpecConfig> | null;
+      //
+      // Use the Result-returning variant (not `configListOrAsync`) so a CLI
+      // spawn/exit failure (e.g. exit 127 when the bundled Electron server's
+      // stripped PATH can't run the `#!/usr/bin/env node` shebang) surfaces as
+      // a distinct error state instead of silently degrading to an empty
+      // `{ profile:"custom", workflows:[] }` that the Settings panel renders as
+      // "not found." The client throws on this 502 and shows a retry state.
+      // See change: fix-openspec-config-read-bundled-node.
+      const result = await configListAsync({ cwd });
+      if (!result.ok) {
+        reply.code(502);
+        return { success: false, error: "openspec config read failed" } satisfies ApiResponse;
+      }
+      const raw = result.value as Partial<OpenSpecConfig> | null;
       // Defensive normalisation: missing fields fall back to safe defaults
       // so the client always receives a well-formed OpenSpecConfig shape.
       const data: OpenSpecConfig = {

--- a/packages/shared/src/platform/__tests__/runner-spawn-env.test.ts
+++ b/packages/shared/src/platform/__tests__/runner-spawn-env.test.ts
@@ -1,0 +1,59 @@
+/**
+ * `buildSpawnEnvForArgv` — Electron `execpath-fallback` safety net.
+ *
+ * When a Node-script executor node-wraps to `process.execPath` and the
+ * server runs under Electron, that interpreter is the Electron binary and
+ * only behaves as `node` with `ELECTRON_RUN_AS_NODE=1`. This is the one
+ * branch not covered by the argv-matrix / spawn-proof suites (which
+ * resolve a real node). See change: fix-openspec-config-read-bundled-node.
+ */
+import { describe, expect, it } from "vitest";
+import { buildSpawnEnvForArgv } from "../runner.js";
+
+const ELECTRON = "/Apps/Pi.app/Contents/MacOS/Pi";
+const REAL_NODE = "/opt/node/bin/node";
+
+describe("buildSpawnEnvForArgv", () => {
+  it("returns undefined (inherit process.env) when no ctxEnv and not electron-as-node", () => {
+    const env = buildSpawnEnvForArgv(REAL_NODE, undefined, {
+      execPath: ELECTRON,
+      electronVersion: "30.0.0",
+    });
+    expect(env).toBeUndefined();
+  });
+
+  it("sets ELECTRON_RUN_AS_NODE=1 when wrapped to the Electron execPath under Electron", () => {
+    const env = buildSpawnEnvForArgv(ELECTRON, undefined, {
+      execPath: ELECTRON,
+      electronVersion: "30.0.0",
+    });
+    expect(env?.ELECTRON_RUN_AS_NODE).toBe("1");
+  });
+
+  it("does NOT set the flag when a real node was resolved (execCmd !== execPath)", () => {
+    const env = buildSpawnEnvForArgv(REAL_NODE, { FOO: "bar" }, {
+      execPath: ELECTRON,
+      electronVersion: "30.0.0",
+    });
+    expect(env?.ELECTRON_RUN_AS_NODE).toBeUndefined();
+    expect(env?.FOO).toBe("bar");
+  });
+
+  it("does NOT set the flag when not running under Electron even if execCmd === execPath", () => {
+    const env = buildSpawnEnvForArgv(REAL_NODE, undefined, {
+      execPath: REAL_NODE,
+      electronVersion: undefined,
+    });
+    // Plain node server: no ctxEnv, not electron → inherit (undefined).
+    expect(env).toBeUndefined();
+  });
+
+  it("merges ctxEnv over process.env and still forces the flag under Electron", () => {
+    const env = buildSpawnEnvForArgv(ELECTRON, { CUSTOM: "x" }, {
+      execPath: ELECTRON,
+      electronVersion: "30.0.0",
+    });
+    expect(env?.CUSTOM).toBe("x");
+    expect(env?.ELECTRON_RUN_AS_NODE).toBe("1");
+  });
+});

--- a/packages/shared/src/platform/binary-lookup.ts
+++ b/packages/shared/src/platform/binary-lookup.ts
@@ -13,7 +13,6 @@ import { MANAGED_BIN, MANAGED_DIR } from "../managed-paths.js";
 import { ensureWindowsSystemPath } from "./ensure-windows-path.js";
 import { buildSafeArgv, execSync, spawnSync } from "./exec.js";
 import { augmentEnvWithGitSource } from "./git-source.js";
-import { getManagedNodeBinDir, isManagedNodePresent } from "./managed-node-path.js";
 
 // ── jiti loader resolution constants ──────────────────────────────────────
 
@@ -483,20 +482,6 @@ export class ToolResolver {
       : null;
     if (nodeBin && !currentPath.includes(nodeBin)) {
       parts.push(nodeBin);
-    }
-
-    // Managed Node runtime bin dir (`~/.pi-dashboard/node/bin` on unix,
-    // `~/.pi-dashboard/node` on Windows). Seeded so shebang-based child
-    // spawns (`#!/usr/bin/env node`) resolve a real `node` even when the
-    // dashboard server runs under Electron (its own execPath dir holds
-    // `Electron`, not `node`). Defense-in-depth alongside the explicit
-    // node-wrap in the tool registry.
-    // See change: fix-openspec-config-read-bundled-node.
-    if (isManagedNodePresent(base, opts.platform)) {
-      const managedNodeBin = getManagedNodeBinDir(base, opts.platform);
-      if (!currentPath.includes(managedNodeBin) && !parts.includes(managedNodeBin)) {
-        parts.push(managedNodeBin);
-      }
     }
 
     // Extra bin dirs

--- a/packages/shared/src/platform/binary-lookup.ts
+++ b/packages/shared/src/platform/binary-lookup.ts
@@ -3,15 +3,17 @@
  * Replaces scattered whichSync/resolvePiCommand/resolveTsxCommand implementations
  * with a single configurable resolver.
  */
-import { execSync, spawnSync, buildSafeArgv } from "./exec.js";
-import { ensureWindowsSystemPath } from "./ensure-windows-path.js";
-import { augmentEnvWithGitSource } from "./git-source.js";
+
 import { existsSync, realpathSync } from "node:fs";
 import { createRequire } from "node:module";
-import { pathToFileURL } from "node:url";
-import path from "node:path";
 import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { MANAGED_BIN, MANAGED_DIR } from "../managed-paths.js";
+import { ensureWindowsSystemPath } from "./ensure-windows-path.js";
+import { buildSafeArgv, execSync, spawnSync } from "./exec.js";
+import { augmentEnvWithGitSource } from "./git-source.js";
+import { getManagedNodeBinDir, isManagedNodePresent } from "./managed-node-path.js";
 
 // ── jiti loader resolution constants ──────────────────────────────────────
 
@@ -481,6 +483,20 @@ export class ToolResolver {
       : null;
     if (nodeBin && !currentPath.includes(nodeBin)) {
       parts.push(nodeBin);
+    }
+
+    // Managed Node runtime bin dir (`~/.pi-dashboard/node/bin` on unix,
+    // `~/.pi-dashboard/node` on Windows). Seeded so shebang-based child
+    // spawns (`#!/usr/bin/env node`) resolve a real `node` even when the
+    // dashboard server runs under Electron (its own execPath dir holds
+    // `Electron`, not `node`). Defense-in-depth alongside the explicit
+    // node-wrap in the tool registry.
+    // See change: fix-openspec-config-read-bundled-node.
+    if (isManagedNodePresent(base, opts.platform)) {
+      const managedNodeBin = getManagedNodeBinDir(base, opts.platform);
+      if (!currentPath.includes(managedNodeBin) && !parts.includes(managedNodeBin)) {
+        parts.push(managedNodeBin);
+      }
     }
 
     // Extra bin dirs

--- a/packages/shared/src/platform/runner.ts
+++ b/packages/shared/src/platform/runner.ts
@@ -117,10 +117,20 @@ function tryGetRegistry(): LazyRegistry | null {
  * `ELECTRON_RUN_AS_NODE=1`, so force that flag on the child's env. This is
  * the safety net for the `execpath-fallback` topology; when
  * `registry.resolve("node")` yields a real node it is never triggered.
+ *
+ * `deps` (execPath / electronVersion) are injected for deterministic
+ * testing; production callers omit them and read the live process.
+ * Exported for unit tests.
  */
-function buildSpawnEnvForArgv(execCmd: string, ctxEnv?: NodeJS.ProcessEnv): NodeJS.ProcessEnv | undefined {
-  const underElectron = Boolean((process as { versions?: { electron?: string } }).versions?.electron);
-  const electronAsNode = underElectron && execCmd === process.execPath;
+export function buildSpawnEnvForArgv(
+  execCmd: string,
+  ctxEnv?: NodeJS.ProcessEnv,
+  deps?: { execPath?: string; electronVersion?: string },
+): NodeJS.ProcessEnv | undefined {
+  const execPath = deps?.execPath ?? process.execPath;
+  const electronVersion =
+    deps?.electronVersion ?? (process as { versions?: { electron?: string } }).versions?.electron;
+  const electronAsNode = Boolean(electronVersion) && execCmd === execPath;
   if (!ctxEnv && !electronAsNode) return undefined;
   const merged: NodeJS.ProcessEnv = ctxEnv ? { ...process.env, ...ctxEnv } : { ...process.env };
   if (electronAsNode) merged.ELECTRON_RUN_AS_NODE = "1";

--- a/packages/shared/src/platform/runner.ts
+++ b/packages/shared/src/platform/runner.ts
@@ -13,10 +13,11 @@
  *
  * See change: platform-command-executor.
  */
-import path from "node:path";
+
 import { existsSync } from "node:fs";
-import { spawnSync, spawn, buildSafeArgv } from "./exec.js";
+import path from "node:path";
 import { ToolResolver } from "./binary-lookup.js";
+import { buildSafeArgv, spawn, spawnSync } from "./exec.js";
 // The tool registry publishes itself on a well-known `globalThis` symbol
 // when `getDefaultRegistry()` is first called from any consumer. The
 // runner reads that global to avoid a load-order cycle (tool-registry
@@ -101,6 +102,29 @@ const GLOBAL_REGISTRY_KEY = Symbol.for("pi-dashboard.tool-registry");
 function tryGetRegistry(): LazyRegistry | null {
   const reg = (globalThis as unknown as { [k: symbol]: LazyRegistry | undefined })[GLOBAL_REGISTRY_KEY];
   return reg ?? null;
+}
+
+/**
+ * Build the spawn env for a resolved executor argv.
+ *
+ * Default behavior is unchanged: when the caller supplied `ctx.env`, merge
+ * it over `process.env`; otherwise inherit `process.env` (return undefined).
+ *
+ * Electron edge (see change: fix-openspec-config-read-bundled-node): when a
+ * Node-script executor node-wraps to `process.execPath` and the server is
+ * itself running under Electron (`process.versions.electron`), that
+ * interpreter is the Electron binary. It only behaves as `node` with
+ * `ELECTRON_RUN_AS_NODE=1`, so force that flag on the child's env. This is
+ * the safety net for the `execpath-fallback` topology; when
+ * `registry.resolve("node")` yields a real node it is never triggered.
+ */
+function buildSpawnEnvForArgv(execCmd: string, ctxEnv?: NodeJS.ProcessEnv): NodeJS.ProcessEnv | undefined {
+  const underElectron = Boolean((process as { versions?: { electron?: string } }).versions?.electron);
+  const electronAsNode = underElectron && execCmd === process.execPath;
+  if (!ctxEnv && !electronAsNode) return undefined;
+  const merged: NodeJS.ProcessEnv = ctxEnv ? { ...process.env, ...ctxEnv } : { ...process.env };
+  if (electronAsNode) merged.ELECTRON_RUN_AS_NODE = "1";
+  return merged;
 }
 
 /**
@@ -220,7 +244,7 @@ export function run<Input, Output>(
   try {
     const result = spawnSync(safeArgv[0], safeArgv.slice(1), {
       cwd: ctx.cwd,
-      env: ctx.env ? { ...process.env, ...ctx.env } : undefined,
+      env: buildSpawnEnvForArgv(execCmd, ctx.env),
       encoding: "utf-8",
       timeout,
       stdio: ["pipe", "pipe", "pipe"],
@@ -315,7 +339,7 @@ export function runAsync<Input, Output>(
     try {
       child = spawn(safeArgv[0], safeArgv.slice(1), {
         cwd: ctx.cwd,
-        env: ctx.env ? { ...process.env, ...ctx.env } : undefined,
+        env: buildSpawnEnvForArgv(execCmd, ctx.env),
         stdio: ["ignore", "pipe", "pipe"],
         ...spawnOptions, // shell: false, windowsHide: true
       });

--- a/packages/shared/src/tool-registry/__tests__/node-script-argv-matrix.test.ts
+++ b/packages/shared/src/tool-registry/__tests__/node-script-argv-matrix.test.ts
@@ -1,0 +1,157 @@
+/**
+ * `nodeScriptToArgv` argv matrix + stripped-PATH spawn proof.
+ *
+ * Covers the generalized node-wrap (unix parity with Windows):
+ *   - `.js` resolved path → `[<node>, script.js]` on unix AND win32.
+ *   - unix `.bin` shebang SYMLINK → dereferenced to its `.js` target,
+ *     then node-wrapped.
+ *   - non-`.js`, non-symlink path → passthrough `[path]`.
+ *
+ * The spawn proof executes the resolved argv with an EMPTY PATH to
+ * simulate the bundled-Electron GUI launch: the raw `#!/usr/bin/env node`
+ * shebang would exit 127 (`env: node: No such file`), but the
+ * node-wrapped argv runs cleanly.
+ *
+ * See change: fix-openspec-config-read-bundled-node.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { OverridesStore, registerDefaultTools, ToolRegistry } from "../index.js";
+
+function freshRegistry(opts: {
+  platform: NodeJS.Platform;
+  exists?: (p: string) => boolean;
+  resolveModule?: (id: string, from: string) => string | null;
+  overrides?: Record<string, string>;
+}) {
+  const store = new OverridesStore({
+    filePath: path.join(os.tmpdir(), `argv-matrix-${Math.random()}.json`),
+    warn: () => {},
+  });
+  for (const [k, v] of Object.entries(opts.overrides ?? {})) store.set(k, v);
+  const r = new ToolRegistry({ overrides: store, platform: opts.platform });
+  registerDefaultTools(r, {
+    exists: opts.exists ?? (() => false),
+    which: () => null,
+    npmRootGlobal: () => "",
+    resolveModule: opts.resolveModule,
+  });
+  return r;
+}
+
+describe("nodeScriptToArgv — argv matrix", () => {
+  it("unix: node-wraps a resolved .js entry", () => {
+    const node = "/opt/node/bin/node";
+    const js = "/app/node_modules/@fission-ai/openspec/bin/openspec.js";
+    const r = freshRegistry({
+      platform: "linux",
+      exists: (p) => p === node || p === js,
+      resolveModule: (id) =>
+        id === "@fission-ai/openspec/package.json"
+          ? "/app/node_modules/@fission-ai/openspec/package.json"
+          : null,
+      overrides: { node },
+    });
+    expect(r.resolveExecutor("openspec").argv).toEqual([node, js]);
+  });
+
+  it("win32: node-wraps a resolved .js entry (unchanged behavior)", () => {
+    // Host-neutral paths (POSIX join runs on the Linux CI host); the point is
+    // the win32 branch still prepends node to a `.js` entry.
+    const node = "/nodejs/node.exe";
+    const pkgDir = "/app/node_modules/@fission-ai/openspec";
+    const r = freshRegistry({
+      platform: "win32",
+      exists: (p) => p === node || p.endsWith("openspec.js"),
+      resolveModule: (id) =>
+        id === "@fission-ai/openspec/package.json" ? `${pkgDir}/package.json` : null,
+      overrides: { node },
+    });
+    const argv = r.resolveExecutor("openspec").argv;
+    expect(argv[0]).toBe(node);
+    expect(argv[1]).toBe(path.join(pkgDir, "bin", "openspec.js"));
+  });
+
+  it("unix: dereferences a .bin shebang symlink to its .js target, then wraps", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openspec-deref-"));
+    dirs.push(tmp);
+    const pkgBin = path.join(tmp, "pkg", "bin");
+    fs.mkdirSync(pkgBin, { recursive: true });
+    const jsTarget = path.join(pkgBin, "openspec.js");
+    fs.writeFileSync(jsTarget, "#!/usr/bin/env node\nconsole.log('ok');\n");
+    const dotBin = path.join(tmp, ".bin");
+    fs.mkdirSync(dotBin, { recursive: true });
+    const symlink = path.join(dotBin, "openspec");
+    fs.symlinkSync(jsTarget, symlink);
+
+    const node = "/opt/node/bin/node";
+    // openspec resolves to the .bin symlink via the `override` strategy;
+    // real fs is used so realpathSync can dereference it.
+    const r = freshRegistry({
+      platform: "linux",
+      exists: (p) => p === node || fs.existsSync(p),
+      // No module resolution → bare-import fails → override wins.
+      overrides: { node, openspec: symlink },
+    });
+    const argv = r.resolveExecutor("openspec").argv;
+    expect(argv).toEqual([node, fs.realpathSync(jsTarget)]);
+  });
+
+  it("passthrough: non-.js, non-symlink resolved path is returned bare", () => {
+    const bareBin = path.join(os.tmpdir(), `openspec-bare-${Math.random()}`);
+    fs.writeFileSync(bareBin, "#!/usr/bin/env node\n");
+    files.push(bareBin);
+    const r = freshRegistry({
+      platform: "linux",
+      exists: (p) => fs.existsSync(p),
+      overrides: { openspec: bareBin },
+    });
+    // No node resolved and the path is not .js → passthrough.
+    expect(r.resolveExecutor("openspec").argv).toEqual([bareBin]);
+  });
+});
+
+describe("nodeScriptToArgv — stripped-PATH spawn proof", () => {
+  it("runs the node-wrapped openspec argv with an empty PATH (no exit 127)", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openspec-spawn-"));
+    dirs.push(tmp);
+    const pkgBin = path.join(tmp, "pkg", "bin");
+    fs.mkdirSync(pkgBin, { recursive: true });
+    const jsTarget = path.join(pkgBin, "openspec.js");
+    fs.writeFileSync(
+      jsTarget,
+      "#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify({ profile: 'core', workflows: [] }));\n",
+    );
+    const dotBin = path.join(tmp, ".bin");
+    fs.mkdirSync(dotBin, { recursive: true });
+    const symlink = path.join(dotBin, "openspec");
+    fs.symlinkSync(jsTarget, symlink);
+
+    // Real node (this test runner's own interpreter) via the node override.
+    const r = freshRegistry({
+      platform: process.platform,
+      exists: (p) => p === process.execPath || fs.existsSync(p),
+      overrides: { node: process.execPath, openspec: symlink },
+    });
+    const argv = r.resolveExecutor("openspec").argv;
+    expect(argv[0]).toBe(process.execPath);
+
+    // Stripped PATH: a raw shebang spawn of `symlink` here would exit 127.
+    const res = spawnSync(argv[0], [...argv.slice(1), "config", "list", "--json"], {
+      env: { PATH: "", HOME: os.tmpdir() },
+      encoding: "utf-8",
+    });
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout)).toEqual({ profile: "core", workflows: [] });
+  });
+});
+
+const dirs: string[] = [];
+const files: string[] = [];
+afterAll(() => {
+  for (const d of dirs) try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  for (const f of files) try { fs.rmSync(f, { force: true }); } catch { /* ignore */ }
+});

--- a/packages/shared/src/tool-registry/__tests__/openspec-unix-node-wrap.test.ts
+++ b/packages/shared/src/tool-registry/__tests__/openspec-unix-node-wrap.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unix Node-script executor node-wrap (openspec / pi).
+ *
+ * Root cause of the bundled-Electron "OpenSpec profile not found" bug:
+ * on unix the managed `openspec` bin is a `#!/usr/bin/env node` shebang
+ * script that only runs when a binary literally named `node` is on the
+ * spawning process's PATH. A GUI-launched Electron server has a stripped
+ * PATH, so the spawn dies with exit 127 / `env: node: No such file`.
+ *
+ * The fix generalizes `nodeScriptToArgv` to supply the interpreter
+ * explicitly on unix (parity with the existing Windows node-wrap):
+ * resolving `openspec` MUST yield `[<node>, .../bin/openspec.js]`, NOT
+ * the bare shebang path.
+ *
+ * See change: fix-openspec-config-read-bundled-node.
+ */
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { OverridesStore, registerDefaultTools, ToolRegistry } from "../index.js";
+
+function freshRegistry(opts: {
+  platform: NodeJS.Platform;
+  exists?: (p: string) => boolean;
+  resolveModule?: (id: string, from: string) => string | null;
+  overrides?: Record<string, string>;
+}) {
+  const store = new OverridesStore({
+    filePath: path.join(os.tmpdir(), `openspec-unix-wrap-${Math.random()}.json`),
+    warn: () => {},
+  });
+  for (const [k, v] of Object.entries(opts.overrides ?? {})) store.set(k, v);
+
+  const r = new ToolRegistry({ overrides: store, platform: opts.platform });
+  registerDefaultTools(r, {
+    exists: opts.exists ?? (() => false),
+    which: () => null,
+    npmRootGlobal: () => "",
+    resolveModule: opts.resolveModule,
+  });
+  return r;
+}
+
+describe("nodeScriptToArgv — unix openspec node-wrap", () => {
+  it("resolves openspec to [node, bin/openspec.js], not the shebang path", () => {
+    const node = "/opt/node/bin/node";
+    const pkgJson = "/app/node_modules/@fission-ai/openspec/package.json";
+    const openspecJs = path.join("/app/node_modules/@fission-ai/openspec", "bin", "openspec.js");
+
+    const r = freshRegistry({
+      platform: "linux",
+      exists: (p) => p === node || p === openspecJs,
+      resolveModule: (id) =>
+        id === "@fission-ai/openspec/package.json" ? pkgJson : null,
+      overrides: { node },
+    });
+
+    const exec = r.resolveExecutor("openspec");
+    expect(exec.ok).toBe(true);
+    expect(exec.argv).toEqual([node, openspecJs]);
+  });
+});

--- a/packages/shared/src/tool-registry/definitions.ts
+++ b/packages/shared/src/tool-registry/definitions.ts
@@ -8,14 +8,12 @@
  *
  * See change: consolidate-tool-resolution.
  */
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ToolDefinition, Source, InstallHints } from "./types.js";
 import type { ToolRegistry } from "./registry.js";
 import {
-  type StrategyDeps,
   bareImportStrategy,
   bundledGitBashStrategy,
   bundledNodeStrategy,
@@ -24,9 +22,10 @@ import {
   managedRuntimeStrategy,
   npmGlobalStrategy,
   overrideStrategy,
+  type StrategyDeps,
   whereStrategy,
 } from "./strategies.js";
-import type { Strategy } from "./types.js";
+import type { InstallHints, Source, Strategy, ToolDefinition } from "./types.js";
 
 // ── Classifier ──────────────────────────────────────────────────────────────
 
@@ -375,35 +374,61 @@ function packageDirModuleDef(
 // See change: consolidate-tool-resolution (follow-up).
 
 /**
+ * Resolve a Node-script executor's resolved path to a `.js` entry point
+ * suitable for node-wrapping, or null when it is not a Node script.
+ *
+ * - Already a `.js` path → return it verbatim (Windows `.js` entry, or a
+ *   unix `bare-import`/`managedModule` hit like `bin/openspec.js`).
+ * - Unix only: the `managedBin` strategy resolves `.bin/openspec` — a
+ *   `#!/usr/bin/env node` shebang SYMLINK whose real target is the
+ *   package's `bin/openspec.js`. Dereference it so we can node-wrap the
+ *   real `.js` and stop depending on the shebang finding `node` on PATH.
+ *   Windows managed-bin resolves a `.cmd` shim (not a symlink), so the
+ *   deref is skipped there — preserving the Windows branch byte-for-byte.
+ */
+function resolveJsScript(resolvedPath: string, platform: NodeJS.Platform): string | null {
+  if (/\.js$/i.test(resolvedPath)) return resolvedPath;
+  if (platform !== "win32") {
+    try {
+      const real = realpathSync(resolvedPath);
+      if (/\.js$/i.test(real)) return real;
+    } catch {
+      // Not a symlink / missing on disk — fall through to shebang path.
+    }
+  }
+  return null;
+}
+
+/**
  * Shared `toArgv` for Node-script executors (pi, openspec, npm).
  *
- * On Windows + `.js` resolved path → prepend node.exe to bypass the
- * `.cmd` shim entirely (no cmd.exe in the spawn chain → no console
- * flash). Elsewhere → direct invocation.
+ * When the resolved path is (or dereferences to) a `.js` entry, prepend a
+ * real `node` interpreter so the spawn becomes `[<node>, <script>.js]`.
+ * This runs on unix AND Windows:
  *
- * This is the heart of the "no cmd flash" story: every CLI that ships
- * as `.cmd` on Windows and is actually a Node script should be
- * registered with this `toArgv` so the spawn becomes
- * `node.exe <script.js>` (pure console-subsystem inherit, no new
- * window ever).
+ * - Windows: bypasses the `.cmd` shim entirely (no cmd.exe → no console
+ *   flash). See change: fix-windows-standalone-spawn.
+ * - Unix: removes the dependency on the `#!/usr/bin/env node` shebang
+ *   finding a binary named `node` on the child's PATH — the exact gap
+ *   that breaks a GUI-launched (Electron) server with a stripped PATH
+ *   (exit 127 / `env: node: No such file`). See change:
+ *   fix-openspec-config-read-bundled-node.
  *
- * Node resolution order on Windows (see change:
- * fix-windows-standalone-spawn):
- *   1. `registry.resolve("node")` when it returns ok with a non-null
- *      path (the strategy chain has already validated existence via
- *      its injected `exists` dep).
- *   2. `process.execPath` — the dashboard server's own Node — as a
- *      guaranteed-working fallback. Live repro: Windows 11 standalone
- *      install where the registry chain failed to find node and the
- *      spawn argv became `[cli.js]` → `spawn EFTYPE`. Falling back to
- *      execPath keeps the spawn argv well-formed because the dashboard
- *      server is itself running on a compatible Node.
+ * Node resolution order:
+ *   1. `registry.resolve("node")` when it returns ok with a non-null path
+ *      (the strategy chain has already validated existence via its
+ *      injected `exists` dep) — the deterministic, PATH-independent path.
+ *   2. `process.execPath` — the dashboard server's own interpreter — as a
+ *      guaranteed-well-formed fallback. Under Electron this is the
+ *      Electron binary; the runner sets `ELECTRON_RUN_AS_NODE=1` on that
+ *      child spawn so it still executes as node.
  */
 const nodeScriptToArgv: ToolDefinition["toArgv"] = (resolvedPath, { platform, registry }) => {
-  if (platform === "win32" && /\.js$/i.test(resolvedPath)) {
+  const scriptPath = resolveJsScript(resolvedPath, platform);
+  if (scriptPath) {
     const node = registry.resolve("node");
-    if (node.ok && node.path) return [node.path, resolvedPath];
-    return [process.execPath, resolvedPath];
+    if (node.ok && node.path) return [node.path, scriptPath];
+    return [process.execPath, scriptPath];
   }
   return [resolvedPath];
 };


### PR DESCRIPTION
Capture root cause + design for OpenSpec global-settings failing in the bundled Electron app on macOS/Windows. The managed openspec CLI is a '#!/usr/bin/env node' shebang script; the bundled server's child-spawn PATH can lack a real 'node', and nodeScriptToArgv only node-wraps on Windows, so the unix spawn dies (exit 127). configListOrAsync swallows the failure to null, so GET /api/openspec/config returns an empty profile and Settings renders 'not found'.

Artifacts: proposal, design, specs (tool-registry + openspec-profile-config deltas), tasks. Planning only, no code changes.