### PR TITLE
feat(flows-edit-mode-folder-settings): per-cwd edit-mode on folder settings via generic slot

### DIFF
--- a/openspec/changes/flows-edit-mode-folder-settings/.openspec.yaml
+++ b/openspec/changes/flows-edit-mode-folder-settings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/flows-edit-mode-folder-settings/design.md
+++ b/openspec/changes/flows-edit-mode-folder-settings/design.md
@@ -1,0 +1,77 @@
+## Context
+
+pi-flows stores edit-mode (`flows.editFlow`) as a two-tier setting resolved at session start (`edit-flow-config.ts`, verified):
+
+```
+isEditFlowEnabled(cwd) = projectFlag(<cwd>/.pi/settings.json)
+                      ?? globalFlag(~/.pi/agent/settings.json)
+                      ?? false          // project overrides global
+setEditFlowFlag(cwd)   → always writes <cwd>/.pi/settings.json (never global)
+```
+
+The dashboard bolted a **third** store on top: `~/.pi/dashboard/config.json#plugins.flows.editFlow` (a single global bool), reconciled into every session by a per-session `useEffect` in `SessionFlowActionsClaim`. That reconcile short-circuits on `flows.length === 0` (never activates in a fresh cwd) and stamps the same global value into every open project's file (destroys manual per-project values).
+
+Since the earlier draft of this change, #232 (`folder-resource-activation-toggle`) landed and changed the terrain:
+- The DirectorySettings surface (`/folder/:cwd/settings`) is now the established home for folder-scoped "installed but active?" controls.
+- `POST /api/resources/reload { scope: "local"|"global", cwd? }` exists, tested, and reloads affected sessions via the universal `/reload` interceptor (`handleSendPrompt` — headless→respawn, TUI→prompt), which works on all session types and in Electron.
+- The route pattern for scope-aware settings writes exists (`resource-activation-routes.ts`).
+
+The folder card/sidebar is simultaneously being **compacted** (`focus-driven-folder-compaction`, `accordion-workspace-folders`), so new per-folder controls must not land on the card.
+
+Constraint: the flows-plugin is **decoupled** — it contributes UI only through slots.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Per-cwd edit-mode control on the folder settings page (no folder-card / session-card clutter), working at zero flows and with zero open sessions.
+- Global default keeps a UI (retargeted to pi's real global layer), and the dashboard keeps **no private copy**.
+- Toggling applies live via the landed folder-scoped reload endpoint.
+- A **generic** `folder-settings-section` slot, so any plugin gains a per-cwd settings surface (not a flows-only hack).
+
+**Non-Goals:**
+- Changing pi-flows (resolution + `session_start` reconcile already correct).
+- A session-card edit-mode switch (deprecated; superseded by this design).
+- Toggling pi *resources* (that is #232's domain; `flows.editFlow` is a custom settings key, not a resource array entry).
+- Selecting a default/attached flow per cwd (separate feature).
+
+## Decisions
+
+### Decision 1: Socket = new generic `folder-settings-section` slot on DirectorySettings
+Add the slot (react-only, multiplicity many, props `{ cwd }`) and host it in `DirectorySettings`. flows-plugin claims it with the edit-mode toggle.
+- **Alternative — session-card flows subcard switch (the earlier draft):** rejected — clutters a surface being compacted, requires a live session, and ties a cwd-scoped setting to a session-scoped control.
+- **Alternative — `sidebar-folder-section`:** rejected — that is the folder card itself; same clutter objection.
+- **Why a shell change is now acceptable:** the earlier draft rejected DirectorySettings because "a decoupled plugin cannot contribute there without a shell change". The shell change is now a one-slot generic capability with multiple prospective consumers (kb, memory, automation), matching how `settings-section` already works for the global page.
+
+### Decision 2: Write path = server-side scope-aware JSON merge (not the session event)
+A new server route (pattern: `resource-activation-routes.ts`) exposes GET `{ project, global, effective }` and PUT `{ scope: "project"|"global", enabled }`. The write is a format-preserving JSON merge of `flows.editFlow` into `<cwd>/.pi/settings.json` or `~/.pi/agent/settings.json`.
+- **Why not `flow_management { set-edit-mode }` (the earlier draft's path)?** It requires a connected session for that cwd; the folder settings page must work session-less (bootstrap case). One write path is simpler than two; pi-flows re-reads the file at `session_start` regardless of who wrote it.
+- `flows.editFlow` is a custom key, so pi's `SettingsManager` typed setters (resource arrays) don't apply; the merge is ~10 lines and test-covered.
+
+### Decision 3: Reload = landed `POST /api/resources/reload { scope: "local", cwd }`
+After a project-scope write, the client calls the existing endpoint; it reloads every connected session whose cwd matches (no-op when none). Global-scope writes offer the `{ scope: "global" }` variant. This inherits the universal reload primitive's cross-platform behavior (headless RPC, tmux, Windows Terminal, Electron) — no new reload mechanism, and the endpoint already idle-routes via the session-action interceptor.
+- Supersedes the earlier draft's client-side `send_prompt { text: "/reload" }` + idle-gating tasks: the server endpoint wraps the same primitive.
+
+### Decision 4: Effective-value read-back replaces the private config everywhere
+- The folder toggle displays `effective` with a "from global" hint when `project` is unset.
+- `SessionFlowActionsClaim`'s `editMode` gating (New/Edit action visibility) switches from `usePluginConfig` to the effective read-back for the session's cwd.
+- `FlowsSettings` keeps its global toggle UI but reads/writes the `global` scope via the same route.
+- `configSchema.json` drops `editFlow`; the reconcile `useEffect` is deleted. No dashboard-private copy remains.
+
+## Risks / Trade-offs
+
+- **Format preservation on settings.json merge** → read-modify-write preserving unknown keys; tests cover file-absent, key-absent, and foreign-keys-present cases.
+- **Trust gating** → pi-flows honors the project file only for trusted projects; in an untrusted project the write persists but `isEditFlowEnabled` may ignore it. The toggle shows effective state from file contents, which may overstate effect in untrusted cwds — document; do not block the write.
+- **Reload interrupts work** → the landed endpoint routes through the session-action interceptor; behavior matches package-install reloads users already know. Document that toggling reloads affected sessions.
+- **Stale dashboard config values** → old `plugins.flows.editFlow` becomes inert; no migration write; rollback = revert, old key resumes being read.
+- **Slot scope creep** → `folder-settings-section` is react-only/many with a `{ cwd }` prop only; no descriptor tier until a second consumer needs it.
+
+## Migration Plan
+
+1. Ship slot + route + flows-plugin claim + config/reconcile removal in one change.
+2. No data migration: existing `plugins.flows.editFlow` ignored going forward; users re-set global via the retargeted FlowsSettings (writes `~/.pi/agent/settings.json`).
+3. Rollback: revert the change.
+
+## Open Questions
+
+- Should the global-scope write also offer the global reload (`{ scope: "global" }` reloads all sessions), or leave global changes to apply at next session start? (Lean: offer it, default off.)
+- Does `DirectorySettings` need a section-ordering convention once multiple plugins claim the slot (priority field like other slots)? (Lean: reuse the existing claim `priority`.)

--- a/openspec/changes/flows-edit-mode-folder-settings/proposal.md
+++ b/openspec/changes/flows-edit-mode-folder-settings/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The dashboard's flows edit-mode is driven by a single **global** knob (`plugins.flows.editFlow` in `~/.pi/dashboard/config.json`) that a per-session `useEffect` reconciles down into every session. This fights pi-flows' own design, which already resolves `flows.editFlow` two-tier (`<cwd>/.pi/settings.json` project value overrides `~/.pi/agent/settings.json` global). The result is broken in practice:
+
+- The reconcile short-circuits on `flows.length === 0`, so edit-mode never activates in a fresh cwd — the exact state where you need it to author your first flow.
+- One global value stamps the same setting into every open project's `.pi/settings.json`, destroying hand-set per-project values and making pi-flows' native per-cwd layer unusable.
+- The event write (`flow:set-edit-mode`) cannot reload the session, so skill/tool visibility silently defers to "next session".
+
+An earlier draft (`fix-flows-edit-mode-per-cwd-reload`, superseded by this change) put a per-cwd switch on the session-card flows subcard. That is now deprecated: the folder card/sidebar is being compacted (`focus-driven-folder-compaction`), and per-cwd controls have since gained a proper home — change #232 (`folder-resource-activation-toggle`) established the DirectorySettings surface (`/folder/:cwd/settings`) as the place for folder-scoped enable/disable controls, including a landed scope-aware reload endpoint (`POST /api/resources/reload { scope, cwd }`). What is missing is a way for a **decoupled plugin** to contribute a section there.
+
+## What Changes
+
+- **Add a generic `folder-settings-section` slot** (react-only, multiplicity many, props `{ cwd }`), hosted by `DirectorySettings` — the folder-scoped twin of the existing global `settings-section` slot. Any plugin can contribute per-cwd settings without touching the folder card.
+- **flows-plugin claims the slot** with a one-row "Flow authoring (edit mode)" toggle. It displays the **effective** value (`project ?? global`) with a source hint when inherited from global, writes the **project** value on toggle, and triggers the landed folder-scoped reload (`POST /api/resources/reload { scope: "local", cwd }`) so tools + edit-flow skill apply live. Works with zero flows and with zero open sessions.
+- **Server: edit-mode read/write endpoint** following the #232 route pattern: GET returns `{ project, global, effective }` read from pi-flows' own two files; PUT writes the requested scope (`project` → `<cwd>/.pi/settings.json`, `global` → `~/.pi/agent/settings.json`) with a format-preserving JSON merge.
+- **Global setting stays, retargeted:** `FlowsSettings` (global settings section) keeps its toggle but now writes pi's real global layer (`~/.pi/agent/settings.json#flows.editFlow`) via the same endpoint, instead of the dashboard-private `plugins.flows.editFlow` config.
+- **Remove the private config + destructive reconcile:** delete `editFlow` from `configSchema.json` and the `flows.length`-guarded reconcile `useEffect` in `SessionFlowActionsClaim`. The subcard's `editMode` gating switches from `usePluginConfig` to the effective read-back. pi-flows' `project ?? global` resolution at `session_start` replaces the reconcile.
+
+## Capabilities
+
+### New Capabilities
+- `folder-settings-sections`: a generic react-only slot rendering plugin-contributed sections on the DirectorySettings surface, scoped to the folder's cwd.
+
+### Modified Capabilities
+- `flows-edit-mode-settings`: remove the dashboard-private global config default and the auto-reconcile-on-availability requirement; redefine edit-mode as a folder-settings toggle (project scope) plus a retargeted global toggle (pi global scope), with effective-value read-back and folder-scoped live reload.
+
+## Impact
+
+- **Code (this repo):**
+  - `packages/shared/src/dashboard-plugin/slot-types.ts` — add `folder-settings-section` (react-only, many; non-breaking minor).
+  - `packages/client/src/components/DirectorySettings/DirectorySettings.tsx` — host the slot.
+  - `packages/server/src/routes/` — new flows edit-mode read/write route (pattern: `resource-activation-routes.ts`); reuses landed `POST /api/resources/reload`.
+  - `packages/flows-plugin/` — slot claim + toggle component; `FlowsSettings` retargeted to global scope; `configSchema.json` drops `editFlow`; `SessionFlowActions.tsx` drops the reconcile `useEffect` and reads effective edit-mode.
+  - `packages/client/src/generated/plugin-registry.tsx` — regenerate.
+- **No changes** to pi-flows (its `edit-flow-config.ts` resolution and `session_start` reconcile are already correct) or to the bridge (`flow_management set-edit-mode` remains available but is no longer the dashboard's write path).
+- **Behavioral:** existing `~/.pi/dashboard/config.json#plugins.flows.editFlow` values become inert (safe to ignore). Per-cwd control lives on the folder settings page; global default lives in pi's own settings file.
+- **Consumers:** other plugins (kb, memory, automation) gain a folder-scoped settings surface for free via the new slot.

--- a/openspec/changes/flows-edit-mode-folder-settings/specs/flows-edit-mode-settings/spec.md
+++ b/openspec/changes/flows-edit-mode-folder-settings/specs/flows-edit-mode-settings/spec.md
@@ -1,0 +1,63 @@
+## REMOVED Requirements
+
+### Requirement: Global edit-mode default in plugin config
+
+**Reason:** The dashboard kept a private global copy of edit-mode in `~/.pi/dashboard/config.json#plugins.flows.editFlow` and reconciled it into sessions. This fought pi-flows' own two-tier resolution (`~/.pi/agent/settings.json` global + `<cwd>/.pi/settings.json` project, project wins), producing a redundant third source of truth.
+
+**Migration:** Set edit-mode per cwd on the folder settings page (writes `<cwd>/.pi/settings.json`), or globally via the retargeted FlowsSettings toggle (writes `~/.pi/agent/settings.json`, which pi-flows already honors). Existing `plugins.flows.editFlow` values become inert and can be ignored or removed.
+
+### Requirement: Edit-mode default reconciled to a session on flows availability
+
+**Reason:** The reconcile `useEffect` short-circuited on `flows.length === 0`, so edit-mode never activated in a fresh cwd (the state where authoring the first flow requires it), and the single global value stamped the same setting into every open project — destroying manual per-project values. pi-flows already resolves the effective value at `session_start`, making a dashboard-driven reconcile both unnecessary and harmful.
+
+**Migration:** None required. pi-flows resolves `projectFlag ?? globalFlag` at each `session_start`; the folder settings toggle writes the project value directly.
+
+### Requirement: Optional per-session override toggle
+
+**Reason:** Superseded. Edit-mode is a cwd-scoped setting; its control belongs on the folder settings surface (established by change #232 for folder-scoped activation controls), not on a session card. The session-card flows subcard remains display/action-only, consistent with the ongoing folder/sidebar compaction work.
+
+**Migration:** Use the folder settings page toggle for the cwd; all sessions in that cwd follow it after reload.
+
+## ADDED Requirements
+
+### Requirement: Per-cwd edit-mode toggle on the folder settings page
+
+The flows-plugin SHALL contribute an edit-mode toggle to the folder settings surface via the `folder-settings-section` slot. The toggle SHALL display the **effective** value (`project ?? global ?? false`) read from pi-flows' own settings files, with a visible hint when the value is inherited from the global layer. Toggling SHALL write `flows.editFlow` to that folder's `<cwd>/.pi/settings.json` via a scope-aware server route that preserves unrelated keys in the file. The toggle SHALL function when the cwd has zero flows and when no session is connected for that cwd. The dashboard SHALL NOT maintain any separate edit-mode copy in its own config.
+
+#### Scenario: Toggle persists per cwd without a session
+- **WHEN** the user enables edit-mode on the folder settings page for a cwd with no connected session
+- **THEN** the server SHALL write `flows.editFlow: true` to `<cwd>/.pi/settings.json`, preserving unrelated keys
+- **AND** the next session started in that cwd SHALL see the flow authoring tools and edit-flow skill
+
+#### Scenario: Effective value read-back
+- **WHEN** the project file has no `flows.editFlow` but the global file has `flows.editFlow: true`
+- **THEN** the toggle SHALL render enabled with a hint that the value is inherited from global
+
+#### Scenario: No dashboard-private config write
+- **WHEN** the edit-mode toggle is used at either scope
+- **THEN** no `~/.pi/dashboard/config.json` plugin-config value SHALL be written or read for edit-mode
+
+### Requirement: Edit-mode toggle reloads affected sessions live
+
+After a project-scope edit-mode write, the dashboard SHALL invoke the folder-scoped reload endpoint (`POST /api/resources/reload { scope: "local", cwd }`) so connected sessions in that cwd re-read the persisted value at `session_start` and the flow authoring tools + edit-flow skill visibility apply live. The reload SHALL reuse the existing universal reload primitive (no new mechanism) and SHALL be a no-op when no session is connected for the cwd.
+
+#### Scenario: Toggle reloads connected sessions in the cwd
+- **WHEN** the user toggles edit-mode for a cwd with a connected idle session
+- **THEN** the dashboard SHALL call the folder-scoped reload endpoint after the write
+- **AND** after reload the session's flow authoring tools and edit-flow skill SHALL reflect the new value without a manual `/reload`
+
+#### Scenario: No connected session
+- **WHEN** the user toggles edit-mode for a cwd with no connected sessions
+- **THEN** the write SHALL succeed and the reload call SHALL affect zero sessions without error
+
+### Requirement: Global edit-mode default targets pi's global settings layer
+
+The FlowsSettings global settings section SHALL read and write the global edit-mode default in pi's own `~/.pi/agent/settings.json` (`flows.editFlow`) via the scope-aware route, instead of a dashboard plugin-config value. Project values SHALL continue to override the global per pi-flows' resolution.
+
+#### Scenario: Global default honored where no project value exists
+- **WHEN** the user enables the global default and a cwd has no project-level `flows.editFlow`
+- **THEN** sessions in that cwd SHALL resolve edit-mode enabled at `session_start`
+
+#### Scenario: Project value wins over global
+- **WHEN** the global default is enabled and a cwd's project file sets `flows.editFlow: false`
+- **THEN** sessions in that cwd SHALL resolve edit-mode disabled

--- a/openspec/changes/flows-edit-mode-folder-settings/specs/folder-settings-sections/spec.md
+++ b/openspec/changes/flows-edit-mode-folder-settings/specs/folder-settings-sections/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Plugin sections on the DirectorySettings surface
+
+The dashboard SHALL provide a `folder-settings-section` plugin slot (react-only, multiplicity many) hosted by the DirectorySettings surface (`/folder/:cwd/settings`). Each claimed section SHALL receive the folder's `cwd` as a prop and SHALL render within the folder settings page, ordered by claim priority. The slot SHALL NOT render anything on the workspace folder card or session cards.
+
+#### Scenario: Claimed section renders with cwd
+- **WHEN** a plugin claims `folder-settings-section` and the user opens `/folder/:cwd/settings`
+- **THEN** the claimed component SHALL render on the page and receive that folder's `cwd` as a prop
+
+#### Scenario: No claims, no artifacts
+- **WHEN** no plugin claims `folder-settings-section`
+- **THEN** the DirectorySettings surface SHALL render exactly as before the slot existed
+
+#### Scenario: Multiple claims order by priority
+- **WHEN** two plugins claim `folder-settings-section` with different priorities
+- **THEN** the sections SHALL render in priority order

--- a/openspec/changes/flows-edit-mode-folder-settings/tasks.md
+++ b/openspec/changes/flows-edit-mode-folder-settings/tasks.md
@@ -1,0 +1,29 @@
+# Tasks
+
+## 1. Generic folder-settings-section slot
+
+- [x] 1.1 Add `folder-settings-section` to `packages/shared/src/dashboard-plugin/slot-types.ts` (react-only, `multiplicity: "many"`, description: plugin-contributed section on the DirectorySettings surface, props `{ cwd }`). Update manifest-validator if slot-specific validation is needed.
+- [x] 1.2 Host the slot in `packages/client/src/components/DirectorySettings/DirectorySettings.tsx`: render claimed sections (ordered by claim `priority`) with the folder's cwd.
+- [x] 1.3 Tests: a fixture claim renders on the folder settings page with the correct `cwd` prop; zero claims renders nothing extra; two claims order by priority.
+
+## 2. Server: edit-mode read/write route (TDD — write tests first)
+
+- [x] 2.1 Tests first (pattern: `resource-activation-routes.test.ts`): GET returns `{ project, global, effective }` for (a) both files absent, (b) global only, (c) project overriding global; PUT `{ scope: "project", enabled }` merges `flows.editFlow` into `<cwd>/.pi/settings.json` preserving foreign keys; PUT `{ scope: "global" }` targets `~/.pi/agent/settings.json`; malformed scope → 400. Use a temp homedir — never touch the real one.
+- [x] 2.2 Implement the route (format-preserving JSON read-merge-write; effective = `project ?? global ?? false`). NOTE: implemented in `packages/flows-plugin/src/server/edit-mode-routes.ts` (plugins mount REST routes via `ctx.fastify`, automation-plugin precedent) — keeps the flows-specific route out of core.
+- [x] 2.3 Wire route registration in the flows-plugin server entry (`mountEditModeRoutes(ctx.fastify)` before listen).
+
+## 3. flows-plugin: claim + toggle + config removal
+
+- [x] 3.1 Claim `folder-settings-section` in the flows-plugin manifest with a "Flow authoring (edit mode)" component; regenerate `packages/client/src/generated/plugin-registry.tsx`.
+- [x] 3.2 Toggle component: GET on mount → render effective value with a "from global" hint when `project` is unset; on toggle PUT `{ scope: "project" }` then `POST /api/resources/reload { scope: "local", cwd }`.
+- [x] 3.3 Retarget `FlowsSettings` (global settings section) to GET/PUT the `global` scope via the same route; remove its `usePluginConfig`/`plugin_config_write` wiring.
+- [x] 3.4 Delete `editFlow` from `packages/flows-plugin/src/configSchema.json` (leave the schema otherwise intact).
+- [x] 3.5 In `SessionFlowActions.tsx`: delete the reconcile `useEffect` (the `flows.length === 0` guard block); source `editMode` for the New/Edit gating from the effective read-back for the session's cwd instead of `usePluginConfig`.
+- [x] 3.6 Tests: toggle renders at zero flows and with zero sessions for the cwd; toggling PUTs project scope then calls the local reload; "from global" hint shown when project unset; no `plugin_config_write` for edit-mode is emitted anywhere; subcard New/Edit gating follows the effective value.
+
+## 4. Verify + land
+
+- [x] 4.1 `npm test 2>&1 | tee /tmp/pi-test.log`; confirm no failures — 9266 passed, 0 failed.
+- [x] 4.2 Quality gate: biome clean on the change's files + `tsc --noEmit` exit 0. (NOTE: `quality:changed` unusable in this worktree — its `--changed` base is the stale local `develop`; scoped `biome check <files>` used instead.)
+- [ ] 4.3 `npm run build` + `curl -X POST http://localhost:8000/api/restart`; manual: in an empty cwd with no session, enable edit-mode on the folder settings page → `<cwd>/.pi/settings.json` has `flows.editFlow: true`; open a session → `flow_agents`/`flow_write` + edit-flow skill available; with a live session, toggling reloads it and tools appear without manual `/reload`.
+- [x] 4.4 Advisory CodeRabbit gate run — CLI unavailable (ENOENT), deferred per warn-and-continue contract; PR-time CodeRabbit review covers it in the ship loop.

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -376,7 +376,7 @@ export default function App() {
   const specsCwd = specsMatch && specsParams ? decodeFolderPath(specsParams.encodedCwd) : null;
   const piResourcesCwd = piResourcesMatch && piResourcesParams ? decodeFolderPath(piResourcesParams.encodedCwd) : null;
   const folderSettingsCwd = folderSettingsMatch && folderSettingsParams ? decodeFolderPath(folderSettingsParams.encodedCwd) : null;
-  const VALID_FOLDER_SETTINGS_PAGES = ["instructions", "packages", "resources"] as const;
+  const VALID_FOLDER_SETTINGS_PAGES = ["instructions", "packages", "resources", "plugins"] as const;
   const folderSettingsPageRaw = folderSettingsMatch ? folderSettingsParams?.page : undefined;
   const folderSettingsPage: DirectorySettingsPage =
     folderSettingsPageRaw && (VALID_FOLDER_SETTINGS_PAGES as readonly string[]).includes(folderSettingsPageRaw)

--- a/packages/client/src/components/DirectorySettings/DirectorySettings.tsx
+++ b/packages/client/src/components/DirectorySettings/DirectorySettings.tsx
@@ -13,7 +13,11 @@
  * See change: directory-settings-page-and-scoped-md-editing.
  */
 
-import { mdiArrowLeft, mdiFileDocumentOutline, mdiPackageVariant, mdiViewListOutline } from "@mdi/js";
+import {
+  FolderSettingsSectionSlot,
+  useFolderSettingsSectionHasClaims,
+} from "@blackbelt-technology/dashboard-plugin-runtime";
+import { mdiArrowLeft, mdiFileDocumentOutline, mdiPackageVariant, mdiPuzzleOutline, mdiViewListOutline } from "@mdi/js";
 import { Icon } from "@mdi/react";
 import { useLocation } from "wouter";
 import { t as i18nT } from "../../lib/i18n";
@@ -22,7 +26,7 @@ import { InstructionsPage } from "./InstructionsPage.js";
 import { PackagesPage } from "./PackagesPage.js";
 import { ResourcesPage } from "./ResourcesPage.js";
 
-export type DirectorySettingsPage = "instructions" | "packages" | "resources";
+export type DirectorySettingsPage = "instructions" | "packages" | "resources" | "plugins";
 
 interface Props {
   cwd: string;
@@ -33,11 +37,17 @@ interface Props {
 
 export function DirectorySettings({ cwd, page, onBack, onViewFile }: Props) {
   const [, navigate] = useLocation();
+  const hasPluginSections = useFolderSettingsSectionHasClaims();
 
   const navItems: { id: DirectorySettingsPage; label: string; icon: string }[] = [
     { id: "instructions", label: i18nT("auto.instructions", undefined, "Instructions"), icon: mdiFileDocumentOutline },
     { id: "packages", label: i18nT("auto.packages", undefined, "Packages"), icon: mdiPackageVariant },
     { id: "resources", label: i18nT("auto.resources", undefined, "Resources"), icon: mdiViewListOutline },
+    // Plugin-contributed per-folder settings (folder-settings-section slot);
+    // the nav item exists only when at least one plugin claims the slot.
+    ...(hasPluginSections
+      ? [{ id: "plugins" as const, label: i18nT("auto.plugins", undefined, "Plugins"), icon: mdiPuzzleOutline }]
+      : []),
   ];
 
   return (
@@ -80,6 +90,7 @@ export function DirectorySettings({ cwd, page, onBack, onViewFile }: Props) {
               <button
                 type="button"
                 key={item.id}
+                data-testid={`directory-settings-nav-${item.id}`}
                 onClick={() => navigate(buildFolderSettingsUrl(cwd, item.id))}
                 aria-current={active ? "page" : undefined}
                 className={`flex items-center gap-2.5 px-3 py-2 rounded-md text-sm whitespace-nowrap transition-colors cursor-pointer ${
@@ -100,6 +111,11 @@ export function DirectorySettings({ cwd, page, onBack, onViewFile }: Props) {
           {page === "instructions" && <InstructionsPage cwd={cwd} />}
           {page === "packages" && <PackagesPage cwd={cwd} />}
           {page === "resources" && <ResourcesPage cwd={cwd} onViewFile={onViewFile} />}
+          {page === "plugins" && (
+            <div className="p-4 flex flex-col gap-4">
+              <FolderSettingsSectionSlot cwd={cwd} />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/packages/client/src/components/DirectorySettings/__tests__/DirectorySettings.test.tsx
+++ b/packages/client/src/components/DirectorySettings/__tests__/DirectorySettings.test.tsx
@@ -1,0 +1,87 @@
+import { createSlotRegistry, PluginContextProvider } from "@blackbelt-technology/dashboard-plugin-runtime";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock the heavy page components — this suite targets the hosting shell
+// (nav + folder-settings-section slot), not the pages themselves.
+vi.mock("../InstructionsPage.js", () => ({
+  InstructionsPage: () => <div data-testid="page-instructions" />,
+}));
+vi.mock("../PackagesPage.js", () => ({
+  PackagesPage: () => <div data-testid="page-packages" />,
+}));
+vi.mock("../ResourcesPage.js", () => ({
+  ResourcesPage: () => <div data-testid="page-resources" />,
+}));
+
+import { DirectorySettings } from "../DirectorySettings.js";
+
+afterEach(() => cleanup());
+
+const noop = () => {};
+
+function renderWithRegistry(
+  registry: ReturnType<typeof createSlotRegistry>,
+  page: Parameters<typeof DirectorySettings>[0]["page"],
+) {
+  return render(
+    <PluginContextProvider registry={registry}>
+      <DirectorySettings cwd="/repo/project" page={page} onBack={noop} onViewFile={noop} />
+    </PluginContextProvider>,
+  );
+}
+
+describe("DirectorySettings folder-settings-section hosting", () => {
+  it("renders a claimed section with the folder's cwd on the plugins page", () => {
+    const registry = createSlotRegistry();
+    registry.addClaim({
+      pluginId: "flows",
+      priority: 100,
+      slot: "folder-settings-section",
+      Component: ({ cwd }: { cwd?: string }) => <div data-testid="flows-section">{cwd}</div>,
+    });
+    renderWithRegistry(registry, "plugins");
+    expect(screen.getByTestId("flows-section").textContent).toBe("/repo/project");
+  });
+
+  it("shows the Plugins nav item only when a claim exists", () => {
+    const registry = createSlotRegistry();
+    registry.addClaim({
+      pluginId: "flows",
+      priority: 100,
+      slot: "folder-settings-section",
+      Component: () => <div />,
+    });
+    renderWithRegistry(registry, "instructions");
+    expect(screen.getByTestId("directory-settings-nav-plugins")).toBeTruthy();
+  });
+
+  it("renders exactly as before when no claims exist (no Plugins nav item)", () => {
+    renderWithRegistry(createSlotRegistry(), "instructions");
+    expect(screen.queryByTestId("directory-settings-nav-plugins")).toBeNull();
+    expect(screen.getByTestId("page-instructions")).toBeTruthy();
+  });
+
+  it("orders multiple claims by registry priority (ascending, matching compareClaims)", () => {
+    const registry = createSlotRegistry();
+    registry.addClaim({
+      pluginId: "second",
+      priority: 200,
+      slot: "folder-settings-section",
+      Component: () => <div data-testid="claim-second" />,
+    });
+    registry.addClaim({
+      pluginId: "first",
+      priority: 10,
+      slot: "folder-settings-section",
+      Component: () => <div data-testid="claim-first" />,
+    });
+    renderWithRegistry(registry, "plugins");
+    const content = screen.getByTestId("directory-settings-content");
+    const nodes = content.querySelectorAll('[data-testid^="claim-"]');
+    expect(Array.from(nodes).map((n) => n.getAttribute("data-testid"))).toEqual([
+      "claim-first",
+      "claim-second",
+    ]);
+  });
+});

--- a/packages/dashboard-plugin-runtime/src/slot-consumers.tsx
+++ b/packages/dashboard-plugin-runtime/src/slot-consumers.tsx
@@ -102,6 +102,37 @@ export function SidebarFolderSectionSlot({ folder }: { folder: FolderDescriptor 
 }
 
 /**
+ * `folder-settings-section` — plugin-contributed section on the
+ * DirectorySettings surface (`/folder/:cwd/settings`). Claims receive the
+ * folder's `cwd` as a prop; ordering follows registry priority. Renders
+ * nothing when no plugin claims the slot.
+ * See change: flows-edit-mode-folder-settings.
+ */
+export function FolderSettingsSectionSlot({ cwd }: { cwd: string }) {
+  const registry = useSlotRegistryOrNull();
+  if (!registry) return null;
+  const claims = registry.getClaims("folder-settings-section");
+  if (!claims.length) return null;
+  return (
+    <>
+      {claims.map(c =>
+        renderClaim(c as Parameters<typeof renderClaim>[0], "folder-settings-section", { cwd }),
+      )}
+    </>
+  );
+}
+
+/**
+ * True when at least one plugin claims `folder-settings-section`. Lets the
+ * DirectorySettings shell show/hide its Plugins nav item without rendering
+ * the slot. See change: flows-edit-mode-folder-settings.
+ */
+export function useFolderSettingsSectionHasClaims(): boolean {
+  const registry = useSlotRegistryOrNull();
+  return !!registry && registry.getClaims("folder-settings-section").length > 0;
+}
+
+/**
  * `worktree-card-section` — folder-scoped block rendered INSIDE a worktree
  * session card, scoped to the worktree's own `cwd` (not the parent repo it
  * collapses under). The KB plugin claims this slot with `FolderKbSection` so a

--- a/packages/flows-plugin/package.json
+++ b/packages/flows-plugin/package.json
@@ -66,6 +66,10 @@
         "slot": "settings-section",
         "component": "FlowsSettings",
         "tab": "general"
+      },
+      {
+        "slot": "folder-settings-section",
+        "component": "FlowsFolderSettings"
       }
     ]
   },

--- a/packages/flows-plugin/src/__tests__/edit-mode-routes.test.ts
+++ b/packages/flows-plugin/src/__tests__/edit-mode-routes.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the flows edit-mode REST routes (GET/PUT /api/plugins/flows/edit-mode).
+ *
+ * Real fs against temp dirs — the write path is a format-preserving JSON
+ * merge into pi-flows' own settings files, so foreign-key preservation and
+ * file-absent bootstrap are the contract under test.
+ *
+ * HOME is ephemeral under `npm test` (test-isolation guard); the "global"
+ * scope tests write inside os.homedir() which resolves into that tmp HOME.
+ *
+ * See change: flows-edit-mode-folder-settings.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mountEditModeRoutes } from "../server/edit-mode-routes.js";
+
+const GLOBAL_SETTINGS = () => path.join(os.homedir(), ".pi", "agent", "settings.json");
+
+function readJson(p: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+describe("flows edit-mode routes", () => {
+  let app: FastifyInstance;
+  let cwd: string;
+
+  beforeEach(async () => {
+    app = Fastify();
+    mountEditModeRoutes(app);
+    await app.ready();
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), "flows-em-"));
+    // start from a clean global file per test
+    fs.rmSync(GLOBAL_SETTINGS(), { force: true });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  // ── GET ────────────────────────────────────────────────────────────────
+
+  it("GET: both files absent → nulls, effective false", async () => {
+    const res = await app.inject({ method: "GET", url: `/api/plugins/flows/edit-mode?cwd=${encodeURIComponent(cwd)}` });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data).toEqual({ project: null, global: null, effective: false });
+  });
+
+  it("GET: global only → effective follows global", async () => {
+    fs.mkdirSync(path.dirname(GLOBAL_SETTINGS()), { recursive: true });
+    fs.writeFileSync(GLOBAL_SETTINGS(), JSON.stringify({ flows: { editFlow: true } }));
+    const res = await app.inject({ method: "GET", url: `/api/plugins/flows/edit-mode?cwd=${encodeURIComponent(cwd)}` });
+    expect(res.json().data).toEqual({ project: null, global: true, effective: true });
+  });
+
+  it("GET: project overrides global", async () => {
+    fs.mkdirSync(path.dirname(GLOBAL_SETTINGS()), { recursive: true });
+    fs.writeFileSync(GLOBAL_SETTINGS(), JSON.stringify({ flows: { editFlow: true } }));
+    fs.mkdirSync(path.join(cwd, ".pi"), { recursive: true });
+    fs.writeFileSync(path.join(cwd, ".pi", "settings.json"), JSON.stringify({ flows: { editFlow: false } }));
+    const res = await app.inject({ method: "GET", url: `/api/plugins/flows/edit-mode?cwd=${encodeURIComponent(cwd)}` });
+    expect(res.json().data).toEqual({ project: false, global: true, effective: false });
+  });
+
+  it("GET without cwd: global-only read (project stays null)", async () => {
+    fs.mkdirSync(path.dirname(GLOBAL_SETTINGS()), { recursive: true });
+    fs.writeFileSync(GLOBAL_SETTINGS(), JSON.stringify({ flows: { editFlow: true } }));
+    const res = await app.inject({ method: "GET", url: "/api/plugins/flows/edit-mode" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data).toEqual({ project: null, global: true, effective: true });
+  });
+
+  // ── PUT ────────────────────────────────────────────────────────────────
+
+  it("PUT project scope: creates .pi/settings.json when absent", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/plugins/flows/edit-mode",
+      payload: { cwd, scope: "project", enabled: true },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(readJson(path.join(cwd, ".pi", "settings.json"))).toEqual({ flows: { editFlow: true } });
+    expect(res.json().data).toEqual({ project: true, global: null, effective: true });
+  });
+
+  it("PUT project scope: preserves foreign keys in an existing file", async () => {
+    fs.mkdirSync(path.join(cwd, ".pi"), { recursive: true });
+    fs.writeFileSync(
+      path.join(cwd, ".pi", "settings.json"),
+      JSON.stringify({ theme: "dark", flows: { editFlow: true, other: 1 } }),
+    );
+    await app.inject({
+      method: "PUT",
+      url: "/api/plugins/flows/edit-mode",
+      payload: { cwd, scope: "project", enabled: false },
+    });
+    expect(readJson(path.join(cwd, ".pi", "settings.json"))).toEqual({
+      theme: "dark",
+      flows: { editFlow: false, other: 1 },
+    });
+  });
+
+  it("PUT global scope: targets ~/.pi/agent/settings.json", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/plugins/flows/edit-mode",
+      payload: { scope: "global", enabled: true },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(readJson(GLOBAL_SETTINGS())).toEqual({ flows: { editFlow: true } });
+  });
+
+  it("PUT: malformed scope → 400", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/plugins/flows/edit-mode",
+      payload: { cwd, scope: "session", enabled: true },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("PUT project scope without cwd → 400", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/plugins/flows/edit-mode",
+      payload: { scope: "project", enabled: true },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/packages/flows-plugin/src/__tests__/flows-folder-settings.test.tsx
+++ b/packages/flows-plugin/src/__tests__/flows-folder-settings.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * FlowsFolderSettings (folder-settings-section claim) — the per-cwd edit-mode
+ * toggle. Fetch is mocked; the contract under test:
+ *   - renders the EFFECTIVE value with an inherited-from-global hint
+ *   - toggling PUTs the project scope, then POSTs the folder-scoped reload
+ *   - no dashboard plugin-config write is involved anywhere
+ * See change: flows-edit-mode-folder-settings.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FlowsFolderSettings } from "../client/FlowsFolderSettings.js";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+type FetchCall = { url: string; method: string; body?: Record<string, unknown> };
+
+function mockFetch(state: { project: boolean | null; global: boolean | null; effective: boolean }) {
+  const calls: FetchCall[] = [];
+  const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+    const u = String(url);
+    const method = init?.method ?? "GET";
+    const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : undefined;
+    calls.push({ url: u, method, body });
+    if (u.startsWith("/api/plugins/flows/edit-mode")) {
+      if (method === "PUT" && body) {
+        state = { project: body.enabled as boolean, global: state.global, effective: body.enabled as boolean };
+      }
+      return { json: async () => ({ success: true, data: state }) };
+    }
+    if (u.startsWith("/api/resources/reload")) {
+      return { json: async () => ({ success: true, data: { reloaded: 1 } }) };
+    }
+    return { json: async () => ({ success: false }) };
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return calls;
+}
+
+describe("FlowsFolderSettings", () => {
+  it("renders the effective value with the inherited hint when project is unset", async () => {
+    mockFetch({ project: null, global: true, effective: true });
+    render(<FlowsFolderSettings cwd="/repo/app" />);
+    await waitFor(() => {
+      const box = screen.getByTestId("flows-folder-edit-mode-toggle") as HTMLInputElement;
+      expect(box.checked).toBe(true);
+    });
+    expect(screen.getByTestId("flows-edit-mode-inherited")).toBeTruthy();
+  });
+
+  it("hides the inherited hint when the project value is explicit", async () => {
+    mockFetch({ project: false, global: true, effective: false });
+    render(<FlowsFolderSettings cwd="/repo/app" />);
+    await waitFor(() => {
+      const box = screen.getByTestId("flows-folder-edit-mode-toggle") as HTMLInputElement;
+      expect(box.disabled).toBe(false);
+    });
+    expect(screen.queryByTestId("flows-edit-mode-inherited")).toBeNull();
+  });
+
+  it("toggling PUTs the project scope then POSTs the folder-scoped reload", async () => {
+    const calls = mockFetch({ project: null, global: null, effective: false });
+    render(<FlowsFolderSettings cwd="/repo/app" />);
+    await waitFor(() => {
+      expect((screen.getByTestId("flows-folder-edit-mode-toggle") as HTMLInputElement).disabled).toBe(false);
+    });
+
+    fireEvent.click(screen.getByTestId("flows-folder-edit-mode-toggle"));
+    await waitFor(() => {
+      expect(calls.some((c) => c.method === "POST" && c.url === "/api/resources/reload")).toBe(true);
+    });
+
+    const put = calls.find((c) => c.method === "PUT");
+    expect(put?.url).toBe("/api/plugins/flows/edit-mode");
+    expect(put?.body).toEqual({ cwd: "/repo/app", scope: "project", enabled: true });
+
+    const reload = calls.find((c) => c.method === "POST" && c.url === "/api/resources/reload");
+    expect(reload?.body).toEqual({ scope: "local", cwd: "/repo/app" });
+
+    // Ordering: write precedes reload so the reload re-reads the persisted value.
+    expect(calls.findIndex((c) => c.method === "PUT")).toBeLessThan(
+      calls.findIndex((c) => c.method === "POST" && c.url === "/api/resources/reload"),
+    );
+
+    // Toggle reflects the written value (from the PUT response read-back).
+    expect((screen.getByTestId("flows-folder-edit-mode-toggle") as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("never writes dashboard plugin config", async () => {
+    const calls = mockFetch({ project: null, global: null, effective: false });
+    render(<FlowsFolderSettings cwd="/repo/app" />);
+    await waitFor(() => {
+      expect((screen.getByTestId("flows-folder-edit-mode-toggle") as HTMLInputElement).disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId("flows-folder-edit-mode-toggle"));
+    await waitFor(() => {
+      expect(calls.some((c) => c.method === "POST")).toBe(true);
+    });
+    // All traffic goes to the edit-mode route + reload endpoint — nothing else.
+    expect(
+      calls.every((c) => c.url.startsWith("/api/plugins/flows/edit-mode") || c.url.startsWith("/api/resources/reload")),
+    ).toBe(true);
+  });
+});

--- a/packages/flows-plugin/src/client/FlowsFolderSettings.tsx
+++ b/packages/flows-plugin/src/client/FlowsFolderSettings.tsx
@@ -1,0 +1,72 @@
+/**
+ * Folder-settings section for the flows plugin (`folder-settings-section`
+ * claim): the per-cwd edit-mode toggle.
+ *
+ * Shows the EFFECTIVE value (`project ?? global ?? false`) with an inherited-
+ * from-global hint when the project file has no value. Toggling writes the
+ * PROJECT scope via the flows edit-mode route, then reloads the cwd's
+ * connected sessions through the existing folder-scoped reload endpoint so
+ * the authoring tools + edit-flow skill apply live. Works with zero flows
+ * and zero sessions (author-first-flow bootstrap).
+ *
+ * See change: flows-edit-mode-folder-settings.
+ */
+import type React from "react";
+import { useState } from "react";
+import { useEditMode } from "./useEditMode.js";
+
+export function FlowsFolderSettings({ cwd }: { cwd?: string }): React.ReactElement | null {
+  const { state, setEditMode } = useEditMode(cwd);
+  const [busy, setBusy] = useState(false);
+  if (!cwd) return null;
+
+  const inherited = state !== null && state.project === null;
+
+  async function onToggle(enabled: boolean) {
+    setBusy(true);
+    try {
+      await setEditMode("project", enabled);
+      // Live-apply: reload connected sessions in this cwd (no-op when none).
+      await fetch("/api/resources/reload", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scope: "local", cwd }),
+      }).catch(() => {});
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section
+      className="border border-[var(--border-primary)] rounded-lg p-4"
+      data-testid="flows-folder-settings"
+    >
+      <h3 className="text-sm font-semibold mb-0.5">Flows</h3>
+      <p className="text-xs text-[var(--text-tertiary)] mb-3">
+        Flow authoring for this directory. Stored in <code>.pi/settings.json</code>.
+      </p>
+      <label className="flex gap-2.5 items-start text-[13px] cursor-pointer">
+        <input
+          type="checkbox"
+          checked={state?.effective ?? false}
+          disabled={state === null || busy}
+          onChange={(e) => void onToggle(e.target.checked)}
+          className="mt-0.5"
+          data-testid="flows-folder-edit-mode-toggle"
+        />
+        <span>
+          <span className="font-medium">Edit mode</span>
+          {" — allow sessions in this directory to author flows & agents"}
+          <span className="block text-[11px] text-[var(--text-muted)] mt-0.5">
+            Activates <code>flow_agents</code> / <code>flow_write</code> and the edit-flow
+            skill. Toggling reloads this directory's connected sessions.
+            {inherited && (
+              <span data-testid="flows-edit-mode-inherited"> Currently inherited from the global default.</span>
+            )}
+          </span>
+        </span>
+      </label>
+    </section>
+  );
+}

--- a/packages/flows-plugin/src/client/FlowsSettings.tsx
+++ b/packages/flows-plugin/src/client/FlowsSettings.tsx
@@ -1,29 +1,35 @@
 /**
- * Settings-section for the flows plugin: a global edit-mode default.
+ * Settings-section for the flows plugin: the GLOBAL edit-mode default.
  *
- * Edit-mode on → the main session sees the `edit-flow` skill and the
- * `flow_agents` / `flow_write` authoring tools. The global default here is
- * reconciled down to each session (via `flow:set-edit-mode`) when that
- * session's flows plugin becomes available — see SessionFlowActionsClaim.
+ * Reads/writes pi's own global layer (`~/.pi/agent/settings.json`
+ * `flows.editFlow`) via the flows edit-mode route — the dashboard keeps no
+ * private plugin-config copy. Per-cwd overrides live on each folder's
+ * settings page (`FlowsFolderSettings`); pi-flows resolves
+ * `project ?? global` at session_start.
  *
- * Uses the unified buffered-draft save contract (commits via the host Settings
- * panel's Save). See change: rework-flows-plugin-for-new-pi-flows.
+ * Uses the unified buffered-draft save contract (commits via the host
+ * Settings panel's Save). See change: flows-edit-mode-folder-settings.
  */
-import React, { useCallback, useRef, useState } from "react";
-import { usePluginConfig, usePluginSend } from "@blackbelt-technology/dashboard-plugin-runtime/context";
-import { useSettingsDraftSource } from "@blackbelt-technology/dashboard-plugin-runtime";
 
-export interface FlowsPluginConfig {
-  /** Global default for pi-flows `flows.editFlow`. Default off. */
-  editFlow?: boolean;
-}
+import { useSettingsDraftSource } from "@blackbelt-technology/dashboard-plugin-runtime";
+import type React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useEditMode } from "./useEditMode.js";
 
 export function FlowsSettings(): React.ReactElement {
-  const config = usePluginConfig<FlowsPluginConfig>();
-  const send = usePluginSend();
+  const { state, setEditMode } = useEditMode();
 
-  const [editFlow, setEditFlow] = useState<boolean>(config.editFlow ?? false);
-  const base = config.editFlow ?? false;
+  const base = state?.global ?? false;
+  const [editFlow, setEditFlow] = useState<boolean>(base);
+  // Adopt the server value once it arrives (state starts null).
+  const loadedRef = useRef(false);
+  useEffect(() => {
+    if (state !== null && !loadedRef.current) {
+      loadedRef.current = true;
+      setEditFlow(state.global ?? false);
+    }
+  }, [state]);
+
   const isDirty = editFlow !== base;
 
   const valuesRef = useRef(editFlow);
@@ -32,8 +38,8 @@ export function FlowsSettings(): React.ReactElement {
   baseRef.current = base;
 
   const commit = useCallback(async () => {
-    await send({ type: "plugin_config_write", id: "flows", config: { editFlow: valuesRef.current } });
-  }, [send]);
+    await setEditMode("global", valuesRef.current);
+  }, [setEditMode]);
   const reset = useCallback(() => setEditFlow(baseRef.current), []);
   useSettingsDraftSource({ id: "plugin:flows", page: "plugins", isDirty, commit, reset });
 
@@ -41,7 +47,8 @@ export function FlowsSettings(): React.ReactElement {
     <section className="border border-[var(--border-primary)] rounded-lg p-4">
       <h3 className="text-sm font-semibold mb-0.5">Flows</h3>
       <p className="text-xs text-[var(--text-tertiary)] mb-3">
-        Multi-agent workflow orchestration. Applies globally; sessions inherit this default.
+        Multi-agent workflow orchestration. Global default (stored in pi's own
+        settings); per-directory overrides live on each folder's settings page.
       </p>
       <label className="flex gap-2.5 items-start text-[13px] cursor-pointer">
         <input
@@ -56,7 +63,8 @@ export function FlowsSettings(): React.ReactElement {
           {" — allow the main session to author flows & agents"}
           <span className="block text-[11px] text-[var(--text-muted)] mt-0.5">
             Activates <code>flow_agents</code> / <code>flow_write</code> and makes the
-            edit-flow skill model-visible. Off by default.
+            edit-flow skill model-visible. Off by default. Applies at each
+            session's next start unless a directory overrides it.
           </span>
         </span>
       </label>

--- a/packages/flows-plugin/src/client/SessionFlowActions.tsx
+++ b/packages/flows-plugin/src/client/SessionFlowActions.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import { Icon } from "@mdi/react";
 import { mdiPlay, mdiPencil } from "@mdi/js";
 import type {
@@ -18,8 +18,7 @@ import {
   usePluginSend,
   useSessionData,
 } from "@blackbelt-technology/dashboard-plugin-runtime";
-import { usePluginConfig } from "@blackbelt-technology/dashboard-plugin-runtime/context";
-import type { FlowsPluginConfig } from "./FlowsSettings.js";
+import { useEditMode } from "./useEditMode.js";
 
 export function SessionFlowActions({
   flows,
@@ -229,22 +228,13 @@ export function SessionFlowActionsClaim({ session }: { session: DashboardSession
   const commands = useSessionData<CommandInfo[]>(session.id, "commandsList") ?? [];
   const { flowState } = useFlowsSessionState(session.id);
   const send = usePluginSend();
-  const config = usePluginConfig<FlowsPluginConfig>();
-  const editMode = config.editFlow ?? false;
+  // Effective edit-mode for this session's cwd (project ?? global), read from
+  // pi-flows' own settings files. The old global-config reconcile is gone —
+  // per-cwd control lives on the folder settings page (FlowsFolderSettings).
+  // See change: flows-edit-mode-folder-settings.
+  const editMode = useEditMode(session.cwd).state?.effective ?? false;
 
   const hasFlowsDelete = commands.some((c) => c.name === "flows:delete");
-
-  // Reconcile the GLOBAL edit-mode default down to this session once its flows
-  // plugin is available (flowsList observed). pi-flows persists it to the
-  // project .pi/settings.json. Idempotent — re-emits only when the default
-  // changes. See change: rework-flows-plugin-for-new-pi-flows (D4).
-  const reconciledRef = useRef<boolean | null>(null);
-  useEffect(() => {
-    if (flows.length === 0) return; // wait until flows-plugin is available
-    if (reconciledRef.current === editMode) return;
-    reconciledRef.current = editMode;
-    send({ type: "flow_management", sessionId: session.id, action: "set-edit-mode", enabled: editMode });
-  }, [flows.length, editMode, session.id, send]);
 
   // Render when there's a flow active OR action buttons are available.
   if (flows.length === 0 && !editMode && !flowState) return null;

--- a/packages/flows-plugin/src/client/index.tsx
+++ b/packages/flows-plugin/src/client/index.tsx
@@ -36,9 +36,13 @@ export { FlowDashboardClaim } from "./FlowDashboard.js";
 export { FlowWriteToolRenderer } from "./FlowWriteToolRenderer.js";
 export { FlowAgentsToolRenderer } from "./FlowAgentsToolRenderer.js";
 
-// Settings section (global edit-mode default) — manifest `settings-section` claim.
+// Settings section (global edit-mode default, stored in pi's own global
+// settings) — manifest `settings-section` claim.
 export { FlowsSettings } from "./FlowsSettings.js";
-export type { FlowsPluginConfig } from "./FlowsSettings.js";
+
+// Per-folder edit-mode toggle — manifest `folder-settings-section` claim.
+// See change: flows-edit-mode-folder-settings.
+export { FlowsFolderSettings } from "./FlowsFolderSettings.js";
 
 export { FlowSummaryClaim } from "./FlowSummary.js";
 export { FlowYamlPreviewClaim } from "./FlowYamlPreview.js";

--- a/packages/flows-plugin/src/client/useEditMode.ts
+++ b/packages/flows-plugin/src/client/useEditMode.ts
@@ -1,0 +1,50 @@
+/**
+ * Client hook for the flows edit-mode setting.
+ *
+ * Reads `{ project, global, effective }` from the flows-plugin server route
+ * (pi-flows' own settings files — the dashboard keeps no private copy) and
+ * exposes a scope-aware setter. See change: flows-edit-mode-folder-settings.
+ */
+import { useCallback, useEffect, useState } from "react";
+
+export interface EditModeState {
+  project: boolean | null;
+  global: boolean | null;
+  effective: boolean;
+}
+
+export function useEditMode(cwd?: string): {
+  state: EditModeState | null;
+  setEditMode: (scope: "project" | "global", enabled: boolean) => Promise<void>;
+} {
+  const [state, setState] = useState<EditModeState | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const qs = cwd ? `?cwd=${encodeURIComponent(cwd)}` : "";
+    fetch(`/api/plugins/flows/edit-mode${qs}`)
+      .then((r) => r.json())
+      .then((j) => {
+        if (!cancelled && j?.success) setState(j.data as EditModeState);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [cwd]);
+
+  const setEditMode = useCallback(
+    async (scope: "project" | "global", enabled: boolean) => {
+      const res = await fetch("/api/plugins/flows/edit-mode", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cwd, scope, enabled }),
+      });
+      const j = await res.json();
+      if (j?.success) setState(j.data as EditModeState);
+    },
+    [cwd],
+  );
+
+  return { state, setEditMode };
+}

--- a/packages/flows-plugin/src/configSchema.json
+++ b/packages/flows-plugin/src/configSchema.json
@@ -1,14 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Flows plugin configuration",
-  "description": "Per-plugin (global) configuration for the flows-plugin. The edit-mode default is reconciled down to each session (via flow:set-edit-mode) when that session's flows plugin becomes available. See change: rework-flows-plugin-for-new-pi-flows.",
+  "description": "Per-plugin (global) configuration for the flows-plugin. Edit-mode is NOT stored here: it lives in pi's own settings files (global ~/.pi/agent/settings.json, per-project <cwd>/.pi/settings.json) managed via the flows edit-mode route. See change: flows-edit-mode-folder-settings.",
   "type": "object",
   "additionalProperties": false,
-  "properties": {
-    "editFlow": {
-      "type": "boolean",
-      "default": false,
-      "description": "Global default for pi-flows `flows.editFlow`. When on, the main session sees the edit-flow skill and the flow_agents / flow_write authoring tools."
-    }
-  }
+  "properties": {}
 }

--- a/packages/flows-plugin/src/server/edit-mode-routes.ts
+++ b/packages/flows-plugin/src/server/edit-mode-routes.ts
@@ -1,0 +1,102 @@
+/**
+ * REST routes for the flows edit-mode setting (`flows.editFlow`).
+ *
+ *   GET /api/plugins/flows/edit-mode?cwd=<abs>
+ *     → { project: boolean|null, global: boolean|null, effective: boolean }
+ *   PUT /api/plugins/flows/edit-mode { cwd?, scope: "project"|"global", enabled }
+ *     → same shape, post-write
+ *
+ * Reads/writes pi-flows' OWN settings files (project `<cwd>/.pi/settings.json`,
+ * global `~/.pi/agent/settings.json`) with a format-preserving JSON merge —
+ * the dashboard keeps no private copy. pi-flows resolves
+ * `project ?? global ?? false` at session_start; `effective` mirrors that.
+ *
+ * Session-less by design: the folder settings toggle must work in a cwd with
+ * zero connected sessions (author-first-flow bootstrap). Live application is
+ * the client's job via the existing `POST /api/resources/reload`.
+ *
+ * See change: flows-edit-mode-folder-settings.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { FastifyInstance } from "fastify";
+
+interface EditModeState {
+  project: boolean | null;
+  global: boolean | null;
+  effective: boolean;
+}
+
+function settingsPath(scope: "project" | "global", cwd?: string): string {
+  return scope === "project"
+    ? path.join(cwd ?? process.cwd(), ".pi", "settings.json")
+    : path.join(os.homedir(), ".pi", "agent", "settings.json");
+}
+
+/** Read `flows.editFlow` from a settings file; non-boolean/absent/unreadable → null. */
+function readEditFlow(file: string): boolean | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as {
+      flows?: { editFlow?: unknown };
+    };
+    const v = parsed?.flows?.editFlow;
+    return typeof v === "boolean" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function readState(cwd?: string): EditModeState {
+  const project = cwd ? readEditFlow(settingsPath("project", cwd)) : null;
+  const globalFlag = readEditFlow(settingsPath("global"));
+  return { project, global: globalFlag, effective: project ?? globalFlag ?? false };
+}
+
+/** Format-preserving merge of `flows.editFlow` into a settings file. */
+function writeEditFlow(file: string, enabled: boolean): void {
+  let root: Record<string, unknown> = {};
+  try {
+    root = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+  } catch {
+    // absent or unparseable → start fresh
+  }
+  const flows =
+    typeof root.flows === "object" && root.flows !== null
+      ? (root.flows as Record<string, unknown>)
+      : {};
+  flows.editFlow = enabled;
+  root.flows = flows;
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(root, null, 2)}\n`);
+}
+
+export function mountEditModeRoutes(fastify: FastifyInstance): void {
+  fastify.get<{ Querystring: { cwd?: string } }>(
+    "/api/plugins/flows/edit-mode",
+    async (req) => {
+      // cwd optional: without it the read is global-only (project stays null) —
+      // the global FlowsSettings section reads this shape.
+      return { success: true, data: readState(req.query?.cwd) };
+    },
+  );
+
+  fastify.put<{ Body: { cwd?: string; scope?: string; enabled?: boolean } }>(
+    "/api/plugins/flows/edit-mode",
+    async (req, reply) => {
+      const body = req.body ?? {};
+      const scope =
+        body.scope === "project" ? "project" : body.scope === "global" ? "global" : null;
+      if (!scope || typeof body.enabled !== "boolean") {
+        reply.code(400);
+        return { success: false, error: "scope must be 'project' or 'global', enabled must be boolean" };
+      }
+      if (scope === "project" && !body.cwd) {
+        reply.code(400);
+        return { success: false, error: "cwd required for project scope" };
+      }
+      writeEditFlow(settingsPath(scope, body.cwd), body.enabled);
+      return { success: true, data: readState(body.cwd) };
+    },
+  );
+}

--- a/packages/flows-plugin/src/server/index.ts
+++ b/packages/flows-plugin/src/server/index.ts
@@ -11,6 +11,7 @@ import type { ServerPluginContext } from "@blackbelt-technology/dashboard-plugin
 import { stateStore } from "./state-store.js";
 import { renderSessionFlowActions } from "./render-actions.js";
 import { provideFlowsActions } from "./automation-actions.js";
+import { mountEditModeRoutes } from "./edit-mode-routes.js";
 
 const PLUGIN_ID = "flows";
 
@@ -25,6 +26,10 @@ export async function registerPlugin(ctx: ServerPluginContext): Promise<void> {
   // to collect. Pure publisher: no consume, no automation dependency, no load
   // order requirement. See change: decouple-automation-action-registry.
   provideFlowsActions((name, value) => ctx.provide(name, value), (m) => logger.info(m));
+
+  // Edit-mode REST routes (folder settings toggle + retargeted global toggle).
+  // Must register before fastify.listen. See change: flows-edit-mode-folder-settings.
+  mountEditModeRoutes(ctx.fastify);
 
   /**
    * Broadcast the current intent tree for one session's slot.

--- a/packages/shared/src/dashboard-plugin/slot-props.ts
+++ b/packages/shared/src/dashboard-plugin/slot-props.ts
@@ -57,6 +57,11 @@ export interface SlotPropsMap {
     folder: FolderDescriptor;
     pluginContext: AnyPluginContext;
   };
+  "folder-settings-section": {
+    /** Absolute path of the folder whose settings page hosts the section. */
+    cwd: string;
+    pluginContext: AnyPluginContext;
+  };
   "session-card-badge": {
     session: DashboardSession;
     pluginContext: AnyPluginContext;

--- a/packages/shared/src/dashboard-plugin/slot-types.ts
+++ b/packages/shared/src/dashboard-plugin/slot-types.ts
@@ -13,6 +13,7 @@ import type { FolderDescriptor } from "./slot-props.js";
 export type SlotId =
   // React-only slots
   | "sidebar-folder-section"
+  | "folder-settings-section"
   | "worktree-card-section"
   | "session-card-action-bar"
   | "workspace-action-bar"
@@ -56,6 +57,11 @@ export const SLOT_DEFINITIONS: Record<SlotId, SlotDefinition> = {
     multiplicity: "many",
     payloadTier: "react-only",
     description: "Collapsible block above session list per workspace folder",
+  },
+  "folder-settings-section": {
+    multiplicity: "many",
+    payloadTier: "react-only",
+    description: "Plugin-contributed section on the DirectorySettings surface (/folder/:cwd/settings), receives { cwd }. See change: flows-edit-mode-folder-settings.",
   },
   "worktree-card-section": {
     multiplicity: "many",


### PR DESCRIPTION
Implements OpenSpec change `flows-edit-mode-folder-settings`.

- Generic `folder-settings-section` slot; DirectorySettings hosts it on a claims-gated Plugins page.
- flows-plugin claims it with a per-cwd edit-mode toggle (effective = project ?? global, inherited-from-global hint) via new `GET/PUT /api/plugins/flows/edit-mode`; live-applies via `POST /api/resources/reload`.
- Retargets global FlowsSettings to `~/.pi/agent/settings.json`; drops the dashboard-private `plugins.flows.editFlow` config + destructive auto-reconcile.

Local verification (docker test harness + browser, per-worktree container):
- API: project/global scope writes, inheritance + override semantics ✓
- UI: Plugins page, toggle round-trip, inherited hint appears/clears ✓
- File: format-preserving merge into `<cwd>/.pi/settings.json` ✓
- Unit: 176/176 (DirectorySettings + flows-plugin suites) ✓
