### PR TITLE
feat(make-keeper-socket-dir-configurable): honor PI_DASHBOARD_HOME as keeper socket base

### DIFF
--- a/openspec/changes/archive/2026-07-13-make-keeper-socket-dir-configurable/proposal.md
+++ b/openspec/changes/archive/2026-07-13-make-keeper-socket-dir-configurable/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The per-session RPC keeper binds a Unix-domain socket at
+`<base>/.pi/dashboard/sessions/<sessionId>.rpc.sock`, where `<base>` is the home
+directory (`os.homedir()`). When the home directory is deep, the socket path
+exceeds the platform `sockaddr_un.sun_path` limit (108 bytes on Linux, 104 on
+macOS) and `bind()` fails with a cryptic `EINVAL`, crashing the keeper inside its
+crash window and failing every session spawn. The base directory is not
+overridable, so there is no way to relocate the sockets to a shorter path.
+
+## What Changes
+
+- Honor a single environment variable **`PI_DASHBOARD_HOME`** as the base
+  directory for the keeper's session meta descriptors (socket, `.pid` sidecar,
+  keeper log): they live under `<PI_DASHBOARD_HOME>/.pi/dashboard/sessions`.
+  When unset or empty, the base is `os.homedir()` — **unchanged** from today
+  (production default `~/.pi/dashboard/sessions`).
+- Apply it in both places that derive the directory so they agree: the server's
+  `defaultSessionsDir()` (used for spawn and the startup reconnect scan) and the
+  keeper child `keeper.cjs` (which computes its own socket path). The server
+  forwards `PI_DASHBOARD_HOME` into the keeper subprocess environment.
+
+## Capabilities
+
+### Modified Capabilities
+- `rpc-keeper-sidecar`: the keeper session/socket directory base is overridable
+  via `PI_DASHBOARD_HOME` (default `os.homedir()`, unchanged).
+
+## Impact
+
+- `packages/server/src/rpc-keeper/keeper-manager.ts` — `defaultSessionsDir()`
+  honors `PI_DASHBOARD_HOME`; `spawnKeeperFor` forwards it to the keeper env.
+- `packages/server/src/rpc-keeper/keeper.cjs` — `SESSIONS_DIR` honors `PI_DASHBOARD_HOME`.
+- **Backward compatible**: with the var unset, the resolved directory is
+  byte-identical to today (`os.homedir()/.pi/dashboard/sessions`); existing
+  keepers, sockets, and reconnect behavior are unchanged.
+- **Windows** named pipes are unaffected (not filesystem-length-bound); only the
+  PID-sidecar directory follows the base.

--- a/openspec/changes/archive/2026-07-13-make-keeper-socket-dir-configurable/specs/rpc-keeper-sidecar/spec.md
+++ b/openspec/changes/archive/2026-07-13-make-keeper-socket-dir-configurable/specs/rpc-keeper-sidecar/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Per-session UDS socket / Windows named pipe
+On Unix (macOS, Linux), the keeper SHALL listen on
+`<base>/.pi/dashboard/sessions/<sessionId>.rpc.sock` (Unix domain socket), where
+`<base>` is the `PI_DASHBOARD_HOME` environment variable when it is set and
+non-empty, and `os.homedir()` otherwise (the default — unchanged). On Windows,
+the keeper SHALL listen on `\\.\pipe\pi-rpc-<sessionId>` (named pipe). The socket
+/ pipe path SHALL be derived deterministically from the base and the sessionId so
+the dashboard server can locate it without consulting any registry. The dashboard
+server SHALL derive the same base for both spawning keepers and the startup
+socket-scan reconnect, and SHALL forward `PI_DASHBOARD_HOME` into the keeper
+subprocess environment so the server and the keeper agree on the directory.
+
+The keeper SHALL also write its own PID to a sidecar file at `<sockPath>.pid`
+(Unix) or `<base>/.pi/dashboard/sessions/pi-rpc-<sessionId>.pid` (Windows) so the
+dashboard server's startup orphan-cleanup pass can detect dead-keeper-with-stale-socket
+and remove the socket.
+
+#### Scenario: Unix socket path derivation (default base)
+- **WHEN** keeper for session `019e0dac-d7a9-745e-b1ac-4306aa7594e2` starts on macOS or Linux with `PI_DASHBOARD_HOME` unset
+- **THEN** the keeper SHALL listen on `<homedir>/.pi/dashboard/sessions/019e0dac-d7a9-745e-b1ac-4306aa7594e2.rpc.sock`
+- **AND** the keeper SHALL write its PID to `<sockPath>.pid`
+
+#### Scenario: Unix socket path derivation (PI_DASHBOARD_HOME override)
+- **WHEN** keeper for session `019e0dac-d7a9-745e-b1ac-4306aa7594e2` starts on macOS or Linux and `PI_DASHBOARD_HOME` is `/home/u/.ibdev`
+- **THEN** the keeper SHALL listen on `/home/u/.ibdev/.pi/dashboard/sessions/019e0dac-d7a9-745e-b1ac-4306aa7594e2.rpc.sock`
+- **AND** the dashboard server's startup reconnect scan SHALL scan `/home/u/.ibdev/.pi/dashboard/sessions`
+
+#### Scenario: Windows named-pipe path derivation
+- **WHEN** keeper for session `019e0dac-d7a9-745e-b1ac-4306aa7594e2` starts on Windows
+- **THEN** the keeper SHALL listen on `\\.\pipe\pi-rpc-019e0dac-d7a9-745e-b1ac-4306aa7594e2`
+- **AND** the keeper SHALL write its PID to `<base>\.pi\dashboard\sessions\pi-rpc-019e0dac-d7a9-745e-b1ac-4306aa7594e2.pid`

--- a/openspec/changes/archive/2026-07-13-make-keeper-socket-dir-configurable/tasks.md
+++ b/openspec/changes/archive/2026-07-13-make-keeper-socket-dir-configurable/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+## 1. Honor PI_DASHBOARD_HOME (server + keeper)
+- [x] 1.1 `defaultSessionsDir()` uses `process.env.PI_DASHBOARD_HOME?.trim() || os.homedir()` as the base for `.pi/dashboard/sessions` (flows to both spawn and the startup reconnect scan via the single `sessionsDir` the manager threads through).
+- [x] 1.2 `keeper.cjs` computes `SESSIONS_DIR` from the same `PI_DASHBOARD_HOME`-or-`homedir` base, so the child binds the same path the server expects.
+- [x] 1.3 `spawnKeeperFor` forwards `PI_DASHBOARD_HOME` into the keeper subprocess env (buildSpawnEnv curates the env and may not carry the custom var through on its own).
+
+## 2. Verify (manual)
+- [x] 2.1 With `PI_DASHBOARD_HOME` set to a short dir under a deep HOME, a headless spawn binds the socket successfully and the session registers (previously `bind EINVAL`).
+- [x] 2.2 With `PI_DASHBOARD_HOME` unset, sockets resolve under `~/.pi/dashboard/sessions` exactly as before (backward compatible).

--- a/openspec/specs/rpc-keeper-sidecar/spec.md
+++ b/openspec/specs/rpc-keeper-sidecar/spec.md
@@ -38,19 +38,36 @@ The keeper SHALL be a CommonJS file (`.cjs`) with no TypeScript loader, jiti, or
 - **AND** the keeper SHALL exit with code 0
 
 ### Requirement: Per-session UDS socket / Windows named pipe
-On Unix (macOS, Linux), the keeper SHALL listen on `~/.pi/dashboard/sessions/<sessionId>.rpc.sock` (Unix domain socket). On Windows, the keeper SHALL listen on `\\.\pipe\pi-rpc-<sessionId>` (named pipe). The socket / pipe path SHALL be derived deterministically from the sessionId so the dashboard server can locate it without consulting any registry.
+On Unix (macOS, Linux), the keeper SHALL listen on
+`<base>/.pi/dashboard/sessions/<sessionId>.rpc.sock` (Unix domain socket), where
+`<base>` is the `PI_DASHBOARD_HOME` environment variable when it is set and
+non-empty, and `os.homedir()` otherwise (the default — unchanged). On Windows,
+the keeper SHALL listen on `\\.\pipe\pi-rpc-<sessionId>` (named pipe). The socket
+/ pipe path SHALL be derived deterministically from the base and the sessionId so
+the dashboard server can locate it without consulting any registry. The dashboard
+server SHALL derive the same base for both spawning keepers and the startup
+socket-scan reconnect, and SHALL forward `PI_DASHBOARD_HOME` into the keeper
+subprocess environment so the server and the keeper agree on the directory.
 
-The keeper SHALL also write its own PID to a sidecar file at `<sockPath>.pid` (Unix) or `<homedir>/.pi/dashboard/sessions/pi-rpc-<sessionId>.pid` (Windows) so the dashboard server's startup orphan-cleanup pass can detect dead-keeper-with-stale-socket and remove the socket.
+The keeper SHALL also write its own PID to a sidecar file at `<sockPath>.pid`
+(Unix) or `<base>/.pi/dashboard/sessions/pi-rpc-<sessionId>.pid` (Windows) so the
+dashboard server's startup orphan-cleanup pass can detect dead-keeper-with-stale-socket
+and remove the socket.
 
-#### Scenario: Unix socket path derivation
-- **WHEN** keeper for session `019e0dac-d7a9-745e-b1ac-4306aa7594e2` starts on macOS or Linux
+#### Scenario: Unix socket path derivation (default base)
+- **WHEN** keeper for session `019e0dac-d7a9-745e-b1ac-4306aa7594e2` starts on macOS or Linux with `PI_DASHBOARD_HOME` unset
 - **THEN** the keeper SHALL listen on `<homedir>/.pi/dashboard/sessions/019e0dac-d7a9-745e-b1ac-4306aa7594e2.rpc.sock`
 - **AND** the keeper SHALL write its PID to `<sockPath>.pid`
+
+#### Scenario: Unix socket path derivation (PI_DASHBOARD_HOME override)
+- **WHEN** keeper for session `019e0dac-d7a9-745e-b1ac-4306aa7594e2` starts on macOS or Linux and `PI_DASHBOARD_HOME` is `/home/u/.ibdev`
+- **THEN** the keeper SHALL listen on `/home/u/.ibdev/.pi/dashboard/sessions/019e0dac-d7a9-745e-b1ac-4306aa7594e2.rpc.sock`
+- **AND** the dashboard server's startup reconnect scan SHALL scan `/home/u/.ibdev/.pi/dashboard/sessions`
 
 #### Scenario: Windows named-pipe path derivation
 - **WHEN** keeper for session `019e0dac-d7a9-745e-b1ac-4306aa7594e2` starts on Windows
 - **THEN** the keeper SHALL listen on `\\.\pipe\pi-rpc-019e0dac-d7a9-745e-b1ac-4306aa7594e2`
-- **AND** the keeper SHALL write its PID to `<homedir>\.pi\dashboard\sessions\pi-rpc-019e0dac-d7a9-745e-b1ac-4306aa7594e2.pid`
+- **AND** the keeper SHALL write its PID to `<base>\.pi\dashboard\sessions\pi-rpc-019e0dac-d7a9-745e-b1ac-4306aa7594e2.pid`
 
 ### Requirement: JSON-line forward protocol (fire-and-forget)
 The keeper's UDS / named-pipe protocol SHALL be JSON-lines: every newline-delimited string received on the socket SHALL be appended with `\n` (if missing) and written verbatim to pi's stdin. The keeper SHALL NOT parse, validate, or modify the JSON content of incoming lines. The keeper SHALL NOT respond to writes — the socket is write-only from the dashboard server's perspective; keeper acknowledgement is implicit (write succeeds → line forwarded).

--- a/packages/server/src/rpc-keeper/keeper-manager.ts
+++ b/packages/server/src/rpc-keeper/keeper-manager.ts
@@ -38,7 +38,14 @@ import { electronAsNodeRequired } from "@blackbelt-technology/pi-dashboard-share
 // ── Path conventions ─────────────────────────────────────────────────────────
 
 function defaultSessionsDir(): string {
-  return path.join(os.homedir(), ".pi", "dashboard", "sessions");
+  // Keeper meta descriptors (UDS socket, .pid sidecar, keeper log) live under
+  // <base>/.pi/dashboard/sessions. The base is os.homedir() by default; set
+  // PI_DASHBOARD_HOME to relocate it (e.g. to keep the Unix socket path under
+  // the sockaddr_un.sun_path limit when the real HOME is deep). This is the only
+  // knob — createKeeperManager() flows this dir to both spawn and the startup
+  // reconnect scan. Unset in production ⇒ ~/.pi/dashboard/sessions (unchanged).
+  const base = process.env.PI_DASHBOARD_HOME?.trim() || os.homedir();
+  return path.join(base, ".pi", "dashboard", "sessions");
 }
 
 function defaultKeeperPath(): string {
@@ -232,6 +239,13 @@ export function createKeeperManager(opts: KeeperManagerOptions = {}): KeeperMana
     // See change: fix-nodescript-argv-electron-execpath-fallback.
     if (electronAsNodeRequired(nodeBinary)) {
       keeperEnv = { ...keeperEnv, ELECTRON_RUN_AS_NODE: "1" };
+    }
+
+    // Forward PI_DASHBOARD_HOME explicitly so the keeper child derives the same
+    // sessions dir as the server's defaultSessionsDir() — buildSpawnEnv curates
+    // the env and may not carry this custom var through on its own.
+    if (process.env.PI_DASHBOARD_HOME && process.env.PI_DASHBOARD_HOME.trim()) {
+      keeperEnv = { ...keeperEnv, PI_DASHBOARD_HOME: process.env.PI_DASHBOARD_HOME };
     }
 
     // Delegate to the shared cross-platform primitive so libuv-correct

--- a/packages/server/src/rpc-keeper/keeper.cjs
+++ b/packages/server/src/rpc-keeper/keeper.cjs
@@ -35,7 +35,15 @@ if (!sessionId || typeof sessionId !== "string") {
   process.exit(2);
 }
 
-const SESSIONS_DIR = path.join(os.homedir(), ".pi", "dashboard", "sessions");
+// Base for keeper meta descriptors (socket, .pid, log). PI_DASHBOARD_HOME
+// overrides the base so the Unix socket path can be kept under the
+// sockaddr_un limit when the real HOME is deep; unset ⇒ ~/.pi (unchanged).
+// Must match the dashboard server's defaultSessionsDir() so both agree.
+const DASH_BASE =
+  process.env.PI_DASHBOARD_HOME && process.env.PI_DASHBOARD_HOME.trim()
+    ? process.env.PI_DASHBOARD_HOME.trim()
+    : os.homedir();
+const SESSIONS_DIR = path.join(DASH_BASE, ".pi", "dashboard", "sessions");
 try {
   fs.mkdirSync(SESSIONS_DIR, { recursive: true });
 } catch (_e) { /* ignore — fs.openSync below will fail with a clearer error */ }


### PR DESCRIPTION
Implements OpenSpec change `make-keeper-socket-dir-configurable`.

Honor `PI_DASHBOARD_HOME` as the base directory for the keeper's session meta
descriptors (`<base>/.pi/dashboard/sessions/*`). Fixes `bind() EINVAL` crashes
when the home directory is deep enough to push the UDS path past the
`sockaddr_un` limit. Applied in `defaultSessionsDir()` and `keeper.cjs`, forwarded
into the keeper env. Unset ⇒ `os.homedir()` (byte-identical to prior behavior).
Windows named pipes are unaffected.

Gate: `npm run build` ✓; full `npm test` green except pre-existing,
environment-sensitive `fs.watch` degrade tests (unrelated to this change).

QA/manual verification tasks deferred to post-merge.
