### PR TITLE
fix(fix-builtin-role-names-relay): forward builtinRoleNames to the browser

### DIFF
--- a/.pi/skills/AGENTS.md
+++ b/.pi/skills/AGENTS.md
@@ -18,7 +18,8 @@ Files in this directory. One row per file. Non-source area (migrated from `docs/
 | `code-review/references/` | Language guides + architecture/performance/security review references |
 | `code-review/SKILL.md` | Skill: comprehensive code review with severity labels |
 | `component-architecture/SKILL.md` | Reusable component patterns: folder structure (`ui/layout/sections/cards/forms/shared/seo`),… → see `component-architecture/SKILL.md.AGENTS.md` |
-| `debug-dashboard/references/known-issues.md` | Known-issue catalogue distilled from `docs/faq.md`: server won't start (Electron Node bin fallback… → see `debug-dashboard/references/known-issues.md.AGENTS.md` |
+| `debug-dashboard/references/isolated-verification.md` | Isolated UI/worktree verification. Live :8000 runs MAIN-repo code; `npm run build` leaks to `packages/client/dist`. Temp HOME + non-8000 ports + `PI_DASHBOARD_NO_MDNS=1`. Mockup-serve + worktree-harness recipe. |
+| `debug-dashboard/references/known-issues.md` | Known-issue catalogue distilled from `docs/faq.md`: server won't start (Electron Node bin fallback… + new-session spawn_register_timeout (pi-crash vs overload split) → see `debug-dashboard/references/known-issues.md.AGENTS.md` |
 | `debug-dashboard/references/log-locations.md` | Persistent file map. `~/.pi/dashboard/`: `server.log` (append, timestamped banners, grep recipes),… → see `debug-dashboard/references/log-locations.md.AGENTS.md` |
 | `debug-dashboard/references/test-failure-triage.md` | Vitest failure triage. Golden rule tee→grep (`npm test 2>&1 | tee /tmp/pi-test.log`), standard greps,… → see `debug-dashboard/references/test-failure-triage.md.AGENTS.md` |
 | `debug-dashboard/references/ui-debug.md` | Pointer to `browser` skill for UI/visual debugging. Symptom routing table:… → see `debug-dashboard/references/ui-debug.md.AGENTS.md` |
@@ -31,6 +32,8 @@ Files in this directory. One row per file. Non-source area (migrated from `docs/
 | `document-converter/SKILL.md` | NL-triggered document conversion. Ingest PDF/DOCX/PPTX/XLSX→md for kb; produce md→DOCX/PDF templated. Routes to packages/document-converter facade. See change: document-converter. |
 | `edit-flow/SKILL.md` | Skill: create/edit pi-flows flows + agents via `flow_agents` + `flow_write`. → see `edit-flow/SKILL.md.AGENTS.md` |
 | `faq-mine/SKILL.md` | Skill: mine `docs/faq.md` from README.md + evergreen `docs/*.md`. → see `faq-mine/SKILL.md.AGENTS.md` |
+| `fix-worktree-opsx-skills-not-created/SKILL.md` | Skill. Fix worktree missing generated openspec-* (opsx) skills. `worktreeInit` must call `npx @fission-ai/openspec init`; bare `openspec` = squatted 0.0.0 npm stub that inits nothing. |
+| `frontend-mockup-loop-dashboard/SKILL.md` | Skill. Dashboard adapter over frontend-mockup-loop. Binds 7-step loop to `packages/client` sources, theme-system tokens (4 themes), isolated-verification, `openspec/changes/<name>/mockups/`. |
 | `implement/references/code-discipline.md` | Reference: expands AGENTS.md "Code Instructions" 5 rules with worked examples. → see `implement/references/code-discipline.md.AGENTS.md` |
 | `implement/references/rebuild-matrix.md` | Reference: full 3-component rebuild matrix. Per-component recipes — extension `npm run… → see `implement/references/rebuild-matrix.md.AGENTS.md` |
 | `implement/scripts/check-mode.ts` | Print dashboard mode ("dev"/"production") via `GET /api/health`. → see `implement/scripts/check-mode.ts.AGENTS.md` |
@@ -88,9 +91,11 @@ Files in this directory. One row per file. Non-source area (migrated from `docs/
 | `pi-dashboard/references/slash-commands.md` | Reference catalog of every `/dashboard:*` slash command with args and LLM-free vs LLM-bound classification. Naming grammar `/dashboard:<resource>-<verb>[-<modifier>]`. |
 | `pi-dashboard/scripts/dashboard-api.sh` | Helper script with port auto-detection + auth |
 | `pi-dashboard/SKILL.md` | Bundled skill: monitor + control dashboard from any pi session. → see `pi-dashboard/SKILL.md.AGENTS.md` |
+| `pre-scaffold-openspec-coherence-check/SKILL.md` | Skill. Pre-scaffold checks before new openspec change: archive sweep, active sweep, current-code verify, slot-props contract, registry check. Avoid re-proposing archived work. |
 | `release-cut/SKILL.md` | Cuts new release: promotes `## [Unreleased]` in CHANGELOG → dated section, bumps every workspace… → see `release-cut/SKILL.md.AGENTS.md` |
 | `release-revoke/SKILL.md` | `release-revoke` skill. Reverts a release: deletes GitHub Release, removes git tag (local + origin), `npm… → see `release-revoke/SKILL.md.AGENTS.md` |
 | `responsive-mobile-first/SKILL.md` | Mobile-first responsive patterns: sticky headers, mobile drawer, floating CTA, responsive grids, touch… → see `responsive-mobile-first/SKILL.md.AGENTS.md` |
+| `run-dashboard-e2e-local-changes/SKILL.md` | Skill. Run Playwright E2E vs `docker/` harness reflecting LOCAL changes. `docker compose -f docker/compose.yml build` FIRST (test-up.sh omits `--build`). Seed env `PI_E2E_SEED=1`. |
 | `scenario-design/references/technique-cheatsheet.md` | How-to per design/resilience technique with repo examples. EP: split input classes (invalid too). → see `scenario-design/references/technique-cheatsheet.md.AGENTS.md` |
 | `scenario-design/references/test-plan-schema.md` | Exact `test-plan.md` layout. Header: stage + generated date. Soft-gate clarification banner. → see `scenario-design/references/test-plan-schema.md.AGENTS.md` |
 | `scenario-design/SKILL.md` | Drafts adversarial real-life test scenarios from OpenSpec change spec. → see `scenario-design/SKILL.md.AGENTS.md` |

--- a/.pi/skills/debug-dashboard/SKILL.md
+++ b/.pi/skills/debug-dashboard/SKILL.md
@@ -48,6 +48,7 @@ If `health-probe` says "not-running" → server isn't up. Check `server.log` for
 | `EADDRINUSE` on start | Concurrent spawn from multiple pi sessions | Harmless — losing process exits silently. Check log. |
 | Bridge connects then disconnects | `server_restarting` broadcast active, or version skew | grep `server_restarting` in server.log; check `/api/health` for version |
 | Blank page in browser | Vite not running in dev mode (silent fallback to prod build); or auth blocking | Check `/api/health.mode`; check `auth` settings |
+| New session won't start / yellow `spawn_register_timeout`, no card | `pi` crashed at startup (bad extension) OR host overload | See `references/known-issues.md` → "New session won't start" — manual `pi --mode rpc` run splits crash vs overload |
 | `Cannot connect to dashboard server` on Electron boot | `launchDashboardServer` fell back to `process.execPath` (Electron GUI binary) | See `references/known-issues.md` → "Electron Node bin selection" |
 | Fastify crashes immediately | Bad Node version (22.0–22.17.x or 24.1–24.2.x per nodejs/node#58515) | `node --version` — must be ≥ 22.18.0 |
 
@@ -74,6 +75,10 @@ Patterns + per-package vitest configs + watch mode are documented in [`reference
 ## When the UI is the problem
 
 This skill stops at "the server says X but the UI shows Y". For visual debugging — verifying layouts, screenshotting, hunting console errors, testing responsive breakpoints — switch to the **`browser`** skill (shipped by the dashboard bridge extension to every session). Quick pointer: see [`references/ui-debug.md`](references/ui-debug.md).
+
+## When you must verify a change without touching the live server
+
+The live `:8000` server runs MAIN-repo code — `/api/restart` never loads worktree edits, and a careless `npm run build` **leaks** into `packages/client/dist` (what live serves). To verify a UI/worktree change or serve a review mockup in full isolation (temp `HOME`, non-8000 ports, `PI_DASHBOARD_NO_MDNS=1`), see [`references/isolated-verification.md`](references/isolated-verification.md).
 
 ## Log file locations
 

--- a/.pi/skills/debug-dashboard/references/isolated-verification.md
+++ b/.pi/skills/debug-dashboard/references/isolated-verification.md
@@ -1,0 +1,29 @@
+# Isolated UI / Worktree Verification
+
+How to visually/functionally verify a dashboard change, build a review mockup, or confirm worktree edits actually load — **without disturbing the live dashboard**. The live server on `:8000` runs MAIN-repo code, so naive browser checks verify the wrong code, and a careless isolated env can clobber live infra.
+
+## Core rule
+
+The live `:8000` server runs from the MAIN repo checkout (`…/pi-agent-dashboard/packages/server/src/cli.ts`), NOT a git worktree. `/api/restart` and `pi-dashboard restart` restart MAIN-repo code — **worktree edits never load there**. Confirm the live root via `lsof -i:8000` / `ps` → `cli.ts` path before and after any isolated run; the original PID must be unchanged.
+
+## Procedure
+
+1. **ISOLATION.** Run any test/verify server in a fully isolated env — temp `HOME` (`mktemp -d`), separate ports, network-silent (`PI_DASHBOARD_NO_MDNS=1`, no tunnel, `autoStart:false`) so live infra stays untouched. In a git worktree, use the parent/main worktree's openspec definitions + skills, not worktree-local copies.
+2. **ALWAYS verify UI in a real browser**, not just programmatic asserts.
+3. **LIVE MOCKUPS.** Serve mockups from a live local static server on `0.0.0.0` (`python3 -m http.server`), hand back a clickable link (local + LAN IP for phone) — NOT screenshots. Iterate conversationally (presets + sliders) before committing.
+4. **GROUND MOCKUPS in the real current UI.** Open the running dashboard + read the authoritative source component (e.g. `packages/client/src/components/SessionCard.tsx`) to capture exact tokens (classes like `rounded-xl shadow-md border bg-[--bg-tertiary]`, `px-4 py-3`; CSS vars `--bg-tertiary` #1e1e1e dark / #fff light). Slot new surfaces into that layout, verify dark+light via the live mockup. Proposal mockups go to `openspec/changes/<name>/mockups/` (HTML + `ui-plan.md` mapping surfaces→slots/states).
+5. **STYLING TASTE.** To separate stacked cards from a container, RECEDE cards to a darker tier (`--bg-primary` #0a0a0a, below the #141414 container), not a lighter "raised card". Sidebar dir cards: bg #0a0a0a, 1px border rgba(255,255,255,0.1), 5px gap, 14px radius.
+6. **VERIFY WORKTREE CODE.** To verify worktree code in a real browser without disturbing live infra: write a standalone harness `tmp-*.mts` (run with the repo jiti/node TS runner) that imports the WORKTREE module directly (e.g. `editor-manager.ts`), pointed at an isolated temp HOME + temp project dir, spawn the real child (code-server), open its port in the browser. Delete the harness after.
+
+## Pitfalls
+
+- **Cannot surface a historical/ended session in a fresh isolated server.** The dashboard is a LIVE aggregator: the event store is IN-MEMORY (`memory-event-store.ts`, "Replaces SQLite-backed event-store.ts"), the sidebar lists only live-bridge-connected sessions, and a transcript is loaded from the pi session's JSONL on disk on `subscribe` (keyed off a `sessionManager` entry with `sessionFile`). `~/.pi/dashboard/dashboard.db` (`sessions`/`events` tables) is LEGACY/unused by current code — copying it into an isolated HOME yields 0 sessions and no replay. To verify a real long transcript either (a) deploy to the live server that already has the session, or (b) build a standalone ChatView harness: read events from the db `events` table (`data` column = JSON per row), fold them through `reduceEvent`, mount `<ChatView state={folded}>` in a Vite entry. This validates rendering/animations/clipping but NOT scroll-anchoring (that needs the real app shell).
+- **Building leaks to live.** `@blackbelt-technology/pi-dashboard-web` symlinks to `packages/client`; `npm run build` writes `packages/client/dist`, which is exactly what the live server serves (via `require.resolve` → that dist; no `clientDir` override env exists). So a plain `npm run build` for an "isolated" test leaks your changes to the live dashboard on its next page load. For a leak-free isolated client, run Vite dev (`PI_DASHBOARD_PORT=<isoPort> npm run dev`, serves worktree source, proxies `/api`+`/ws`) against an isolated backend, and never build into `packages/client/dist`.
+- **`os.homedir()` DOES honor `$HOME` here** (verified on macOS+Node), so `HOME=$(mktemp -d)` fully isolates the server's config/db/dirs. Launch the foreground server directly (`HOME=<iso> PI_DASHBOARD_NO_MDNS=1 node packages/server/bin/pi-dashboard.mjs --port <p> --pi-port <pp>`) so you own the PID and kill by PID — never `pi-dashboard stop` (it kills `:8000` via stale-port lsof).
+- **Do NOT leave openspec poll enabled during browser QA on this repo** (many active changes) — it starves the WS heartbeat → blank client + dropped bridge. Set `enabled:false` in the isolated HOME config first.
+
+## Verification
+
+1. Isolated server runs on non-8000 ports with temp HOME; `lsof -i:8000` still shows the original live server PID unchanged.
+2. Browser loads the isolated port and shows the NEW behavior (worktree/edit under test), not stale main-repo behavior.
+3. Mockup reachable via the handed-back local + LAN URL and renders correctly in both dark and light.

--- a/.pi/skills/debug-dashboard/references/known-issues.md
+++ b/.pi/skills/debug-dashboard/references/known-issues.md
@@ -46,6 +46,37 @@ pi-dashboard start
 
 `pi-dashboard stop` kills processes holding the port via `lsof`, not just the PID file — so stale PIDs don't block it.
 
+## New session won't start (spawn_register_timeout)
+
+### Symptom — "+ New session" yields a yellow timeout banner, no session card ever renders
+
+`/api/session/spawn` returns success (the RPC keeper launched) but `activeSessions` never increments. **Success from the spawn API means ONLY the keeper launched — it does NOT mean `pi` started.** Two root causes, distinguished by one manual `pi` run.
+
+**Reproduce + isolate:**
+```bash
+# 1. Spawn and poll activeSessions for ~40s
+curl -s -o /tmp/sp.json -X POST http://localhost:8000/api/session/spawn -d '{"cwd":"<repo>"}'
+watch -n2 'curl -s http://localhost:8000/api/health | jq .server.activeSessions'
+
+# 2. Read the keeper log for that spawn (transport id from /tmp/sp.json)
+#    ~/.pi/dashboard/sessions/keeper-<transport>.log
+#    'pi exited code=1 ... elapsed=NNNNms' == pi crashed at startup (extension/config), NOT overload.
+
+# 3. Capture pi's crash reason directly (keeper output-capture is OFF by default):
+NODE=~/.pi-dashboard/node/bin/node
+CLI=node_modules/@earendil-works/pi-coding-agent/dist/cli.js
+( echo '' | timeout 8 "$NODE" "$CLI" --mode rpc ) >/tmp/o 2>/tmp/e; echo exit=$?; head /tmp/e
+```
+
+**Branch on the manual exit code:**
+- **exit=1 + `Failed to load extension`** → an enabled extension is incompatible with the bundled pi. Note the package + the missing module. Check `~/.pi/agent/settings.json` for enabled `npm:<ext>` and `~/.pi/agent/npm/package.json` for the pinned version + install mtime (correlate with when spawns started failing). Fix: pin a known-working version in `~/.pi/agent/npm/package.json`, then `npm install --legacy-peer-deps` (the tree has conflicting peers; plain install fails). Pin EXACTLY (not `^`) so it can't auto-upgrade back to a broken `latest`. Re-run the manual pi check (expect exit=0), then a real dashboard spawn (expect `activeSessions` +1 within ~5s).
+- **exit=0 (no crash)** → it's host overload, not a crash. Count real pi procs, group cwds via `lsof`, check `uptime` load + server RSS via `/api/health`. Look for runaway burst-spawns (many `rpc-keeper/keeper.cjs` under one parent pi pid, started within ~60s). Kill keeper subtrees with SIGTERM (the keeper stops its child; killing only the child triggers a respawn). Optionally raise `spawnRegisterTimeoutMs` (default 30000, clamp 5000–120000) in `~/.pi/dashboard/config.json`.
+
+**Pitfalls:**
+- Killing a pi child PID alone is futile — the RPC keeper respawns it. Kill the keeper parent (`rpc-keeper/keeper.cjs`) instead.
+- UUIDv7 session ids sharing an 8-char prefix (e.g. `019ef4c7-e291` / `019ef4c7-e292`) are DISTINCT sessions spawned ms apart, not duplicates — don't chase a phantom dup bug.
+- The `[dashboard] failed to flip ctx.hasUI` stderr line is a non-fatal bridge warning; pi still exits 0 — not the crash cause.
+
 ## Bridge won't connect
 
 ### Symptom — Bridge connects then immediately disconnects

--- a/.pi/skills/fix-worktree-opsx-skills-not-created/SKILL.md
+++ b/.pi/skills/fix-worktree-opsx-skills-not-created/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: "fix-worktree-opsx-skills-not-created"
+description: "Diagnose/fix worktrees missing the generated openspec-* (opsx) skills after worktreeInit. Root cause: bare `npx openspec` can resolve a squatted registry stub instead of the real CLI."
+version: 1
+created: "2026-07-13"
+updated: "2026-07-13"
+---
+## When to Use
+Use when a git worktree lacks the OpenSpec experimental-workflow skills (.pi/skills/openspec-explore, openspec-new-change, etc.), the /opsx: slash commands are missing, or openspec-apply-change stalls in a worktree. Also when auditing the .pi/settings.json worktreeInit hook.
+
+## Procedure
+1. Confirm the skills are GENERATED, not committed: `.pi/.gitignore` has `skills/openspec-*/**` (only `openspec-shared` is tracked). So every fresh worktree starts without them and must regenerate via `openspec init`.
+2. Know the CLI package: the `openspec` binary is provided by the SCOPED package `@fission-ai/openspec` (declared in packages/server, hoisted to root node_modules/.bin/openspec). The BARE name `openspec` on npm is a squatted `0.0.0` stub that does nothing.
+3. Root cause of silent failure: worktreeInit ran `npx openspec init ...`. When the local .bin/openspec isn't resolvable from the worktree root (hoisting/install timing/npx cache), bare `npx openspec` fetches `openspec@0.0.0` → init creates nothing → no opsx skills, while the `&&` chain still exits 0.
+4. Fix: in .pi/settings.json worktreeInit.run.command, call the scoped package explicitly: `npx @fission-ai/openspec init --tools pi --force`. npx then resolves the local install (or fetches the CORRECT scoped package) and can never hit the 0.0.0 stub.
+5. Verify: fresh worktree → `npx @fission-ai/openspec init --tools pi --force` → `ls .pi/skills/ | grep openspec-` shows 8 generated skills + openspec-shared (9 total). CLI prints `8 skills and 8 commands in .pi/` and `/opsx:new`.
+6. To backfill an existing broken worktree: cd into it and run `npx @fission-ai/openspec init --tools pi --force` (safe — the openspec-* dirs are gitignored so this won't dirty git).
+
+## Pitfalls
+- Don't use `npx --no-install @fission-ai/openspec` in a worktree that hasn't run `npm ci` yet — nothing is installed, so it errors. The worktreeInit chain runs `(npm ci || npm install)` FIRST, so plain `npx @fission-ai/openspec` is correct.
+- The worktreeInit gate `test ! -d .pi/skills/openspec-explore` correctly re-triggers init when only the skills are missing (OR-chained), so the gate is fine — the bug was the command, not the gate.
+- `openspec init --force` may rewrite tracked AGENTS.md/CLAUDE.md; the gitignored `.pi/skills/openspec-*` dirs are safe to (re)generate.
+
+## Verification
+1. git worktree add --detach /tmp/wt develop; cd /tmp/wt; npx @fission-ai/openspec init --tools pi --force; test -d .pi/skills/openspec-explore && echo OK; git worktree remove --force /tmp/wt
+2. npm view openspec version  # → 0.0.0 (proves the bare-name stub); npx --no-install @fission-ai/openspec --version  # → real 1.4.x from local install

--- a/.pi/skills/frontend-mockup-loop-dashboard/SKILL.md
+++ b/.pi/skills/frontend-mockup-loop-dashboard/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: "frontend-mockup-loop-dashboard"
+description: "Dashboard-specific adapter on top of the generic frontend-mockup-loop skill/package. Binds the 7-step design loop to pi-agent-dashboard reality: real component sources, theme-system tokens (4 themes), isolated verification for safe preview/promote, and openspec mockup paths. Use when designing/redesigning any pi-agent-dashboard client surface. Triggers: \"design a dashboard screen\", \"mockup a dashboard surface\", \"redesign SessionCard\", \"make dashboard UI consistent\"."
+version: 1
+created: "2026-06-23"
+updated: "2026-06-23"
+---
+## When to Use
+Use when designing or refining any surface in packages/client (or src/client) of pi-agent-dashboard. This is a THIN ADAPTER: the generic loop, tools, and rubric live in the frontend-mockup-loop skill (shipped by @blackbelt-technology/frontend-mockup-loop). Load that first for the full procedure; this skill only supplies the dashboard-specific bindings. Skip for trivial one-class tweaks.
+
+## Procedure
+1. LOAD the generic loop first: /skill:frontend-mockup-loop. Follow its 7 steps (GROUND, CONTRACT, MOCKUP, TEST, FIX, PROMOTE, LEARN) and use its tools (serve_mockup, score_mockup, init_ui_contract). The bindings below override only the dashboard-specific details.
+2. GROUND binding: read the authoritative component source (e.g. packages/client/src/components/SessionCard.tsx) and capture exact classes (rounded-xl shadow-md border px-4 py-3) + CSS vars (--bg-tertiary #1e1e1e dark / #fff light, --bg-primary #0a0a0a, container #141414). Delegate harvest per the debug-dashboard skill's references/isolated-verification.md.
+3. CONTRACT binding: the token authority is the theme-system skill (4 themes: studio, earth, athlete, gradient; CSS custom properties --background/--primary/--radius). ui-contract.md references those vars; new tokens get added to the theme layer first. Per-change scope: write openspec/changes/<name>/mockups/ui-plan.md (surfaces -> tokens -> states).
+4. MOCKUP binding: mockups for a proposal go to openspec/changes/<name>/mockups/. Serve live + hand back local + LAN URL; verify dark AND light.
+5. PROMOTE binding: NEVER verify against the live :8000 server — it runs MAIN-repo code; worktree edits never load. Use isolated verification (debug-dashboard skill → references/isolated-verification.md: temp HOME, non-8000 ports, PI_DASHBOARD_NO_MDNS=1, openspec poll enabled:false). Confirm live root via lsof -i:8000 before/after; original PID must be unchanged.
+
+## Pitfalls
+- Do NOT run pi-dashboard stop in an isolated env — it defaults to port 8000 / pi-port 9999 even under custom HOME and kills the real dashboard via stale-port lsof. Pass explicit --port/--pi-port or kill by pgrep -f 'cli.ts.*--port <N>'.
+- Do NOT leave openspec poll enabled during browser QA on this repo (73+ changes) — it starves the WS heartbeat -> blank client + dropped bridge. Set enabled:false in the isolated HOME config first.
+- Do NOT trust agent-browser eval on a file:// static page — it can blank the page and the live session-list timer invalidates @e<N> snapshot refs. Prefer clicking the page's own controls.
+- Do NOT duplicate the generic procedure here — if a rule is not dashboard-specific, it belongs in the frontend-mockup-loop skill, not this adapter.
+
+## Verification
+1. Generic frontend-mockup-loop rubric passes (contrast, responsive, anti-slop) in both themes at 3 breakpoints.
+2. ui-contract.md / ui-plan.md values reference theme-system CSS vars, not raw hex.
+3. Promote happened in an isolated env on non-8000 ports; lsof -i:8000 still shows the original live server PID unchanged.
+4. Mockups landed under openspec/changes/<name>/mockups/.

--- a/.pi/skills/pre-scaffold-openspec-coherence-check/SKILL.md
+++ b/.pi/skills/pre-scaffold-openspec-coherence-check/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: "pre-scaffold-openspec-coherence-check"
+description: "Run before scaffolding any OpenSpec proposal in pi-agent-dashboard to catch duplicates of archived work and contradictions with already-shipped architecture. Always run when about to create openspec/changes/&lt;name&gt;/ (proposal.md/design.md/tasks.md), especially for proposals touching tool-renderers, plugin slots, MCP rendering, or any subsystem with a recent archive entry. Skipping this check produces stale proposals that duplicate archived work and contradict shipped architecture. Triggers: 'scaffold OpenSpec', 'write a proposal', 'create change', 'openspec change new'."
+version: 1
+created: "2026-06-13"
+updated: "2026-06-13"
+---
+## When to Use
+Use before scaffolding any new OpenSpec change in pi-agent-dashboard, regardless of whether the topic feels novel. Two of the most damaging mistakes the assistant has made are (a) re-proposing work that already shipped and was archived, and (b) basing claims about current code on stale file-index harvests or grep results that miss the actual wiring idiom. This skill front-loads the cheap checks that would have caught both.
+
+Trigger this skill when about to run any of: openspec change new, Write to openspec/changes/&lt;name&gt;/proposal.md, the openspec-new-change skill, the openspec-ff-change skill, or any drafted "## Why / ## What Changes" markdown that will become a proposal.
+
+Do NOT skip even when the explore-mode conversation feels grounded. The Explore subagent harvests the file-index which can be days stale; the main agent's own grep can answer the wrong question (e.g. grepping for a consumer component when the wiring is inline).
+
+## Procedure
+1. Archive sweep: ls openspec/changes/archive/ | grep -iE ‘&lt;topic-keywords&gt;’. For tool-renderer / plugin-slot / MCP / ctx_* / context-mode topics specifically check for 2026-06-05-wire-tool-renderer-slot and 2026-06-05-add-ctx-tool-renderer. If any archive entry matches the topic, READ its proposal.md before writing a new one.
+2. Active sweep: openspec list | grep -iE ‘&lt;topic-keywords&gt;’. Read any active change that overlaps so the new proposal does not collide on filename, capability, or scope.
+3. Current-code verification (for behaviour claims): if the proposal says ‘X is not wired’, ‘Y never fires’, ‘Z falls through to Generic’, grep for the FUNCTIONAL pattern not just the named component. For tool-renderer claims specifically: grep -rn 'getClaims.*tool-renderer\\|forToolName' packages/client/src/components/ToolCallStep.tsx and read the current dispatch block (lines 90–120). The slot wiring inlines useSlotRegistryOrNull + forToolName + claimShouldRender; the ToolRendererSlot consumer component is unused, but that does NOT mean the slot is unwired.
+4. Slot-prop contract check: cat packages/shared/src/dashboard-plugin/slot-props.ts and read SlotPropsMap[‘&lt;slot&gt;’]. Confirm the required fields (every slot requires pluginContext: AnyPluginContext) and the optional fields. Do not invent a contract.
+5. Registry check (built-in renderers): cat packages/client/src/components/tool-renderers/registry.ts. The ctx_* family is mapped to a single CtxToolRenderer with a ctx_-prefix safety net for new tool names. Honour this architecture choice unless explicitly proposing to revisit it.
+6. Architecture-choice review: when the topic intersects an existing implementation, search recent commits with git log --oneline --since=&lt;30 days&gt; -- &lt;relevant paths&gt; to understand which design the team picked and the rationale. The choice between core built-in vs plugin for ctx_* was DELIBERATE (high-frequency tool, hot path); do not propose to reverse it without an explicit justification section.
+7. Optional but recommended: run the spec-coherence-check skill (project skill) which sweeps all active proposals for staleness, conflicts, and obsolescence against the current codebase and archived changes. Treat its output as authoritative.
+
+## Pitfalls
+- Trusting an Explore subagent that read only the file-index. The file-index can lag commits by days; for any claim about CURRENT code behaviour, verify against the source tree directly.
+- Misreading grep results: 'rg ToolRendererSlot returns no hits' is technically correct but does NOT imply 'plugin tool-renderer claims do not fire'. The wiring may be inline. Always grep for the FUNCTIONAL identifier (getClaims, forToolName) not just the named component.
+- Skipping the archive sweep because the topic feels new. Topics that already shipped get archived under YYYY-MM-DD-prefixed folder names; ls openspec/changes/archive/ once, costs nothing.
+- Inventing a slot prop contract from memory. Every plugin slot in slot-props.ts requires pluginContext: AnyPluginContext on top of the slot-specific fields. Missing this in a spec is a silent gap.
+- Re-proposing a plugin-based architecture without acknowledging the team chose core built-in (commit 858464d0 for ctx_*). The proposal must explicitly argue why the existing choice should be reversed; otherwise it contradicts shipped reality.
+- Pushing a proposal commit straight to develop without running these checks. develop accumulates contributions quickly; a stale proposal there gets cleaned up by others (which is what happened to openspec/changes/wire-tool-renderer-slot/ in commit e4e63989 — someone deleted my folder upstream, and I had to revert the rest).
+
+## Verification
+1. The archive sweep ran and either returned no matches OR I read every matching proposal.md and either align with it (delta-style change) or explicitly argue why a fresh proposal is needed.
+2. For every behaviour claim in the proposal's ## Why section, I have a direct grep / cat result from current code that supports it, not a recollection.
+3. The proposal's ## What Changes section does not contradict any code in packages/client/src/components/tool-renderers/registry.ts, packages/client/src/components/ToolCallStep.tsx, or packages/shared/src/dashboard-plugin/slot-props.ts.
+4. If proposing a new capability name, it does not collide with any folder under openspec/changes/ or openspec/changes/archive/. Specifically: openspec/changes/&lt;name&gt;/ does not exist AND openspec/changes/archive/*-&lt;name&gt;/ does not exist.
+5. openspec validate &lt;change-name&gt; passes (catches structural issues but not contradictions — the above checks catch those).

--- a/.pi/skills/run-dashboard-e2e-local-changes/SKILL.md
+++ b/.pi/skills/run-dashboard-e2e-local-changes/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: "run-dashboard-e2e-local-changes"
+description: "Run Playwright E2E (tests/e2e/) against the docker/ all-in-one harness so it reflects LOCAL code changes, not a stale cached image."
+version: 3
+created: "2026-06-24"
+updated: "2026-07-13"
+---
+## When to Use
+Use when validating local dashboard changes via the Docker browser-E2E harness (npm run test:e2e), or when a new/edited E2E spec mysteriously fails to see your code. The harness's test-up.sh runs `docker compose up` WITHOUT `--build`, so it reuses a cached `pi-dashboard:local` image and your committed changes are NOT in the running container until you rebuild.
+
+## Procedure
+1. Rebuild the image from current source FIRST: `docker compose -f docker/compose.yml build` (Dockerfile COPYs packages/ + runs npm install && npm run build → bakes local source). Slow (~4-6 min: apt + npm install + build).
+2. Run the suite (or one spec): `npm run test:e2e` or `npx playwright test <spec-name>`. Playwright globalSetup runs docker/test-up.sh (compose up, reuses the just-built image), waits for /api/health 200, runs specs at http://localhost:18000, globalTeardown runs test-down.sh (removes container+volumes+network).
+3. Fast iteration after a build: `PW_E2E_USE_RUNNING=1 npm run test:e2e` attaches to an already-running harness and skips teardown.
+4. Spec conventions: select existing app `data-testid`s (helpers/index.ts TESTIDS map for static keys; page.getByTestId(`...-${id}`) for dynamic). Navigate Settings→Packages via page.goto('/settings/packages') then wait for testid `package-browser`; RecommendedExtensions card renders inside it (non-collapsible Section).
+
+## Pitfalls
+- Under heavy host load (multiple worktree test containers + many pi sessions), the managed `npm run test:e2e` globalSetup can blow its 180s health cap even with a pre-built image. Robust fallback = manual up + attach mode for a SINGLE spec: (1) pre-build the per-worktree tag; (2) bring the container up yourself WITH the seed env `PI_E2E_SEED=1 PI_TEST_PEERS=both ./docker/test-up.sh -d` (writes `.pi-test-harness.json` with the derived port); (3) poll `curl :$PORT/api/health` until 200; (4) run `PW_E2E_USE_RUNNING=1 PW_E2E_PORT=$PORT PW_CHANNEL=chrome npx playwright test <spec>` (skips globalSetup build + teardown); (5) `./docker/test-down.sh` after.
+- MANDATORY seed env on manual `test-up.sh`: without `PI_E2E_SEED=1` the onboarding "Add folder" CTA renders DISABLED (`title="Set up credentials first"`, gated on `providersReady`), so `spawnFreshGitSession`/`pinDirectory` time out at 60s. The managed globalSetup sets `PI_E2E_SEED=1` + `PI_TEST_PEERS=both`; a hand-rolled `test-up.sh -d` does NOT — pass them explicitly.
+- Specs needing global roles/models data (e.g. `roles-custom.spec.ts` asserting `builtinRoleNames`-driven UI) MUST spawn a live session first: the client only sends `request_roles`/`request_models` through the first non-ended session (App.tsx), so with zero sessions the roles panel never receives `builtinRoleNames` and renders its flat back-compat layout.
+## Verification
+1. `docker compose -f docker/compose.yml build` ends with `Image pi-dashboard:local Built`.
+2. `npm run test:e2e` prints `N passed` and the teardown removes the pi-dash-test-* container/volumes/network.
+3. A spec asserting your new UI (e.g. recommended-requires) passes only after the rebuild, not before.

--- a/openspec/changes/archive/2026-07-13-fix-builtin-role-names-relay/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-13-fix-builtin-role-names-relay/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/archive/2026-07-13-fix-builtin-role-names-relay/design.md
+++ b/openspec/changes/archive/2026-07-13-fix-builtin-role-names-relay/design.md
@@ -9,11 +9,11 @@
 
 Two relay hops between the bridge and the plugin config drop the field:
 
-```
-bridge.ts (sends builtinRoleNames)
-  → event-wiring.ts:1328  roles_list broadcast  → { roles, presets, activePreset }   ❌ drops it
-  → useMessageHandler.ts:508  roleInfo          → { roles, presets, activePreset }   ❌ drops it
-  → BuiltInRolesSettings  cfg.builtinRoleNames = undefined → [] → flat render, no "＋ Add custom role"
+```mermaid
+flowchart TD
+  A["bridge.ts<br/>sends builtinRoleNames"] -->|roles_list| B["event-wiring.ts:1328<br/>broadcast → { roles, presets, activePreset }"]
+  B -->|❌ drops it| C["useMessageHandler.ts:508<br/>roleInfo → { roles, presets, activePreset }"]
+  C -->|❌ drops it| D["BuiltInRolesSettings<br/>cfg.builtinRoleNames = undefined → []<br/>flat render, no '＋ Add custom role'"]
 ```
 
 ## Goals / Non-Goals

--- a/openspec/changes/archive/2026-07-13-fix-builtin-role-names-relay/design.md
+++ b/openspec/changes/archive/2026-07-13-fix-builtin-role-names-relay/design.md
@@ -1,0 +1,33 @@
+## Context
+
+`add-custom-roles-ui` (#282) wired three of four hops for `builtinRoleNames`:
+
+- **Bridge (sender)** — `bridge.ts` sets `builtinRoleNames: rolesData.builtinRoleNames ?? []` on every `roles_list` it emits. ✅
+- **Extension→server type** — `RolesListMessage.builtinRoleNames?` exists in `protocol.ts`. ✅
+- **UI (reader)** — `RolesSettingsSection.tsx` reads `cfg.builtinRoleNames` and branches the render on it. ✅
+- **Server→browser relay + browser type + client handler** — MISSED. ❌
+
+Two relay hops between the bridge and the plugin config drop the field:
+
+```
+bridge.ts (sends builtinRoleNames)
+  → event-wiring.ts:1328  roles_list broadcast  → { roles, presets, activePreset }   ❌ drops it
+  → useMessageHandler.ts:508  roleInfo          → { roles, presets, activePreset }   ❌ drops it
+  → BuiltInRolesSettings  cfg.builtinRoleNames = undefined → [] → flat render, no "＋ Add custom role"
+```
+
+## Goals / Non-Goals
+
+- **Goal:** make `builtinRoleNames` reach the roles plugin config, so the custom-role UI renders. Conform to the existing `dashboard-roles-ownership` requirement.
+- **Non-Goal:** any change to the bridge, the `roles:get-all` handler, role persistence, or the UI component. They are already correct.
+
+## Decisions
+
+1. **Additive optional field, no version gate.** `BrowserRolesListMessage.builtinRoleNames?: string[]` mirrors the already-optional `RolesListMessage` field. Older clients ignore it (matches the spec's "additive" clause). No back-compat shim needed.
+2. **Forward, don't recompute, on the server.** The server relay copies `(msg as any).builtinRoleNames` straight through rather than re-deriving `DEFAULT_ROLE_NAMES` server-side — the bridge remains the single source of truth (spec design D2), and the server stays a dumb relay for this message.
+3. **Merge into plugin config verbatim on the client.** `useMessageHandler`'s `roleInfo` gains `builtinRoleNames: msg.builtinRoleNames`; the existing `applyPluginConfigUpdate({ id: "roles", ... })` spread carries it into `usePluginConfig<BuiltinsConfig>()`. No new store, no new message.
+
+## Risks
+
+- **Low.** Purely additive on an optional field across one message type. The failure mode if wrong is the current already-broken flat render — no regression surface beyond roles.
+- The client change requires a rebuild to deploy; the server change is jiti (restart only). A regression test at each hop guards against a future re-drop.

--- a/openspec/changes/archive/2026-07-13-fix-builtin-role-names-relay/proposal.md
+++ b/openspec/changes/archive/2026-07-13-fix-builtin-role-names-relay/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The custom-roles UI (`add-custom-roles-ui`, #282) is dead on the dashboard: the "＋ Add custom role" control and the Built-in/Custom grouping never render, so users cannot define `@fast`-style custom named roles. Root cause: `builtinRoleNames` — which the bridge sends and the spec REQUIRES to reach the client (`dashboard-roles-ownership`, "The `roles:get-all` payload SHALL advertise the built-in role-name set") — is silently dropped at both server→browser relay hops. This is a spec-conformance regression, not a missing feature.
+
+## What Changes
+
+- Add `builtinRoleNames?: string[]` to the browser-facing `BrowserRolesListMessage` (server→browser protocol type).
+- Forward `builtinRoleNames` in the server's `roles_list` re-broadcast (`event-wiring.ts`), instead of dropping it.
+- Carry `builtinRoleNames` into the roles plugin config in the client's `roles_list` handler (`useMessageHandler.ts`), instead of dropping it.
+- Add a regression guard asserting the field survives the full bridge→server→client relay so the custom-role UI renders.
+
+No behavior change for consumers that ignore the field (additive/optional). No bridge change — the extension already sends it correctly.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `dashboard-roles-ownership`: strengthen the existing "advertise the built-in role-name set" requirement with an explicit end-to-end relay scenario — the browser-facing `roles_list` message and the client's plugin-config write SHALL both preserve `builtinRoleNames`. Codifies the boundary the regression crossed.
+
+## Impact
+
+- `packages/shared/src/browser-protocol.ts` — `BrowserRolesListMessage` gains `builtinRoleNames?: string[]`.
+- `packages/server/src/event-wiring.ts` — `roles_list` broadcast forwards the field (server runs via jiti; restart only, no build).
+- `packages/client/src/hooks/useMessageHandler.ts` — `roleInfo` includes the field (requires client rebuild + server restart to deploy).
+- Tests: server relay + client handler regression coverage.
+
+## Discipline Skills
+
+- `systematic-debugging` — the fix completes a root-caused relay-drop regression; a reproducing regression test anchors it before the one-line relays land.

--- a/openspec/changes/archive/2026-07-13-fix-builtin-role-names-relay/specs/dashboard-roles-ownership/spec.md
+++ b/openspec/changes/archive/2026-07-13-fix-builtin-role-names-relay/specs/dashboard-roles-ownership/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: The `roles:get-all` payload SHALL advertise the built-in role-name set
+
+The `roles:get-all` response (and the `roles_list` WebSocket payload the bridge forwards to the client) SHALL include a `builtinRoleNames: string[]` field equal to `DEFAULT_ROLE_NAMES`. This lets the human UI classify each role as Built-in or Custom without duplicating the default-name constant in the client. The field SHALL be additive; consumers that do not read it SHALL be unaffected.
+
+The field SHALL survive the full relay to the browser. The server's `roles_list` re-broadcast to browser clients SHALL forward `builtinRoleNames`, and the browser-facing `roles_list` message type SHALL carry it. The client's `roles_list` handler SHALL write `builtinRoleNames` into the roles plugin config so the Roles settings panel can render the Built-in/Custom split and the "＋ Add custom role" control. A relay hop that omits the field is a defect, since it collapses the UI to the flat back-compat layout and makes custom roles unreachable.
+
+#### Scenario: builtinRoleNames mirrors DEFAULT_ROLE_NAMES
+
+- **GIVEN** the Roles back-end responds to `roles:get-all`
+- **THEN** the response SHALL include `builtinRoleNames` equal to `["planning", "coding", "compact", "fast", "vision", "research"]`
+- **AND** the field SHALL be present regardless of how many roles have assigned models
+
+#### Scenario: builtinRoleNames survives the server→browser relay
+
+- **GIVEN** the bridge emits a `roles_list` message carrying `builtinRoleNames`
+- **WHEN** the server re-broadcasts `roles_list` to browser clients
+- **THEN** the broadcast message SHALL include the same `builtinRoleNames` array
+- **AND** the client `roles_list` handler SHALL write `builtinRoleNames` into the `roles` plugin config
+- **AND** the Roles settings panel SHALL render the Built-in/Custom groups and the "＋ Add custom role" control

--- a/openspec/changes/archive/2026-07-13-fix-builtin-role-names-relay/tasks.md
+++ b/openspec/changes/archive/2026-07-13-fix-builtin-role-names-relay/tasks.md
@@ -1,0 +1,29 @@
+# Tasks
+
+## 1. Regression tests first (TDD — write, watch fail)
+
+- [x] 1.1 Server relay test: in `packages/server/src/__tests__/`, feed a bridge `roles_list` message carrying `builtinRoleNames: ["planning","coding","compact","fast","vision","research"]` through the `event-wiring` handler and assert the broadcast to browser clients includes the same `builtinRoleNames` array. → verify: fails against current source (field dropped).
+- [x] 1.2 Client handler test: in `packages/client/src/hooks/__tests__/` (or the existing `useMessageHandler` test), dispatch a `roles_list` message with `builtinRoleNames` and assert `getPluginConfig("roles").builtinRoleNames` equals the array. → verify: fails against current source.
+
+## 2. Shared protocol type
+
+- [x] 2.1 `packages/shared/src/browser-protocol.ts` — add `builtinRoleNames?: string[];` to `BrowserRolesListMessage` (mirror the optional field on `RolesListMessage` in `protocol.ts`). → verify: `tsc --noEmit` clean.
+
+## 3. Server relay
+
+- [x] 3.1 `packages/server/src/event-wiring.ts` (`roles_list` broadcast, ~line 1330) — add `builtinRoleNames: (msg as any).builtinRoleNames,` to the `broadcastToAll` payload. → verify: task 1.1 passes.
+
+## 4. Client handler
+
+- [x] 4.1 `packages/client/src/hooks/useMessageHandler.ts` (`roles_list` case, ~line 508) — add `builtinRoleNames: msg.builtinRoleNames` to the `roleInfo` object. → verify: task 1.2 passes.
+
+## Tests
+
+- [x] T.1 `npm test` green (new relay + handler tests included). → verify: tee→grep shows no FAIL.
+- [x] T.2 Full suite type-check clean (`npm run quality:changed` or `tsc --noEmit`).
+
+## Validate
+
+- [x] V.1 Deploy: `npm run build` → `curl -X POST http://localhost:8000/api/restart` → `npm run reload` (client rebuild + server restart + bridge reload).
+- [x] V.2 Manual (web dashboard): VERIFIED in system browser against live :8000 after deploy — ROLES shows Built-in group (@planning @coding @compact @fast @vision @research), Custom group (@review-model-1/2/3 with × remove), and "＋ Add custom role". builtinRoleNames now survives bridge→server→client.
+- [x] V.3 Playwright e2e regression guard: `tests/e2e/roles-custom.spec.ts` (L3) — PASSED in system Chrome (PW_CHANNEL=chrome) against the Docker harness on local code (1 passed, 13.2s). — spawn a session, open `/settings/general`, assert `roles-group-builtin` (contains `@fast`) + `roles-group-custom` + `roles-add-custom` render and the add-custom flow reaches the model picker. Run in system browser: pre-build the per-worktree image, then `PW_CHANNEL=chrome npx playwright test roles-custom`. Settings → General → ROLES now shows **Built-in** and **Custom** group headers and a **"＋ Add custom role"** button. Adding `@myrole`, picking a model, and Save persists it; the × removes it. (Playwright e2e for this lives with the `add-custom-roles-ui` scenarios — extend there if a rendered-UI assertion is wanted.)

--- a/openspec/specs/dashboard-roles-ownership/spec.md
+++ b/openspec/specs/dashboard-roles-ownership/spec.md
@@ -192,11 +192,21 @@ The dashboard extension SHALL register listeners for five dashboard-owned role e
 
 The `roles:get-all` response (and the `roles_list` WebSocket payload the bridge forwards to the client) SHALL include a `builtinRoleNames: string[]` field equal to `DEFAULT_ROLE_NAMES`. This lets the human UI classify each role as Built-in or Custom without duplicating the default-name constant in the client. The field SHALL be additive; consumers that do not read it SHALL be unaffected.
 
+The field SHALL survive the full relay to the browser. The server's `roles_list` re-broadcast to browser clients SHALL forward `builtinRoleNames`, and the browser-facing `roles_list` message type SHALL carry it. The client's `roles_list` handler SHALL write `builtinRoleNames` into the roles plugin config so the Roles settings panel can render the Built-in/Custom split and the "＋ Add custom role" control. A relay hop that omits the field is a defect, since it collapses the UI to the flat back-compat layout and makes custom roles unreachable.
+
 #### Scenario: builtinRoleNames mirrors DEFAULT_ROLE_NAMES
 
 - **GIVEN** the Roles back-end responds to `roles:get-all`
 - **THEN** the response SHALL include `builtinRoleNames` equal to `["planning", "coding", "compact", "fast", "vision", "research"]`
 - **AND** the field SHALL be present regardless of how many roles have assigned models
+
+#### Scenario: builtinRoleNames survives the server→browser relay
+
+- **GIVEN** the bridge emits a `roles_list` message carrying `builtinRoleNames`
+- **WHEN** the server re-broadcasts `roles_list` to browser clients
+- **THEN** the broadcast message SHALL include the same `builtinRoleNames` array
+- **AND** the client `roles_list` handler SHALL write `builtinRoleNames` into the `roles` plugin config
+- **AND** the Roles settings panel SHALL render the Built-in/Custom groups and the "＋ Add custom role" control
 
 ### Requirement: A `role_remove` message SHALL purge a custom role from the schema and every preset
 

--- a/packages/client/src/hooks/__tests__/useMessageHandler.roles-builtin.test.tsx
+++ b/packages/client/src/hooks/__tests__/useMessageHandler.roles-builtin.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Regression for change: fix-builtin-role-names-relay.
+ *
+ * The `roles_list` handler MUST carry `builtinRoleNames` into the roles
+ * plugin config. BuiltInRolesSettings reads `cfg.builtinRoleNames` to render
+ * the Built-in/Custom split and the "＋ Add custom role" control; dropping it
+ * here collapses the panel to the flat back-compat layout.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useMessageHandler } from "../useMessageHandler.js";
+import { type SessionState } from "../../lib/event-reducer.js";
+import { getPluginConfig } from "@blackbelt-technology/dashboard-plugin-runtime/context";
+import type { ServerToBrowserMessage } from "@blackbelt-technology/pi-dashboard-shared/browser-protocol.js";
+
+function setup() {
+  const sessionStatesRef = { current: new Map<string, SessionState>() };
+  const setSessionStates = vi.fn((updater: any) => {
+    sessionStatesRef.current =
+      typeof updater === "function" ? updater(sessionStatesRef.current) : updater;
+  });
+  const setters: any = {
+    setSessions: vi.fn(), setSessionStates, setSessionCommands: vi.fn(), setSessionFlows: vi.fn(),
+    setFileResults: vi.fn(), setOpenspecMap: vi.fn(), setModelsMap: vi.fn(), setRolesMap: vi.fn(),
+    setSpawnResult: vi.fn(), setSessionOrderMap: vi.fn(), setPinnedDirectories: vi.fn(),
+    setFavoriteModels: vi.fn(), setTerminals: vi.fn(), setEditorStatuses: vi.fn(),
+    setDiscoveredServers: vi.fn(), setSpawnErrors: vi.fn(), setResumeErrors: vi.fn(),
+    setLoadingHistory: vi.fn(),
+  };
+  const deps: any = {
+    send: vi.fn(), navigate: vi.fn(), clearSpawningCwd: vi.fn(),
+    spawningCwdsRef: { current: new Set() }, subscribedRef: { current: new Set() },
+    pendingTerminalCwdRef: { current: null }, lastCreatedTerminalIdRef: { current: null },
+    maxSeqMapRef: { current: new Map() }, selectedSessionIdRef: { current: undefined },
+    loadingHistoryTimersRef: { current: new Map() },
+  };
+  const { result } = renderHook(() => useMessageHandler(setters, deps));
+  return { dispatch: (msg: ServerToBrowserMessage) => result.current(msg) };
+}
+
+describe("useMessageHandler roles_list → builtinRoleNames", () => {
+  it("writes builtinRoleNames into the roles plugin config", () => {
+    const { dispatch } = setup();
+    const builtin = ["planning", "coding", "compact", "fast", "vision", "research"];
+
+    dispatch({
+      type: "roles_list",
+      sessionId: "s1",
+      roles: { fast: "deepseek/deepseek-v4-flash" },
+      presets: [],
+      activePreset: null,
+      builtinRoleNames: builtin,
+    } as unknown as ServerToBrowserMessage);
+
+    const cfg = getPluginConfig("roles");
+    expect(cfg.builtinRoleNames).toEqual(builtin);
+    expect(cfg.roles).toEqual({ fast: "deepseek/deepseek-v4-flash" });
+  });
+});

--- a/packages/client/src/hooks/useMessageHandler.ts
+++ b/packages/client/src/hooks/useMessageHandler.ts
@@ -519,6 +519,12 @@ export function useMessageHandler(
           roles: msg.roles,
           presets: msg.presets,
           activePreset: msg.activePreset,
+          // Carry the built-in role-name set into the roles plugin config so
+          // BuiltInRolesSettings renders the Built-in/Custom split and the
+          // "＋ Add custom role" control. Dropping it here (the original defect)
+          // forced the flat back-compat layout.
+          // See change: fix-builtin-role-names-relay.
+          builtinRoleNames: msg.builtinRoleNames,
         };
         setRolesMap((prev) => {
           const next = new Map(prev);

--- a/packages/server/src/__tests__/event-wiring-roles-list-builtin.test.ts
+++ b/packages/server/src/__tests__/event-wiring-roles-list-builtin.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression: the server's `roles_list` re-broadcast to browser clients MUST
+ * forward `builtinRoleNames` end-to-end. The bridge attaches it (source of
+ * truth = DEFAULT_ROLE_NAMES); dropping it on the relay collapses the Roles
+ * settings panel to its flat back-compat render and makes custom roles
+ * (@fast-style) unreachable in the UI.
+ *
+ * See change: fix-builtin-role-names-relay.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { WebSocket } from "ws";
+import { createServer, type DashboardServer } from "../server.js";
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function connectSession(piPort: number, sessionId: string): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${piPort}`);
+  await new Promise<void>((resolve) => {
+    ws.on("open", () => {
+      ws.send(JSON.stringify({
+        type: "session_register",
+        sessionId,
+        cwd: "/tmp",
+        source: "cli",
+      }));
+      ws.send(JSON.stringify({ type: "replay_complete", sessionId }));
+      setTimeout(resolve, 60);
+    });
+  });
+  return ws;
+}
+
+describe("roles_list — server relay preserves builtinRoleNames", () => {
+  let server: DashboardServer;
+  let piPort: number;
+  let browserPort: number;
+
+  beforeEach(async () => {
+    server = await createServer({
+      port: 0,
+      piPort: 0,
+      host: "127.0.0.1",
+      dev: true,
+      autoShutdown: false,
+      shutdownIdleSeconds: 999,
+      tunnel: false,
+      editor: { idleTimeoutMinutes: 10, maxInstances: 3 },
+    });
+    await server.start();
+    browserPort = server.httpPort()!;
+    piPort = server.piPort()!;
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it("forwards builtinRoleNames from the bridge roles_list to browser clients", async () => {
+    const piWs = await connectSession(piPort, "r1");
+    const browserWs = new WebSocket(`ws://127.0.0.1:${browserPort}/ws`);
+    const browserMessages: any[] = [];
+    await new Promise<void>((resolve) => browserWs.on("open", () => resolve()));
+    browserWs.on("message", (raw) => {
+      try {
+        browserMessages.push(JSON.parse(raw.toString()));
+      } catch { /* ignore */ }
+    });
+    await wait(80);
+    browserMessages.length = 0;
+
+    const builtin = ["planning", "coding", "compact", "fast", "vision", "research"];
+    piWs.send(JSON.stringify({
+      type: "roles_list",
+      sessionId: "r1",
+      roles: { fast: "deepseek/deepseek-v4-flash" },
+      presets: [],
+      activePreset: null,
+      builtinRoleNames: builtin,
+    }));
+
+    await wait(80);
+
+    const rolesList = browserMessages.find((m) => m.type === "roles_list");
+    expect(rolesList).toBeDefined();
+    expect(rolesList.builtinRoleNames).toEqual(builtin);
+    expect(rolesList.roles).toEqual({ fast: "deepseek/deepseek-v4-flash" });
+
+    piWs.close();
+    browserWs.close();
+  });
+});

--- a/packages/server/src/event-wiring.ts
+++ b/packages/server/src/event-wiring.ts
@@ -1332,6 +1332,11 @@ export function wireEvents(deps: EventWiringDeps): void {
         roles: (msg as any).roles,
         presets: (msg as any).presets,
         activePreset: (msg as any).activePreset,
+        // Forward the built-in role-name set so the Roles panel can render the
+        // Built-in/Custom split + "＋ Add custom role". Dropping it here (the
+        // original defect) collapsed the panel to its flat back-compat render.
+        // See change: fix-builtin-role-names-relay.
+        builtinRoleNames: (msg as any).builtinRoleNames,
       } as any);
     }
 

--- a/packages/shared/src/browser-protocol.ts
+++ b/packages/shared/src/browser-protocol.ts
@@ -208,6 +208,14 @@ export interface BrowserRolesListMessage {
   roles: Record<string, string>;
   presets: Array<{ name: string; roles: Record<string, string> }>;
   activePreset: string | null;
+  /**
+   * Built-in (seeded default) role names, equal to `DEFAULT_ROLE_NAMES`.
+   * Forwarded verbatim from the bridge's `roles_list`. The Roles panel reads
+   * it to split roles into Built-in vs Custom and to show "＋ Add custom role".
+   * Additive/optional; older clients ignore it.
+   * See change: fix-builtin-role-names-relay.
+   */
+  builtinRoleNames?: string[];
 }
 
 export interface SessionsListBrowserMessage {

--- a/tests/e2e/roles-custom.spec.ts
+++ b/tests/e2e/roles-custom.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+import { spawnFreshGitSession } from "./helpers/index.js";
+
+// L3 regression for change: fix-builtin-role-names-relay.
+//
+// Guards the full bridge→server→client relay of `builtinRoleNames`. The bridge
+// attaches it to every `roles_list`; the server re-broadcast (event-wiring.ts)
+// and the client handler (useMessageHandler.ts) must both preserve it. When
+// either hop drops the field, the Roles panel collapses to its flat
+// back-compat render — no Built-in/Custom grouping and no "＋ Add custom role"
+// control — which is exactly the defect this change fixes.
+//
+// Transport: `builtinRoleNames` only reaches the browser once a live pi session
+// exists (App.tsx sends `request_roles` through the first non-ended session).
+// spawnFreshGitSession provides that session; the container's bridge seeds the
+// canonical DEFAULT_ROLE_NAMES set regardless of credential validity.
+//
+// Selects on existing app data-testids shipped by RolesSettingsSection
+// (roles-settings / roles-group-builtin / roles-group-custom / roles-add-custom
+// / roles-add-custom-input / roles-add-custom-confirm / roles-model-picker) —
+// no new app testids added.
+test.describe("custom roles UI (L3: builtinRoleNames relay)", () => {
+  test("Built-in/Custom groups + Add custom role render (field survives the relay)", async ({
+    page,
+  }) => {
+    // A live session is the transport for request_roles → roles_list.
+    await spawnFreshGitSession(page);
+
+    // General tab hosts the Roles settings section (canonical route).
+    await page.goto("/settings/general");
+
+    const roles = page.getByTestId("roles-settings");
+    await expect(roles).toBeVisible({ timeout: 30_000 });
+
+    // The split render only appears when builtinRoleNames arrived non-empty.
+    // If the relay dropped it, these are absent (flat back-compat layout).
+    const builtinGroup = page.getByTestId("roles-group-builtin");
+    await expect(builtinGroup).toBeVisible({ timeout: 30_000 });
+    // A canonical built-in pill proves the classification, not just presence.
+    await expect(builtinGroup).toContainText("@fast");
+
+    await expect(page.getByTestId("roles-group-custom")).toBeVisible();
+
+    // The previously-missing control — its existence is the user-facing payoff.
+    const addBtn = page.getByTestId("roles-add-custom");
+    await expect(addBtn).toBeVisible();
+
+    // Exercise the add-custom-role affordance up to the model picker WITHOUT
+    // persisting (keeps the shared container's providers.json untouched).
+    await addBtn.click();
+    const nameInput = page.getByTestId("roles-add-custom-input");
+    await expect(nameInput).toBeVisible();
+    await nameInput.fill("e2e-relay-check");
+    await page.getByTestId("roles-add-custom-confirm").click();
+
+    // Confirming a valid, non-colliding name opens the scoped model picker.
+    await expect(page.getByTestId("roles-model-picker")).toBeVisible({ timeout: 15_000 });
+  });
+});


### PR DESCRIPTION
Implements OpenSpec change `fix-builtin-role-names-relay`.

## Problem
The custom-roles UI (`add-custom-roles-ui`, #282) never rendered on the dashboard — no Built-in/Custom groups, no "＋ Add custom role" for `@fast`-style roles. Root cause: `builtinRoleNames` was dropped at **both** server→browser relay hops, violating the `dashboard-roles-ownership` requirement that the field reach the client.

## Fix (additive)
- `packages/shared/src/browser-protocol.ts` — `BrowserRolesListMessage.builtinRoleNames?`
- `packages/server/src/event-wiring.ts` — forward it in the `roles_list` broadcast
- `packages/client/src/hooks/useMessageHandler.ts` — carry it into the roles plugin config

## Tests
- Server relay regression (`event-wiring-roles-list-builtin.test.ts`) — full bridge→server→browser round trip
- Client handler regression (`useMessageHandler.roles-builtin.test.tsx`)
- Playwright e2e (`tests/e2e/roles-custom.spec.ts`) — asserts Built-in/Custom groups + Add-custom flow in a real browser
- Full vitest suite green (9925 passed)

QA/manual tasks verified pre-merge (live dashboard + system-Chrome e2e against the Docker harness).
