### PR TITLE
fix(client): confirm display preferences persist

### DIFF
--- a/packages/client/src/__tests__/FirstLaunchDisplayModal.test.tsx
+++ b/packages/client/src/__tests__/FirstLaunchDisplayModal.test.tsx
@@ -2,17 +2,20 @@
  * Tests for FirstLaunchDisplayModal — preset PATCH on submit, default-to-
  * standard on dismiss. See change: configurable-chat-display.
  */
-import React from "react";
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
-import { FirstLaunchDisplayModal } from "../components/FirstLaunchDisplayModal.js";
+
 import { DISPLAY_PRESETS } from "@blackbelt-technology/pi-dashboard-shared/display-prefs.js";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FirstLaunchDisplayModal } from "../components/FirstLaunchDisplayModal.js";
 
 describe("FirstLaunchDisplayModal", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    fetchMock = vi.fn().mockImplementation(async (_url, init) => ({
+      ok: true,
+      json: async () => ({ displayPrefs: JSON.parse(init.body as string) }),
+    }));
     (globalThis as any).fetch = fetchMock;
   });
 
@@ -43,21 +46,63 @@ describe("FirstLaunchDisplayModal", () => {
     await waitFor(() => expect(onClose).toHaveBeenCalledWith(merged));
   });
 
-  it("closes with the preset prefs even when the PATCH returns non-2xx", async () => {
+  it("keeps the modal open when the PATCH returns non-2xx", async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
     const onClose = vi.fn();
     render(<FirstLaunchDisplayModal apiBase="" onClose={onClose} />);
     fireEvent.click(screen.getByDisplayValue("everything"));
     fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
-    await waitFor(() => expect(onClose).toHaveBeenCalledWith(DISPLAY_PRESETS.everything));
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/couldn't save/i));
+    expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("closes with the preset prefs even when fetch rejects", async () => {
+  it("keeps the modal open when a version-skewed server returns the SPA HTML", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => { throw new SyntaxError("Unexpected token '<'"); },
+    });
+    const onClose = vi.fn();
+    render(<FirstLaunchDisplayModal apiBase="" onClose={onClose} />);
+    fireEvent.click(screen.getByDisplayValue("everything"));
+    fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/dashboard version/i));
+    expect(onClose).not.toHaveBeenCalled();
+    expect((screen.getByDisplayValue("everything") as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("keeps the modal open when fetch rejects", async () => {
     fetchMock.mockRejectedValue(new Error("network down"));
     const onClose = vi.fn();
     render(<FirstLaunchDisplayModal apiBase="" onClose={onClose} />);
     fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
-    await waitFor(() => expect(onClose).toHaveBeenCalledWith(DISPLAY_PRESETS.standard));
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/couldn't save/i));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps the modal open when the response contains malformed preferences", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ displayPrefs: { tokenStatsBar: true, toolCalls: null } }),
+    });
+    const onClose = vi.fn();
+    render(<FirstLaunchDisplayModal apiBase="" onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("ignores Escape while a preset save is pending", async () => {
+    let resolveFetch: ((value: unknown) => void) | undefined;
+    fetchMock.mockImplementation(() => new Promise((resolve) => { resolveFetch = resolve; }));
+    const onClose = vi.fn();
+    render(<FirstLaunchDisplayModal apiBase="" onClose={onClose} />);
+    fireEvent.click(screen.getByDisplayValue("everything"));
+    fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    resolveFetch?.({ ok: true, json: async () => ({ displayPrefs: DISPLAY_PRESETS.everything }) });
+    await waitFor(() => expect(onClose).toHaveBeenCalledWith(DISPLAY_PRESETS.everything));
   });
 
   it("PATCHes standard on Skip dismissal", async () => {

--- a/packages/client/src/components/FirstLaunchDisplayModal.tsx
+++ b/packages/client/src/components/FirstLaunchDisplayModal.tsx
@@ -4,10 +4,9 @@
  * three presets (`simple` | `standard` | `everything`); on dismiss the
  * client PATCHes `standard` so the modal does not re-open.
  *
- * `seed()` closes the modal optimistically from local state: it applies the
- * chosen preset and calls `onClose(prefs)` on EVERY path (PATCH 200, non-2xx,
- * thrown fetch), so a dropped/failed WS broadcast never strands the modal.
- * The 200 body `{ displayPrefs }`, when readable, refines the passed value.
+ * `seed()` closes only after the PATCH response confirms the persisted
+ * `displayPrefs`. Failed or incompatible responses leave the selected preset
+ * in place and show an actionable error.
  *
  * See change: configurable-chat-display, fix-first-launch-display-modal-stuck-on-mobile.
  */
@@ -35,12 +34,11 @@ export function FirstLaunchDisplayModal({
 }): React.ReactElement {
   const [choice, setChoice] = useState<PresetKey>("standard");
   const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(false);
 
   const seed = useCallback(async (key: PresetKey) => {
     setSubmitting(true);
-    // Source of truth is the chosen preset — the modal closes even if the
-    // PATCH never completes. The 200 body may refine it (server deep-merges).
-    let prefs = DISPLAY_PRESETS[key] as DisplayPrefs;
+    setError(false);
     try {
       const r = await fetch(`${apiBase}/api/preferences/display`, {
         method: "PATCH",
@@ -48,17 +46,28 @@ export function FirstLaunchDisplayModal({
         body: JSON.stringify(DISPLAY_PRESETS[key] as DisplayPrefs),
         credentials: "include",
       });
-      if (r.ok) {
-        const body = await r.json().catch(() => undefined) as { displayPrefs?: DisplayPrefs } | undefined;
-        if (body?.displayPrefs) prefs = body.displayPrefs;
+      if (!r.ok) throw new Error();
+      const body = await r.json() as { displayPrefs?: DisplayPrefs };
+      if (
+        !body.displayPrefs ||
+        typeof body.displayPrefs.tokenStatsBar !== "boolean" ||
+        !body.displayPrefs.toolCalls ||
+        Array.isArray(body.displayPrefs.toolCalls)
+      ) {
+        throw new Error();
       }
-    } catch { /* keep preset prefs; close unconditionally below */ }
-    setSubmitting(false);
-    onClose(prefs);
+      onClose(body.displayPrefs);
+    } catch {
+      setError(true);
+    } finally {
+      setSubmitting(false);
+    }
   }, [apiBase, onClose]);
 
   // Dismissal (Esc / backdrop) seeds `standard` — same as picking it.
-  const dismiss = useCallback(() => { void seed("standard"); }, [seed]);
+  const dismiss = useCallback(() => {
+    if (!submitting) void seed("standard");
+  }, [seed, submitting]);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -112,6 +121,15 @@ export function FirstLaunchDisplayModal({
               </label>
             ))}
           </div>
+          {error && (
+            <p role="alert" className="mt-3 text-xs text-red-400">
+              {i18nT(
+                "session.chatDisplaySaveFailed",
+                undefined,
+                "Couldn't save this preference. Check your connection and dashboard version, then try again.",
+              )}
+            </p>
+          )}
           <div className="mt-5 flex justify-end gap-2">
             <button
               type="button"


### PR DESCRIPTION
## Summary

Keep the first-launch chat display modal open until `PATCH /api/preferences/display` returns a valid persisted `displayPrefs` payload.

This prevents **Show everything** from appearing to succeed locally while remaining unset on the server. The modal preserves the selected option and shows an actionable error when the request fails or an incompatible/version-skewed server returns the SPA HTML.

## Context and root cause

Related: #255 fixed the modal depending on a WebSocket echo by closing optimistically from the selected preset. That removed the mobile deadlock, but it also made a failed or incompatible PATCH indistinguishable from a persisted preference.

The observed deployment had a newer web bundle served by the published `0.5.4` server. That server does not expose `/api/preferences/display`, so the SPA fallback returned `200 text/html`. `FirstLaunchDisplayModal.seed()` ignored the unreadable/missing response body and still called `onClose()` with local values. The next page load had no persisted preference and reopened the prompt.

Affected symbols:

- `packages/client/src/components/FirstLaunchDisplayModal.tsx#seed`
- `packages/client/src/__tests__/FirstLaunchDisplayModal.test.tsx`

## Reproduction

1. Render `FirstLaunchDisplayModal` with a fetch implementation that resolves `ok: true` but whose JSON parser throws, matching a `200` SPA HTML fallback.
2. Select **Show everything** and press **Continue**.
3. Before this patch, `onClose(DISPLAY_PRESETS.everything)` ran even though the server never confirmed persistence.
4. Reloading fetched no stored preference, so the modal appeared again.

The same false success occurred for a rejected fetch and non-2xx response.

## Fix

- Parse and validate the successful PATCH response before calling `onClose`.
- Keep the modal and selected preset visible when persistence is not confirmed.
- Show an inline `role="alert"` message with connection/version guidance.
- Suppress Escape/backdrop dismissal while a save is pending, preventing a concurrent fallback PATCH for `standard` from racing the selected preset.

This is intentionally client-only. It does not add retries, alter the server contract, or change stored preference schemas.

## Automated tests

Added/updated focused coverage for valid persistence, non-2xx, SPA HTML/version skew, rejected fetch, malformed preferences, and Escape during an in-flight save.

Commands run:

- `npm test -- packages/client/src/__tests__/FirstLaunchDisplayModal.test.tsx` — **passed, 10 tests**
- `./node_modules/.bin/tsc --noEmit` — **passed**
- `npm run i18n:parity` — **passed**
- `npm run i18n:lint` — **passed for this change**; one pre-existing `FolderActionBar.tsx` candidate remains
- `npm run build` — **passed**
- `npm test` — attempted twice, but the repository-wide run did not complete cleanly due unrelated infrastructure/baseline failures: Vitest package files disappeared during worker execution, faux-session registration timed out, and existing goal-supervisor/pi-changelog assertions failed. The touched focused suite remained green.

## Production and rollout instructions

Trigger: a PATCH failure, network interruption, or web/server version skew during first-launch preference selection.

User-visible impact: the modal stays open with an error instead of falsely reporting success. The selected preset remains selected for retry.

No migration or configuration change is required. Deploy the web client and server from the same revision, rebuild the client, and restart the dashboard service. Validate by selecting **Show everything**, reloading, and confirming the modal does not return. Roll back by reverting this commit and rebuilding the client.

## Maintainer self-fix prompt

If you would rather reproduce and implement this independently, this prompt captures the observed contract and acceptance criteria:

```text
Read every applicable contributor and agent instruction in this repository before editing. Reproduce the false-success first-launch display preference behavior on current develop by inspecting FirstLaunchDisplayModal.seed() and the PATCH /api/preferences/display contract. Add a focused failing regression test where a version-skewed server returns HTTP 200 with SPA HTML (JSON parsing fails) after the user selects Show everything. The modal must not call onClose unless the response contains a valid persisted displayPrefs object; failed, malformed, and non-2xx responses must keep the selected option visible and show an actionable accessible error. Also verify that Escape/backdrop dismissal cannot race an in-flight save with a second standard-preset request. Implement the smallest change in FirstLaunchDisplayModal.tsx and its focused test file without retries, server changes, unrelated refactoring, or dependency additions. Run the focused red/green test, TypeScript check, i18n checks, production build, and the repository's full automated suite. Report all results and keep the diff limited to the client modal and its regression tests.
```
