### PR TITLE
fix(test): unbreak develop CI — recovery-server is not a Column C runtime path

### DIFF
--- a/packages/server/src/__tests__/recovery-server.test.ts
+++ b/packages/server/src/__tests__/recovery-server.test.ts
@@ -107,6 +107,21 @@ describe("suggestedReinstallCommand", () => {
     const cli = path.join(root, "packages", "server", "src", "cli.ts");
     expect(suggestedReinstallCommand("monorepo", cli).startsWith("npm install")).toBe(true);
   });
+
+  // Column C intent (change: adopt-pnpm-for-dev-ci, X3), asserted behaviourally
+  // here instead of by the source-text guard in pnpm-migration-contract.test.ts:
+  // END-USER layouts run where pnpm does not exist, so they must never be told
+  // to run it. Only the `monorepo` layout may resolve to pnpm, and only behind
+  // the workspace probe above. Passing a pnpm-workspace-rooted scriptPath must
+  // NOT leak pnpm into a non-monorepo layout.
+  it("never suggests pnpm for end-user layouts, even from a pnpm workspace path", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "rec-enduser-"));
+    fs.writeFileSync(path.join(root, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+    const cli = path.join(root, "packages", "server", "src", "cli.ts");
+    for (const layout of ["npm-global", "electron", "unknown"] as const) {
+      expect(suggestedReinstallCommand(layout, cli)).not.toMatch(/\bpnpm\b/);
+    }
+  });
 });
 
 describe("detectPackageManager", () => {

--- a/packages/shared/src/__tests__/pnpm-migration-contract.test.ts
+++ b/packages/shared/src/__tests__/pnpm-migration-contract.test.ts
@@ -78,10 +78,11 @@ describe("X3 — runtime pi-core installs stay npm (never pnpm)", () => {
   // pnpm, but only behind an explicit workspace probe: `detectPackageManager`
   // returns "pnpm" solely when `pnpm-workspace.yaml` / `pnpm-lock.yaml` sits at
   // the resolved repo root, and `suggestedReinstallCommand` consults it ONLY
-  // for the `monorepo` layout. The end-user layouts (`npm-global`, `electron`,
-  // and the default fallback) still return npm, so the Column C premise — "runs
-  // on an end-user machine, where pnpm is not present" — does not hold for that
-  // reference. Blanket-guarding it would force `npm install` onto a pnpm
+  // for the `monorepo` layout. The end-user layouts never reach it: `npm-global`
+  // and the default fallback return an npm command, and `electron` returns an
+  // installer message with no package manager at all. So the Column C premise —
+  // "runs on an end-user machine, where pnpm is not present" — does not hold for
+  // that reference. Blanket-guarding it would force `npm install` onto a pnpm
   // hoisted workspace, which is exactly the tree-corrupting bug
   // `recovery-server-respect-package-manager` fixed.
   const columnC = [

--- a/packages/shared/src/__tests__/pnpm-migration-contract.test.ts
+++ b/packages/shared/src/__tests__/pnpm-migration-contract.test.ts
@@ -74,10 +74,19 @@ describe("E4 — pnpm-lock.yaml is the single committed lockfile", () => {
 // `npm install` (npm ships in Node). These MUST NOT be rewritten to pnpm.
 // `"pnpm".includes("npm")` is true, so npm-presence uses a word boundary.
 describe("X3 — runtime pi-core installs stay npm (never pnpm)", () => {
+  // `recovery-server.ts` is deliberately NOT in this list. It DOES reference
+  // pnpm, but only behind an explicit workspace probe: `detectPackageManager`
+  // returns "pnpm" solely when `pnpm-workspace.yaml` / `pnpm-lock.yaml` sits at
+  // the resolved repo root, and `suggestedReinstallCommand` consults it ONLY
+  // for the `monorepo` layout. The end-user layouts (`npm-global`, `electron`,
+  // and the default fallback) still return npm, so the Column C premise — "runs
+  // on an end-user machine, where pnpm is not present" — does not hold for that
+  // reference. Blanket-guarding it would force `npm install` onto a pnpm
+  // hoisted workspace, which is exactly the tree-corrupting bug
+  // `recovery-server-respect-package-manager` fixed.
   const columnC = [
     "packages/server/src/pi/pi-core-updater.ts",
     "packages/server/src/pi/pi-core-checker.ts",
-    "packages/server/src/lifecycle/recovery-server.ts",
     "packages/electron/src/lib/update-checker.ts",
   ];
   for (const file of columnC) {


### PR DESCRIPTION
`develop` CI has been red for its last runs. This restores it.

## Cause

`cf18e682` ("fix(recovery): reinstall with the repo's own package manager, not always npm") added `detectPackageManager()` to `packages/server/src/lifecycle/recovery-server.ts`. That file now references `pnpm`, which trips the **X3** source-text guard in `pnpm-migration-contract.test.ts` — it asserts every "Column C" runtime-install file references `npm` and never `pnpm`, because those paths run on end-user machines where pnpm isn't installed.

## Why the guard's premise doesn't hold here

`detectPackageManager()` returns `"pnpm"` **only** when `pnpm-workspace.yaml` / `pnpm-lock.yaml` sits at the resolved repo root, and `suggestedReinstallCommand()` consults it **only** for the `monorepo` layout:

```ts
case "npm-global": return "npm install -g @blackbelt-technology/pi-agent-dashboard";
case "electron":   return "Reinstall the Pi Dashboard application from your installer.";
case "monorepo":   { const pm = root ? detectPackageManager(root) : "npm"; ... }
default:           return "npm install -g @blackbelt-technology/pi-agent-dashboard";
```

Every end-user layout still returns npm. Keeping this file under the blanket guard would force `npm install` onto a pnpm hoisted workspace — precisely the tree corruption (`lru-cache@6` shadowing v11 → "LRUCache is not a constructor") that `recovery-server-respect-package-manager` fixed.

## Change

- Drop `recovery-server.ts` from `columnC`, with the rationale inline so the next reader doesn't "restore" it.
- **Replace the lost coverage rather than just deleting it.** New behavioural test in `recovery-server.test.ts`: end-user layouts (`npm-global`, `electron`, `unknown`) never suggest pnpm, *even when `scriptPath` points inside a pnpm workspace*. That asserts X3's actual intent instead of the source-text proxy.

Verified the new test fails when a pnpm leak is injected into the `npm-global` branch:

```
AssertionError: expected 'pnpm install -g @blackbelt-technology…' not to match /\bpnpm\b/
```

The other three Column C entries (`pi-core-updater.ts`, `pi-core-checker.ts`, `update-checker.ts`) are untouched and still guarded.

Local: `pnpm-migration-contract` 45 passed, `recovery-server` 25 passed.

Unblocks #402.
