### PR TITLE
docs(openspec): sync retry-forever specs into main (deferred from #410)

### DIFF
--- a/openspec/specs/bridge-retry-observability/spec.md
+++ b/openspec/specs/bridge-retry-observability/spec.md
@@ -8,55 +8,136 @@ pi-coding-agent owns its provider-retry policy and exposes NO `auto_retry_*` eve
 
 ### Requirement: Synthesize retry lifecycle from observed events
 
-The bridge SHALL synthesize `auto_retry_start` and `auto_retry_end` events by observing pi's `message_start`, `message_end`, and `agent_end` sequence, never by predicting retries from error text. A retry is confirmed only when pi actually starts a fresh attempt; nothing is emitted on the failing message alone.
+The bridge SHALL synthesize `auto_retry_start` and `auto_retry_end` by observing pi's real
+event sequence, never by predicting retries from error text.
 
-#### Scenario: Error message_end records a pending failure silently
+**The observation model is corrected here.** pi does NOT keep a retry chain inside one agent
+turn. Every attempt is a complete `agent_start` … `agent_end` cycle, and exactly one
+`agent_settled` fires after the final `agent_end`. The prior model — "error `message_end`, then
+a fresh assistant `message_start` in the same turn" — never matches, so the bridge synthesized
+NOTHING and the retry surface was dead. The corrected rules are:
 
-- WHEN an assistant `message_end` with `stopReason` `error` is observed for a session
-- THEN the bridge records the error message as a pending failure for that session
-- AND emits NO synthetic event yet, because the retry is not yet confirmed
+- An assistant `message_end` with `stopReason: "error"` SHALL record a pending failure for the
+  session. It SHALL NOT clear the chain.
+- An `agent_end` whose last message is an error SHALL be treated as **an attempt that ended
+  with another one coming**, NOT as terminal. It SHALL emit `auto_retry_start` for that attempt
+  and a **waiting signal**, and SHALL NOT clear the session's retry tracking.
+- `agent_settled` SHALL be the SOLE terminal signal. It SHALL close the chain with
+  `auto_retry_end` and clear all per-session retry tracking.
 
-#### Scenario: Fresh attempt confirms a retry
+`maxAttempts` and `delayMs` SHALL be derived read-only from pi's retry settings
+(`retry.maxRetries`, `retry.baseDelayMs`; defaults `3` and `2000` when absent), computing the
+delay as `baseDelayMs · 2^(attempt-1)` — pi's own arithmetic. When the settings cannot be read
+the bridge SHALL emit `delayMs: 0`, which the surface renders elapsed-only. The `-1` sentinels
+are REMOVED. The bridge SHALL NOT write pi's settings.
 
-- WHEN an assistant `message_start` is observed while a failure is pending for that session (no user prompt in between)
-- THEN the bridge emits `auto_retry_start` with a 1-based `attempt` counter, `errorMessage` carrying the recorded failure text, and sentinel `maxAttempts` `-1` and `delayMs` `-1`
-- AND clears the pending failure so the same failure is not re-counted
+**`agent_end.willRetry` SHALL NOT be relied upon.** pi 0.83 computes it, but only on the session
+(RPC/SDK) channel: `agent-session.js` line 353 emits `{ ...event, willRetry }` to session listeners
+while line 433 emits `{ type: "agent_end", messages }` to the extension runner, stripping it. The
+extension-facing `AgentEndEvent` type is `{type, messages}`; the only `willRetry` in extension types
+belongs to `session_before_compact` / `session_compact`. The bridge is an extension, so it SHALL
+synthesize from `agent_end` + the following `agent_start` + `agent_settled` instead.
 
-#### Scenario: Retry attempt counter increments across a chain
+pi's predicate is
+`settings.enabled && _retryAttempt < settings.maxRetries && _isRetryableError(lastAssistant)`. The
+bridge SHALL honor the first two conditions (both settings-readable) when deciding whether to emit a
+waiting signal, and SHALL NOT replicate `_isRetryableError` — duplicating pi's regex classifier is
+forbidden. Retryability therefore remains observed, never predicted.
 
-- WHEN a second error `message_end` then another assistant `message_start` occur in the same in-flight turn
-- THEN the emitted `auto_retry_start` carries `attempt` incremented to the next value for that session
+#### Scenario: Error agent_end emits a waiting signal instead of clearing the chain
 
-#### Scenario: Delay and max attempts are unknowable
+- **WHEN** an `agent_end` whose last message has `stopReason: "error"` is observed for a session
+- **THEN** the bridge SHALL emit a waiting signal carrying the attempt number, the computed
+  `delayMs`, the `errorMessage`, and `nextAttemptAt` equal to the `agent_end` timestamp plus
+  `delayMs`
+- **AND** the bridge SHALL NOT clear the session's pending failure or attempt counter
 
-- WHEN `auto_retry_start` is synthesized
-- THEN `maxAttempts` and `delayMs` are `-1` sentinels, because pi's retry settings are not exposed to the extension
+#### Scenario: Regression — pi's real event order produces retry events
+
+- **GIVEN** the observed sequence `agent_start → message_end(error) → agent_end` repeated three
+  times, followed by `agent_settled`
+- **WHEN** the bridge processes it
+- **THEN** at least one `auto_retry_start` SHALL be synthesized
+- **AND** exactly one `auto_retry_end` SHALL be synthesized
+
+#### Scenario: Attempt counter increments across the chain
+
+- **WHEN** a second error `agent_end` occurs for a session whose chain is already in flight
+- **THEN** the emitted attempt number SHALL be incremented to the next value
+- **AND** the emitted `delayMs` SHALL be `baseDelayMs · 2^(attempt-1)` for that attempt
+
+#### Scenario: agent_settled closes the chain
+
+- **GIVEN** a retry chain is in flight for a session
+- **WHEN** `agent_settled` is observed
+- **THEN** the bridge SHALL emit `auto_retry_end` exactly once
+- **AND** all per-session retry tracking SHALL be cleared
+
+#### Scenario: Delay and max attempts are computed, not sentinel
+
+- **WHEN** a retry event is synthesized for attempt 2 with pi's defaults in force
+- **THEN** `maxAttempts` SHALL be `3` and `delayMs` SHALL be `4000`
+- **AND** neither field SHALL be `-1`
+
+#### Scenario: Final attempt does not emit a spurious waiting signal
+
+- **GIVEN** `retry.maxRetries` is `3` and the chain has reached attempt `3`
+- **WHEN** the error `agent_end` for that attempt is observed
+- **THEN** the bridge SHALL NOT emit a waiting signal, because no further attempt will follow
+
+#### Scenario: Retry disabled suppresses the waiting signal entirely
+
+- **GIVEN** `retry.enabled` is `false`
+- **WHEN** an error `agent_end` is observed
+- **THEN** the bridge SHALL NOT emit a waiting signal, because pi will not retry at all
+- **AND** the error SHALL surface as an ordinary settled error
+
+#### Scenario: willRetry is not consumed from agent_end
+
+- **WHEN** the bridge processes an `agent_end`
+- **THEN** it SHALL NOT read a `willRetry` field from that event, because the extension channel
+  strips it
+- **AND** it SHALL NOT test the error text against any retryable pattern
+
+#### Scenario: Unreadable retry settings degrade to elapsed-only
+
+- **WHEN** pi's retry settings cannot be read
+- **THEN** the synthesized events SHALL carry `delayMs: 0`
+- **AND** the surface SHALL render an elapsed-only waiting state rather than a countdown
+
+#### Scenario: No regex gate on the error message
+
+- **GIVEN** an error `message_end` with `errorMessage: "prompt is too long"` (a string pi will
+  NOT retry)
+- **WHEN** `agent_settled` follows immediately after the `agent_end`
+- **THEN** the chain SHALL close as terminal — because no further attempt was observed, NOT
+  because a regex rejected the string
 
 ### Requirement: Close the retry chain on success or terminal error
 
-The bridge SHALL emit `auto_retry_end` exactly once per in-flight retry chain, distinguishing a successful resolution from a terminal error, and SHALL emit nothing for a failure pi never re-attempted.
+The bridge SHALL emit `auto_retry_end` exactly once per in-flight retry chain, distinguishing a
+successful resolution from a terminal error, and SHALL emit nothing for a failure pi never
+re-attempted. The terminal trigger is `agent_settled`, NOT `agent_end`, because `agent_end`
+fires once per attempt.
 
 #### Scenario: Retry resolves successfully
 
-- WHEN a non-error assistant `message_end` closes an in-flight retry chain
-- THEN the bridge emits `auto_retry_end` with `success` `true` and the last `attempt` number
-- AND clears the pending failure and the in-flight retry tracking for that session
+- **WHEN** a non-error assistant `message_end` closes an in-flight retry chain
+- **THEN** the bridge emits `auto_retry_end` with `success: true` and the last attempt number
+- **AND** clears the pending failure and the in-flight retry tracking for that session
 
 #### Scenario: Retry chain ends with a terminal error
 
-- WHEN `agent_end` fires while a retry chain is in flight AND the last message has `stopReason` `error`
-- THEN the bridge emits `auto_retry_end` with `success` `false`, the last `attempt`, and `finalError` carrying the terminal error message
-- AND this event is forwarded BEFORE `agent_end` so the dashboard clears the retry sub-line before the settled error renders
+- **WHEN** `agent_settled` fires while a retry chain is in flight AND the last message has
+  `stopReason: "error"`
+- **THEN** the bridge emits `auto_retry_end` with `success: false`, the last attempt, and
+  `finalError` carrying the terminal error message
 
-#### Scenario: agent_end with no in-flight chain emits nothing
+#### Scenario: agent_settled with no in-flight chain emits nothing
 
-- WHEN `agent_end` fires and no retry chain was in flight for that session
-- THEN the bridge synthesizes NO `auto_retry_end`, because a terminal error pi deemed non-retryable surfaces through the ordinary settled-error `agent_end` path
-
-#### Scenario: Non-error completion without an in-flight chain
-
-- WHEN a non-error assistant `message_end` is observed and no retry chain is in flight
-- THEN the bridge clears any stray pending failure and emits NO synthetic event
+- **WHEN** `agent_settled` fires and no retry chain was in flight for that session
+- **THEN** the bridge synthesizes NO `auto_retry_end`, because a terminal error pi deemed
+  non-retryable surfaces through the ordinary settled-error path
 
 ### Requirement: Forward synthetic retry events in the standard shape
 
@@ -74,28 +155,42 @@ The bridge SHALL forward each synthetic retry event to the dashboard using the s
 
 ### Requirement: Latch a user abort across a long provider backoff
 
-The bridge SHALL latch a user abort per session so that an abort issued during a long provider backoff — which outlives the 200 ms / 2 s persistent-abort scheduler — still stops pi when it wakes to resume the retry. The latch operates as abort-on-sight scoped to the aborted turn, using "no intervening user prompt" as the discriminator.
+The bridge SHALL latch a user abort per session so an abort issued during a provider backoff
+still stops pi. The latch operates as abort-on-sight scoped to the aborted turn, using "no
+intervening user prompt" as the discriminator.
+
+The latch is retained as defense-in-depth for interactive/TUI-attached sessions. For
+dashboard-spawned `--mode rpc` sessions it is belt-and-braces only: `ctx.abort()` resolves to
+`AgentSession.abort()`, which calls `abortRetry()` before `agent.abort()` and cancels the
+backoff sleep directly — measured at 2 ms during a 16 s sleep.
 
 #### Scenario: Abort latches before the abort call
 
-- WHEN a user abort arrives for a session
-- THEN the bridge sets the abort latch for that session BEFORE invoking `cachedCtx.abort()`
-- AND clears the retry attempt counter (via the tracker's abort note) so a subsequent `agent_end` does not double-emit `auto_retry_end` with `success` `true`
+- **WHEN** the bridge receives an `abort` command for a session
+- **THEN** the latch SHALL be set for that session before `cachedCtx.abort()` is invoked
+
+#### Scenario: Abort during a backoff stops the chain promptly
+
+- **GIVEN** a session is sleeping between retry attempts
+- **WHEN** the user aborts
+- **THEN** the retry chain SHALL terminate without waiting for the remaining backoff
+- **AND** the bridge SHALL close the chain with `auto_retry_end`
 
 #### Scenario: Aborted turn resuming is aborted again
 
-- WHEN the abort latch is set AND the bridge observes the aborted turn resuming — a fresh `agent_start`, or an assistant (non-user) `message_start` with no intervening user prompt
-- THEN the bridge issues a fresh `cachedCtx.abort()` to honor the latch when pi wakes from its backoff
+- **GIVEN** the latch is set for a session
+- **WHEN** the bridge observes the aborted turn resuming with no intervening user prompt
+- **THEN** the bridge SHALL call `cachedCtx.abort()` again to honor the latch
 
-#### Scenario: New user prompt clears the latch
+#### Scenario: Latch cleared by a new user prompt
 
-- WHEN a new user prompt is dispatched for the session (a user `message_start`, or send-prompt handling)
-- THEN the bridge clears the abort latch so the user's deliberate new turn is never aborted
+- **WHEN** a NEW user prompt is dispatched for the session
+- **THEN** the latch SHALL be cleared so the deliberate new turn is not killed
 
-#### Scenario: Settled turn clears the latch
+#### Scenario: Latch cleared on settle
 
-- WHEN the aborted turn settles at `agent_end`
-- THEN the bridge clears the abort latch so a later, unrelated turn is not aborted
+- **WHEN** the aborted turn settles (`agent_settled` / idle)
+- **THEN** the latch SHALL be cleared
 
 ### Requirement: Persistent-abort scheduler covers the short backoff window
 

--- a/openspec/specs/error-detection/spec.md
+++ b/openspec/specs/error-detection/spec.md
@@ -58,60 +58,42 @@ Transient retryable errors that pi-coding-agent retries internally SHALL NOT set
 
 ### Requirement: Error state cleared on confirmed-good response
 
-The `lastError` field SHALL persist across the start of a retry/continuation turn and SHALL be cleared ONLY when the subsequent turn produces a **confirmed non-error response**. `agent_start` alone SHALL NOT clear `lastError`.
+`SessionState.lastError` SHALL persist across the start of a retry or continuation turn and
+SHALL clear only on a confirmed non-error response for the session. A settled error whose retry
+chain is still running SHALL NOT be presented as terminal: while a `retry` sub-status is
+carried the surface SHALL present a pending retry, and the error anchor SHALL remain as its
+header.
 
-A confirmed non-error response is the first of the following observed after `lastError` was set:
+Because pi fires one `agent_end` per retry attempt, an `agent_end` carrying an error SHALL NOT
+by itself be treated as the end of the lifecycle; only `agent_settled` terminates it.
 
-- an assistant `message_end` with a terminal-success `stopReason`, OR
-- a clean `agent_end` whose last message has a terminal-success `stopReason`.
+#### Scenario: Error persists while a retry is pending
 
-Terminal-success `stopReason` = pi-ai `"stop"` (the real over-the-wire value for a normal completion); `"end_turn"` is also accepted (Anthropic-normalized / fixture value). Mid-turn / non-success stops (`"toolUse"`/`"tool_use"`, `"error"`, `"aborted"`, `"length"`) SHALL NOT clear `lastError`: the turn can still error after a tool-use stop, AND pi fires an `agent_end` carrying a `toolUse` last message when a turn yields at an interactive tool (e.g. `ask_user`) — a mid-turn pause, not a successful response. Clearing on any non-success stop would reintroduce a clear→re-set flicker and would wrongly drop the error anchor across an interactive pause or a user abort.
+- **GIVEN** `lastError` is set AND a `retry` sub-status is carried
+- **WHEN** the next attempt starts
+- **THEN** `lastError` SHALL remain set
+- **AND** the surface SHALL continue to show the error text as the card header
 
-Until that signal arrives, the error-lifecycle surface SHALL keep showing the prior `lastError` (as the persistent anchor) with the live retry status composed on top of it.
+#### Scenario: Error clears on a confirmed non-error response
 
-A brand-new (non-retry) user prompt SHALL NOT optimistically clear `lastError`. The error anchor persists across a new prompt's `agent_start` and clears only on that new turn's confirmed non-error response (same rule as a retry). The abort latch is cleared on the new prompt (per `provider-retry-state`) so the new turn runs freely; only the display anchor lingers.
+- **WHEN** a turn for the session completes with a non-error stop reason
+- **THEN** `SessionState.lastError` SHALL be cleared
+- **AND** the surface SHALL become hidden once `retryState` is also undefined
 
-`retryState` clearing is unchanged (cleared on `auto_retry_end`, `agent_start`, `agent_end` per `provider-retry-state`). Only `lastError` lifetime changes here.
+#### Scenario: The error persists when retries run out
 
-#### Scenario: agent_start no longer clears lastError
-- **GIVEN** `SessionState.lastError` is set from a previous error
-- **WHEN** an `agent_start` event arrives
+- **GIVEN** pi has exhausted `retry.maxRetries` and the chain terminated with an error
+- **WHEN** `agent_settled` clears the retry sub-status
 - **THEN** `SessionState.lastError` SHALL remain set
-- **AND** the error-lifecycle surface SHALL remain visible
+- **AND** the surface SHALL remain visible as a settled error, with a state-clearing dismiss
+- **AND** the message SHALL NOT auto-hide when retrying stops
 
-#### Scenario: Confirmed non-error message_end clears lastError
-- **GIVEN** `SessionState.lastError` is set
-- **AND** an `agent_start` for the retry/continuation turn has arrived (lastError still set)
-- **WHEN** an assistant `message_end` with `stopReason: "end_turn"` arrives
-- **THEN** `SessionState.lastError` SHALL be cleared to `undefined`
-- **AND** the error-lifecycle surface SHALL transition to `hidden`
+#### Scenario: A retrying chain is not presented as terminal
 
-#### Scenario: Brand-new user prompt does not clear stale error until confirmed-good
-- **GIVEN** `SessionState.lastError` is set from a previous turn
-- **WHEN** the user sends a NEW (non-retry) prompt and its `agent_start` arrives
-- **THEN** `SessionState.lastError` SHALL remain set (no optimistic clear on send)
-- **AND** `SessionState.lastError` SHALL clear only when the new turn produces a confirmed non-error response (`stopReason === "end_turn"` message_end or clean `agent_end`)
-
-#### Scenario: Failed retry keeps the error visible (no flicker)
-- **GIVEN** `SessionState.lastError` is set
-- **WHEN** the retry turn fails again (`agent_end` with `stopReason: "error"`)
-- **THEN** `SessionState.lastError` SHALL be updated to the new error WITHOUT a hidden intermediate frame
-- **AND** the surface SHALL NOT have flashed to `hidden` between `agent_start` and the new error
-
-#### Scenario: Mid-turn tool_use stop does NOT clear lastError
-- **GIVEN** `SessionState.lastError` is set
-- **AND** an `agent_start` for the retry/continuation turn has arrived (lastError still set)
-- **WHEN** an assistant `message_end` with `stopReason: "tool_use"` arrives
-- **THEN** `SessionState.lastError` SHALL remain set
-- **AND** the error-lifecycle surface SHALL remain visible
-- **AND** a subsequent `agent_end` with `stopReason: "error"` SHALL update `lastError` WITHOUT the surface having flashed to `hidden`
-
-#### Scenario: agent_end yielding at an interactive tool does NOT clear lastError
-- **GIVEN** `SessionState.lastError` is set
-- **AND** a new turn has started (`agent_start`) that emits an `ask_user` tool call
-- **WHEN** an `agent_end` arrives whose last message has `stopReason: "tool_use"` (the turn paused awaiting the answer)
-- **THEN** `SessionState.lastError` SHALL remain set
-- **AND** the error-lifecycle surface SHALL remain visible
+- **GIVEN** an attempt ended with an error AND a further attempt is pending
+- **THEN** the surface SHALL render the pending-retry presentation (Stop retrying, attempt,
+  countdown)
+- **AND** the surface SHALL NOT render the settled presentation (clearing dismiss)
 
 ### Requirement: Error banner in chat view
 
@@ -148,38 +130,6 @@ The `data-testid` attributes `error-banner` and `error-banner-dismiss` SHALL be 
 #### Scenario: Error message is copyable
 - **WHEN** the unified banner is visible in `error` or `limit-exceeded` sub-state
 - **THEN** a copy control SHALL be present that writes the full untruncated `lastError.message` to the clipboard via `navigator.clipboard.writeText`
-
-### Requirement: Retry action on error banner
-
-The unified `SessionBanner` SHALL render a Retry control ONLY in the `error` sub-state (NOT in `limit-exceeded`). Clicking Retry SHALL re-send the last user-authored prompt for the session via a `send_prompt` message (text + images), so an alive-but-errored session re-runs the same input that originally triggered the failure.
-
-The retried user message SHALL be visually deduplicated in the chat view per the "Manual retry hides duplicate user bubble in chat view" requirement in `session-status-banner`.
-
-The host view SHALL identify the last user-authored message via a helper that walks `state.messages` newest-to-oldest and returns the first user message's `text` and `images`. When no user message exists in history, the Retry button MAY be hidden or be a no-op.
-
-#### Scenario: Retry button re-sends last user prompt and dedupes bubble
-- **GIVEN** the unified banner is visible in `error` sub-state for a session with `lastError` set
-- **AND** the session history contains [user("please refactor X"), assistant(error)]
-- **AND** a retry handler is wired in App.tsx
-- **WHEN** the user clicks the Retry button
-- **THEN** a `send_prompt` message SHALL be sent with `text: "please refactor X"`
-- **AND** when the resulting `message_start { role: "user", content: "please refactor X" }` event arrives the chat view SHALL render only ONE "please refactor X" user bubble
-- **AND** the prior `lastError` SHALL remain visible until the retry produces a confirmed non-error response (per "Error state cleared on confirmed-good response")
-
-#### Scenario: Retry button absent in limit-exceeded variant
-- **WHEN** the unified banner is in `limit-exceeded` sub-state
-- **THEN** no Retry button SHALL be rendered in the DOM
-- **AND** no `onRetry` callback SHALL be invocable from the banner
-
-#### Scenario: Retry button hidden when no handler is provided
-- **WHEN** the unified banner is rendered in `error` sub-state without an `onRetry` callback
-- **THEN** no Retry button SHALL be rendered
-
-#### Scenario: Retry button no-op when no prior user prompt exists
-- **GIVEN** the unified banner is visible in `error` sub-state for a session whose history contains no user-authored messages
-- **WHEN** the user clicks the Retry button
-- **THEN** no `send_prompt` SHALL be sent
-- **AND** the banner SHALL remain visible
 
 ### Requirement: Error indicator on session card
 The session card in the sidebar SHALL show a red status dot when the session has an active error.

--- a/openspec/specs/pi-retry-settings/spec.md
+++ b/openspec/specs/pi-retry-settings/spec.md
@@ -1,0 +1,230 @@
+# pi-retry-settings Specification
+
+## Purpose
+TBD - created by archiving change retry-forever-with-stop-control. Update Purpose after archive.
+## Requirements
+### Requirement: Dashboard exposes pi's native retry policy as a GLOBAL editor
+
+The dashboard SHALL expose pi's own retry policy as an editable settings surface on the Sessions
+settings tab, covering ALL SIX native fields:
+
+| Field | pi default |
+|---|---|
+| `retry.enabled` | `true` |
+| `retry.maxRetries` | `3` |
+| `retry.baseDelayMs` | `2000` |
+| `retry.provider.timeoutMs` | SDK default (absent) |
+| `retry.provider.maxRetries` | `0` |
+| `retry.provider.maxRetryDelayMs` | `60000` |
+
+These values are pi's, not the dashboard's: the dashboard SHALL NOT maintain a parallel retry
+policy, and SHALL NOT implement a retry loop of its own.
+
+The editor SHALL be GLOBAL only. pi has no persisted per-session retry policy —
+`AgentSession.setAutoRetryEnabled` delegates to `SettingsManager.setRetryEnabled`, which writes the
+global file — so the surface SHALL NOT present a per-session or project-scoped editor.
+
+#### Scenario: Surface reads the effective policy
+
+- **WHEN** the retry settings surface is opened
+- **THEN** it SHALL display the values currently in `~/.pi/agent/settings.json`
+- **AND** where a key is absent it SHALL display pi's own default from the table above
+
+#### Scenario: All six native fields are editable
+
+- **WHEN** the retry settings surface is rendered
+- **THEN** it SHALL offer a control for each of `retry.enabled`, `retry.maxRetries`,
+  `retry.baseDelayMs`, `retry.provider.timeoutMs`, `retry.provider.maxRetries`,
+  `retry.provider.maxRetryDelayMs`
+
+#### Scenario: No project-scope or per-session editor
+
+- **WHEN** the retry settings surface is rendered
+- **THEN** it SHALL NOT offer a project-scoped (`.pi/settings.json`) variant of any field
+- **AND** it SHALL NOT offer a per-session retry control
+
+#### Scenario: Defaults are pi's own until the user opts in
+
+- **GIVEN** a dashboard installation whose user has never edited retry settings
+- **THEN** no `retry` block SHALL have been written to `~/.pi/agent/settings.json`
+- **AND** pi's behavior SHALL be unchanged from a dashboard-free install
+
+#### Scenario: The invisible-wait consequence of the provider layer is disclosed
+
+- **WHEN** the provider fields are rendered
+- **THEN** the surface SHALL state that a wait taken inside the provider layer emits no event, so it
+  renders as ordinary streaming with no attempt count or countdown
+
+### Requirement: The editor lives on the Sessions tab and commits through the unified Save
+
+The retry editor SHALL render on the **Sessions** settings tab, not Providers. Three of the six
+fields (`retry.enabled`, `retry.maxRetries`, `retry.baseDelayMs`) are turn-level rather than
+provider-scoped, the policy's observable effect is on a session (waiting / attempt n / countdown /
+Stop), and the sibling turn-lifecycle settings (`askUserPromptTimeoutSeconds`,
+`spawnRegisterTimeoutMs`) already live there. The enclosing section SHALL be titled "Retry"; the
+provider trio keeps its own subheading inside it.
+
+The editor SHALL NOT render a private Save button. It SHALL register as a draft source with the
+panel's unified Save (see change: unify-settings-save-contract) so that a single Save commits every
+dirty store, the nav rail shows a per-page dirty dot, and the leave guard offers Save / Discard /
+Cancel. The registered `page` SHALL match the tab the section renders on. A commit that cannot
+proceed SHALL reject rather than silently no-op, so the host keeps the source dirty and names it in
+the partial-failure message instead of reporting a false success.
+
+#### Scenario: Section renders exactly one heading
+
+- **WHEN** the retry section is rendered inside its settings section
+- **THEN** the title SHALL appear exactly once (the section provides it; the body SHALL NOT repeat it)
+
+#### Scenario: No private Save button
+
+- **WHEN** the retry settings surface is rendered
+- **THEN** it SHALL NOT render its own Save control
+
+#### Scenario: An edit marks the panel dirty on the Sessions page
+
+- **GIVEN** the loaded policy is displayed
+- **WHEN** the user changes any retry field
+- **THEN** the source SHALL report dirty
+- **AND** the unsaved-changes count SHALL include it
+- **AND** the Sessions nav entry SHALL show a dirty dot
+
+#### Scenario: The unified Save commits the retry policy
+
+- **GIVEN** a dirty retry edit
+- **WHEN** the user activates the panel's Save
+- **THEN** the retry policy SHALL be written
+- **AND** the source SHALL report clean afterwards
+
+#### Scenario: Discard restores the loaded policy
+
+- **GIVEN** a dirty retry edit
+- **WHEN** the user discards
+- **THEN** the fields SHALL return to the loaded values
+- **AND** the source SHALL report clean
+
+#### Scenario: A failed write keeps the source dirty
+
+- **GIVEN** a dirty retry edit whose write will fail
+- **WHEN** the unified Save runs
+- **THEN** the commit SHALL reject
+- **AND** the source SHALL remain dirty
+- **AND** the panel SHALL name it among the failed sources rather than reporting success
+
+#### Scenario: Invalid input rejects the commit
+
+- **GIVEN** a field holding a value the validator rejects
+- **WHEN** the unified Save runs
+- **THEN** the commit SHALL reject
+- **AND** nothing SHALL be written
+
+### Requirement: Saving writes a merge-preserving global settings block
+
+Saving SHALL write into the GLOBAL `~/.pi/agent/settings.json`. The write SHALL preserve every
+unrelated key byte-identical, including keys the dashboard does not know about. The project-scoped
+`.pi/settings.json` SHALL NEVER be written.
+
+#### Scenario: Unrelated keys survive the write byte-identically
+
+- **GIVEN** `~/.pi/agent/settings.json` contains `packages`, `extensions`, and
+  `dashboardPluginBridges` keys
+- **WHEN** the user saves a retry policy
+- **THEN** the file SHALL contain the new `retry` block
+- **AND** `packages`, `extensions`, and `dashboardPluginBridges` SHALL be byte-identical to their
+  prior values
+
+#### Scenario: Unknown keys inside the retry block survive
+
+- **GIVEN** the file contains `retry.someFutureKnob`
+- **WHEN** the user saves the six known fields
+- **THEN** `retry.someFutureKnob` SHALL remain unchanged
+
+#### Scenario: Project settings are never written
+
+- **WHEN** any retry policy is saved
+- **THEN** `<cwd>/.pi/settings.json` SHALL NOT be created or modified
+
+### Requirement: Values are validated before they are written
+
+The surface SHALL reject values pi cannot use. An invalid value SHALL NOT be written.
+
+- `enabled` — boolean.
+- `maxRetries` — non-negative integer.
+- `baseDelayMs` — positive integer.
+- `provider.timeoutMs` — positive integer, or absent (meaning "SDK default").
+- `provider.maxRetries` — non-negative integer.
+- `provider.maxRetryDelayMs` — non-negative integer; `0` disables pi's server-requested-delay limit.
+
+#### Scenario: Invalid value is rejected
+
+- **WHEN** the user submits `maxRetries: -1` or `baseDelayMs: 0`
+- **THEN** the value SHALL NOT be written to the settings file
+- **AND** the surface SHALL report the reason
+
+#### Scenario: Provider fields validate independently
+
+- **WHEN** the user submits `provider.maxRetryDelayMs: -5`
+- **THEN** nothing SHALL be written
+- **AND** the surface SHALL report the offending field
+
+#### Scenario: An absent provider timeout is permitted
+
+- **WHEN** `provider.timeoutMs` is left empty
+- **THEN** the save SHALL succeed
+- **AND** the key SHALL be omitted rather than written as `0` or `null`
+
+#### Scenario: Large attempt counts are permitted, not capped
+
+- **WHEN** the user submits `maxRetries: 100`
+- **THEN** the value SHALL be accepted and written, because pi imposes no clamp on it
+- **AND** the surface SHALL NOT impose a maximum of its own
+
+#### Scenario: A long tail is warned about, not refused
+
+- **WHEN** the entered values yield more than ~20 attempts
+- **THEN** the surface SHALL show a non-blocking warning carrying the computed total wait
+- **AND** the value SHALL remain saveable
+
+#### Scenario: Retry can be disabled entirely
+
+- **WHEN** the user turns `retry.enabled` off and saves
+- **THEN** `retry.enabled: false` SHALL be written
+- **AND** the agent-level attempt-count and base-delay controls SHALL be shown as inactive, because
+  pi ignores them when retry is disabled
+
+### Requirement: Saving applies the policy to running sessions
+
+Because pi reads its settings once, at session construction, a settings write alone SHALL NOT be
+treated as applied. On a successful save the dashboard SHALL reload every connected session so the
+new policy takes effect immediately.
+
+#### Scenario: Connected sessions are reloaded on save
+
+- **GIVEN** three sessions are connected to the dashboard
+- **WHEN** the user saves a new retry policy
+- **THEN** the dashboard SHALL dispatch a reload to each of the three sessions
+
+#### Scenario: A failed write does not reload anything
+
+- **GIVEN** the settings file cannot be written (permissions, invalid JSON on disk)
+- **WHEN** the user saves
+- **THEN** no session SHALL be reloaded
+- **AND** the surface SHALL report the failure
+
+#### Scenario: Global scope is disclosed
+
+- **WHEN** the retry settings surface is rendered
+- **THEN** it SHALL state that the policy is global and also affects pi sessions started outside the
+  dashboard
+
+### Requirement: The delay curve is disclosed, not hidden
+
+Because pi's agent-level delay is `baseDelayMs · 2^(attempt-1)` with no ceiling, the surface SHALL
+show the consequence of the chosen values rather than leaving the user to discover a multi-hour tail.
+
+#### Scenario: Surface previews the resulting schedule
+
+- **WHEN** `maxRetries: 8` and `baseDelayMs: 2000` are entered
+- **THEN** the surface SHALL show the resulting delay progression and the total time before the turn
+  finally fails
+

--- a/openspec/specs/provider-retry-state/spec.md
+++ b/openspec/specs/provider-retry-state/spec.md
@@ -5,138 +5,215 @@ TBD - created by archiving change fix-provider-retry-infinite-loop. Update Purpo
 ## Requirements
 ### Requirement: Reducer tracks in-flight retry state
 
-The event reducer SHALL maintain a `retryState` field on `SessionState` describing the current LLM-provider retry phase. The field SHALL be set on `auto_retry_start` and cleared on `auto_retry_end`, `agent_start`, and `agent_end`.
+The event reducer SHALL maintain a `retryState` field on `SessionState` describing the current
+retry, covering BOTH an in-flight attempt and the wait between attempts. The field SHALL be set
+on the waiting signal and on `auto_retry_start`, and cleared on `auto_retry_end`, `agent_start`,
+and `agent_settled`.
+
+`agent_end` SHALL NOT clear `retryState`, because pi fires one `agent_end` per attempt and only
+`agent_settled` is terminal. Clearing on `agent_end` would erase the retry state between every
+attempt.
 
 The shape SHALL be:
 ```ts
 retryState?: {
-  attempt: number;       // 1-based attempt number
-  maxAttempts: number;   // total attempts pi-coding-agent will make
-  delayMs: number;       // milliseconds between this attempt and the next
-  reason: string;        // errorMessage that triggered this retry
-  startedAt: number;     // event.timestamp at auto_retry_start
+  attempt: number;        // 1-based
+  maxAttempts: number;    // pi's retry.maxRetries; 0 = unknown
+  delayMs: number;        // computed from pi's settings; 0 = unknown
+  nextAttemptAt?: number; // absolute epoch ms of the next attempt when known
+  waiting: boolean;       // true between attempts, false while an attempt is in flight
+  reason: string;         // errorMessage that triggered this retry
+  startedAt: number;      // event.timestamp when this retry record was set
 }
 ```
 
-#### Scenario: auto_retry_start sets retryState
-- **WHEN** an `auto_retry_start` event arrives with `data: { attempt: 1, maxAttempts: 3, delayMs: 2000, errorMessage: "rate limit exceeded" }`
-- **THEN** `SessionState.retryState` SHALL equal `{ attempt: 1, maxAttempts: 3, delayMs: 2000, reason: "rate limit exceeded", startedAt: <event.timestamp> }`
+There is no `phase` discriminator: the dashboard runs no retry loop of its own, so pi's is the
+only retry that exists.
+
+**Runtime status only.** `retryState` describes what is happening *now* — waiting, which attempt,
+when the next attempt lands. It SHALL NOT carry, and no session surface SHALL render, pi's retry
+POLICY values (`baseDelayMs`, the provider sub-block, or any editable knob). `maxAttempts` is
+retained solely to suppress a spurious waiting signal on the final attempt and SHALL NOT be rendered
+as a denominator. pi has no persisted per-session retry policy
+(`setAutoRetryEnabled` → the global setter), so no session surface SHALL present a per-session or
+project-scoped retry editor; policy is edited only in the global surface (capability
+`pi-retry-settings`).
+
+#### Scenario: auto_retry_start sets an in-flight retryState
+
+- **WHEN** an `auto_retry_start` event arrives with `data: { attempt: 2, maxAttempts: 3, delayMs: 4000, errorMessage: "rate limit exceeded" }`
+- **THEN** `SessionState.retryState` SHALL equal `{ attempt: 2, maxAttempts: 3, delayMs: 4000, waiting: false, reason: "rate limit exceeded", startedAt: <event.timestamp> }`
 - **AND** `SessionState.lastError` SHALL remain unchanged
 
+#### Scenario: Waiting signal sets a waiting retryState
+
+- **WHEN** a waiting signal arrives with `data: { attempt: 2, delayMs: 4000, nextAttemptAt: 1700000004000, errorMessage: "overloaded" }`
+- **THEN** `SessionState.retryState.waiting` SHALL be `true`
+- **AND** `SessionState.retryState.attempt` SHALL be `2`
+- **AND** `SessionState.retryState.nextAttemptAt` SHALL be `1700000004000`
+
+#### Scenario: agent_end preserves the retry state
+
+- **GIVEN** `retryState` is set with `waiting: true`
+- **WHEN** an `agent_end` event arrives
+- **THEN** the existing `lastError` extraction logic SHALL run
+- **AND** `SessionState.retryState` SHALL remain set
+
+#### Scenario: agent_settled clears the retry state
+
+- **GIVEN** `retryState` is set
+- **WHEN** an `agent_settled` event arrives
+- **THEN** `SessionState.retryState` SHALL be cleared to undefined
+
 #### Scenario: auto_retry_end with success clears retryState
-- **WHEN** `retryState` is set
-- **AND** an `auto_retry_end` event arrives with `data: { success: true, attempt: 2 }`
+
+- **WHEN** `retryState` is set AND an `auto_retry_end` arrives with `data: { success: true, attempt: 2 }`
 - **THEN** `SessionState.retryState` SHALL be cleared to undefined
 - **AND** `SessionState.lastError` SHALL remain unchanged
 
-#### Scenario: auto_retry_end with failure clears retryState and surfaces error early
-- **WHEN** `retryState` is set
-- **AND** an `auto_retry_end` event arrives with `data: { success: false, attempt: 3, finalError: "Rate limit exceeded" }`
-- **AND** `SessionState.lastError` is currently undefined
+#### Scenario: auto_retry_end with failure clears retryState and sets lastError
+
+- **WHEN** `auto_retry_end` arrives with `data: { success: false, attempt: 3, finalError: "Rate limit exceeded" }`
 - **THEN** `SessionState.retryState` SHALL be cleared
 - **AND** `SessionState.lastError` SHALL be set to `{ message: "Rate limit exceeded", timestamp: <event.timestamp> }`
 
-#### Scenario: auto_retry_end after lastError already set
-- **WHEN** `auto_retry_end` arrives with `success: false` and a `finalError`
-- **AND** `SessionState.lastError` is already set (e.g. by an earlier `agent_end`)
-- **THEN** `SessionState.retryState` SHALL be cleared
-- **AND** `SessionState.lastError` SHALL NOT be overwritten
-
 #### Scenario: agent_start defensively clears stale retryState
-- **WHEN** `retryState` is set (e.g. session reload mid-retry)
-- **AND** an `agent_start` event arrives
+
+- **WHEN** `retryState` is set (e.g. session reload mid-retry) AND an `agent_start` arrives
 - **THEN** `SessionState.retryState` SHALL be cleared to undefined
 
-#### Scenario: agent_end defensively clears retryState
-- **WHEN** `retryState` is set
-- **AND** an `agent_end` event arrives
-- **THEN** `SessionState.retryState` SHALL be cleared after the existing `lastError` extraction logic runs
-
 #### Scenario: auto_retry_end ignored when retryState is undefined
-- **WHEN** `SessionState.retryState` is undefined
-- **AND** an `auto_retry_end` event arrives
+
+- **WHEN** `SessionState.retryState` is undefined AND an `auto_retry_end` event arrives
 - **THEN** `SessionState.retryState` SHALL remain undefined
 - **AND** `SessionState.lastError` SHALL NOT be modified by this event
 
 ### Requirement: Retry banner in chat view
 
-The dashboard SHALL surface in-flight provider retries via the unified `SessionBanner` component (see capability `session-status-banner`), rendered in the `retrying` variant when `SessionState.retryState` is set. The previous standalone `<RetryBanner>` component is REMOVED; banner placement moves from inside `ChatView` to sticky above the `CommandInput`.
+The dashboard SHALL surface retries via the unified `SessionBanner` component (see capability
+`session-status-banner`) whenever `SessionState.retryState` is set, covering both the waiting
+and in-flight sub-states.
 
-In the `retrying` variant the banner SHALL display:
+The surface SHALL display:
 
-- Attempt phrasing. When `retryState.maxAttempts > 0` AND `retryState.delayMs > 0`, the phrasing SHALL include current attempt and max attempts plus a live countdown to `startedAt + delayMs`, refreshed at least once per second, never going below 0. When either is `<= 0` (sentinel — indeterminate retry; bridge does not know pi's retry settings), the banner SHALL show an indeterminate "retrying…" message instead.
-- A "Stop retrying" button that triggers the same `wrappedHandleAbort` flow as the main Stop button.
-- The original `reason` string, truncated to a single line with overflow ellipsis.
+- **Attempt phrasing.** The attempt number SHALL be rendered bare ("attempt 7"). The surface
+  SHALL NEVER render "of N": `maxRetries` is user-configurable and typically large, so a
+  denominator is noise rather than information.
+- **Countdown.** When `nextAttemptAt` is known the surface SHALL render a live countdown to it,
+  refreshed at least once per second and never below 0. When only `delayMs > 0` is known the
+  surface SHALL render a countdown to `startedAt + delayMs`, and SHALL switch to
+  "still waiting… (N s elapsed)" once that instant has passed while the retry is still pending.
+  When `delayMs` is 0 the surface SHALL render elapsed-only.
+- **A "Stop retrying" control** that aborts the session, thereby ending pi's retry chain.
+- The originating `reason` string.
 
-#### Scenario: Banner visible during retry with known countdown
-- **WHEN** `retryState = { attempt: 2, maxAttempts: 3, delayMs: 4000, reason: "rate limit exceeded", startedAt: 1700000000000 }`
-- **THEN** the unified `SessionBanner` SHALL be visible in the `retrying` variant
-- **AND** the banner SHALL include text identifying attempt 2 of 3
-- **AND** a "Stop retrying" button SHALL be rendered
+#### Scenario: Waiting state shows an exact countdown
 
-#### Scenario: Banner shows indeterminate state when delayMs is sentinel -1
-- **WHEN** `retryState = { attempt: 1, maxAttempts: -1, delayMs: -1, reason: "rate limit exceeded", startedAt: 0 }`
-- **THEN** the banner SHALL be visible in the `retrying` variant
-- **AND** the banner SHALL show "retrying…" without a countdown
-- **AND** a "Stop retrying" button SHALL be rendered
+- **WHEN** `retryState = { attempt: 7, maxAttempts: 100, delayMs: 60000, nextAttemptAt: <now + 42s>, waiting: true, reason: "overloaded", startedAt: <now> }`
+- **THEN** the surface SHALL show a countdown of 42 s decreasing at least once per second
+- **AND** the surface SHALL show "attempt 7" without "of"
 
-#### Scenario: Banner countdown reaches zero and stays
-- **WHEN** the banner is mounted with `startedAt + delayMs` already elapsed AND `delayMs > 0`
-- **THEN** the displayed countdown SHALL be `0` (not negative)
-- **AND** the banner SHALL remain visible until `retryState` is cleared
+#### Scenario: Overrun countdown degrades to elapsed
 
-#### Scenario: Stop retrying button triggers abort
-- **GIVEN** the banner is in `retrying` variant
-- **WHEN** the user clicks "Stop retrying"
-- **THEN** `wrappedHandleAbort()` SHALL be invoked for the selected session
-- **AND** an `abort` message SHALL be sent for the current session
-- **AND** the banner SHALL clear once `retryState` is cleared (typically within ≤200ms via the bridge's synthetic auto_retry_end)
+- **GIVEN** a `waiting: true` record whose countdown target has passed
+- **WHEN** the retry is still pending
+- **THEN** the surface SHALL render "still waiting… (N s elapsed)" instead of a zeroed countdown
 
-#### Scenario: Banner clears on auto_retry_end
-- **GIVEN** the banner is in `retrying` variant
-- **WHEN** an `auto_retry_end` event arrives (success or failure)
-- **THEN** the banner SHALL no longer render in the `retrying` variant
-- **AND** the banner SHALL transition to `error` / `limit-exceeded` (if `lastError` is set) or `hidden`
+#### Scenario: Zero delay renders elapsed-only
+
+- **WHEN** `retryState.delayMs` is 0 and `nextAttemptAt` is absent
+- **THEN** the surface SHALL render an elapsed-only waiting line with no countdown
+
+#### Scenario: Stop retrying aborts the session
+
+- **GIVEN** the surface carries any `retryState`
+- **WHEN** the user activates "Stop retrying"
+- **THEN** an `abort` SHALL be dispatched for the session
+
+#### Scenario: Surface persists across attempts
+
+- **GIVEN** the surface is rendering a waiting retry for attempt 3
+- **WHEN** attempt 4 starts and then fails
+- **THEN** the surface SHALL remain visible throughout
+- **AND** the attempt counter SHALL advance rather than resetting
 
 ### Requirement: Session card amber dot during retry
 
-A session card in the sidebar SHALL render an amber pulsing status dot when its `SessionState.retryState` is set AND `SessionState.lastError` is undefined. This visual SHALL be distinct from the existing red error dot and the default idle/streaming/ended dots.
+A session card in the sidebar SHALL render an amber (working-token) pulsing status mark whenever
+its `SessionState.retryState` is set AND `SessionState.lastError` is undefined, in both the
+waiting and in-flight sub-states. This visual SHALL be distinct from the red error mark and the
+default idle/streaming/ended marks, and SHALL carry a non-hue channel (a shape/icon marker) so
+it is distinguishable without colour.
 
-#### Scenario: Amber dot during retry
+The per-attempt number and countdown are surfaced on the `SessionBanner` (including its collapsed
+pill), NOT on every sidebar card: duplicating a live countdown onto each card would require a
+per-card timer in a render-hot component for information the banner already carries. The card's
+job is only to mark "this session is retrying".
+
+#### Scenario: Amber mark during retry (both sub-states)
+
 - **WHEN** the session has `retryState` set and `lastError` is undefined
-- **THEN** the session card status dot SHALL be amber and pulsing
+- **THEN** the session card status mark SHALL be the amber working token, pulsing
 
-#### Scenario: Red error dot wins over amber
+#### Scenario: Red error mark wins over amber
+
 - **WHEN** the session has both `retryState` set AND `lastError` set
-- **THEN** the session card status dot SHALL be red (lastError takes precedence)
+- **THEN** the session card status mark SHALL be red (lastError takes precedence)
 
-#### Scenario: Dot returns to default after retry clears
-- **WHEN** `retryState` is cleared (success or failure)
-- **AND** `lastError` is undefined
-- **THEN** the session card status dot SHALL return to its non-error default
+#### Scenario: Mark returns to default after retry clears
+
+- **WHEN** `retryState` is cleared (success or stop) AND `lastError` is undefined
+- **THEN** the session card status mark SHALL return to its non-error default
+
+#### Scenario: No policy values on any session surface
+
+- **WHEN** any session surface renders a retry (banner, collapsed pill, or sidebar card)
+- **THEN** it SHALL NOT display `baseDelayMs`, `retry.provider.*`, or any other editable policy value
+- **AND** it SHALL NOT offer a control that edits retry policy
+
+#### Scenario: Marking uses an MDI mark, never an emoji
+
+- **WHEN** a retry is marked on any surface
+- **THEN** the mark SHALL be an MDI icon / token-driven indicator
+- **AND** no emoji SHALL be used
 
 ### Requirement: Bridge synthesizes auto_retry_start from observed message_end
 
-The bridge SHALL maintain a per-session retry tracker. Retry detection SHALL be derived from OBSERVED pi behavior, NOT from a regex classifier. The bridge SHALL NOT test any `RETRYABLE_PATTERN` / copy of pi's internal `_isRetryableError`.
+The bridge SHALL maintain a per-session retry tracker. Retry detection SHALL be derived from
+OBSERVED pi behavior, NOT from a regex classifier. The bridge SHALL NOT test any
+`RETRYABLE_PATTERN` / copy of pi's internal `_isRetryableError`.
 
-Rule: when pi emits `message_end` whose `message.role === "assistant"` AND `message.stopReason === "error"`, the bridge SHALL record a pending failure for the session (it does NOT yet know whether pi will retry). When pi subsequently emits a fresh assistant `message_start` for the same agent turn (i.e. before any `agent_end` for that turn and with no intervening user prompt), that observed new attempt SHALL cause the bridge to forward a synthesized `event_forward` with `eventType: "auto_retry_start"` and `data: { attempt: <1-based observed-attempt counter>, maxAttempts: -1, delayMs: -1, errorMessage: <observed errorMessage> }`. The session SHALL be marked as in retry until cleared.
+The observed sequence is one full `agent_start` … `agent_end` cycle per attempt, terminated by
+a single `agent_settled`. An error `agent_end` therefore means "another attempt is coming" and
+SHALL produce both `auto_retry_start` for the completed attempt and a waiting signal; only
+`agent_settled` terminates the chain. See capability `bridge-retry-observability` for the full
+rules.
 
-`maxAttempts: -1` and `delayMs: -1` are sentinels: pi does not expose its retry settings to extensions, so the dashboard SHALL render an indeterminate "retrying…" UI instead of a countdown. During pi's backoff sleep (before the next `message_start`), the surface SHALL show the error without a "retrying…" sub-line; the sub-line appears when the next attempt is observed.
+`maxAttempts` and `delayMs` SHALL be derived read-only from pi's retry settings, defaulting to
+`3` and `2000`, and SHALL be `0` when the settings cannot be read. The `-1` sentinels are
+REMOVED. The bridge SHALL NOT write pi's settings.
 
-#### Scenario: Observed new attempt after an error triggers synthesized auto_retry_start
-- **GIVEN** the bridge forwarded a `message_end` with `message: { role: "assistant", stopReason: "error", errorMessage: "overloaded" }` (pending failure recorded)
-- **WHEN** the bridge observes a fresh assistant `message_start` for the same agent turn with no intervening user prompt
-- **THEN** the bridge SHALL forward an `event_forward` with `event.eventType === "auto_retry_start"`
-- **AND** the synthesized event SHALL have `data.attempt >= 1`, `data.maxAttempts === -1`, `data.delayMs === -1`, `data.errorMessage === "overloaded"`
+#### Scenario: Error agent_end triggers synthesized retry events
 
-#### Scenario: No regex gate on the error message
-- **GIVEN** the bridge forwarded a `message_end` with `errorMessage: "prompt is too long: 300000 tokens > 200000 maximum"` (a string pi will NOT retry)
-- **WHEN** no fresh assistant `message_start` follows (pi ends the turn with `agent_end` error)
-- **THEN** NO `auto_retry_start` SHALL be synthesized (because no new attempt was observed, NOT because a regex rejected the string)
+- **GIVEN** the bridge forwarded a `message_end` with `stopReason: "error"` and
+  `errorMessage: "overloaded"`
+- **WHEN** the matching `agent_end` is observed and no `agent_settled` terminates the chain
+- **THEN** the bridge SHALL forward an `event_forward` with
+  `event.eventType === "auto_retry_start"`
+- **AND** the synthesized event SHALL have `data.attempt >= 1`, `data.maxAttempts === 3`,
+  `data.delayMs > 0`, `data.errorMessage === "overloaded"`
 
-#### Scenario: Successful assistant message_end clears retry tracker and synthesizes auto_retry_end
+#### Scenario: Waiting signal covers pi's sleep
+
+- **GIVEN** the bridge observed an error `agent_end`
+- **WHEN** pi is sleeping before the next attempt
+- **THEN** the dashboard SHALL have received a waiting signal for that session
+- **AND** the surface SHALL show a pending retry rather than a silent settled error
+
+#### Scenario: Successful message_end clears the tracker and synthesizes auto_retry_end
+
 - **GIVEN** the bridge previously synthesized `auto_retry_start` for session X
-- **WHEN** the bridge forwards a subsequent `message_end` with `message: { role: "assistant", stopReason: "end_turn" }`
+- **WHEN** the bridge forwards a subsequent `message_end` with `stopReason: "end_turn"`
 - **THEN** the bridge SHALL forward a synthesized `auto_retry_end { success: true, attempt: <last attempt> }`
 - **AND** the retry tracker SHALL clear its in-flight flag for session X
 

--- a/openspec/specs/session-status-banner/spec.md
+++ b/openspec/specs/session-status-banner/spec.md
@@ -6,76 +6,124 @@ Unified single-banner component (`SessionBanner`) for per-session retry/error/li
 ## Requirements
 ### Requirement: Single banner component with composed error-lifecycle surface
 
-The dashboard SHALL render exactly one banner component (`SessionBanner`) per selected session, mounted sticky above the `CommandInput` (between `ChatView` and `CommandInput`). The banner is a single **error-lifecycle surface** whose contents are derived from a single selector over `SessionState`. Two banner components SHALL NEVER be visible simultaneously for the same session, AND the surface SHALL render as ONE card (a single bordered element), NOT two stacked blocks. The surface SHALL be rendered via the shared `InlineMessage` primitive with `severity="error"`, so its colors resolve from `--severity-error-*` theme tokens (NOT raw `red-500` literals); the in-flight retry indicator SHALL be the primitive's `animate` top accent-bar sweep.
+The dashboard SHALL render exactly one banner component (`SessionBanner`) per selected session,
+mounted sticky above the `CommandInput`. The banner is a single **error-lifecycle surface**
+whose contents are derived from a single selector over `SessionState`. Two banner components
+SHALL NEVER be visible simultaneously for the same session, AND the surface SHALL render as ONE
+card (a single bordered element), NOT two stacked blocks. The surface SHALL be rendered via the
+shared `InlineMessage` primitive with `severity="error"`, so its colors resolve from
+`--severity-error-*` theme tokens (NOT raw `red-500` literals); the in-flight retry indicator
+SHALL be the primitive's `animate` top accent-bar sweep.
 
-The surface composes an optional **error anchor** (from `lastError`) with an optional **live retry sub-line** (from `retryState`) WITHIN the same card body: the error message is the header row, the retry status is a sub-line beneath it, and a thin animated indicator on the same card conveys the retrying state. There SHALL NOT be a separate red card and a separate amber card for one failure.
-
-There SHALL be NO `limit-exceeded` surface state. Billing / quota failures render identically to any other error (ordinary error state); no `USAGE_LIMIT_PATTERN` classification is performed.
+The surface composes an optional **error anchor** (from `lastError`) with an optional **live
+retry sub-line** (from `retryState`) WITHIN the same card body. There SHALL NOT be a separate
+red card and a separate amber card for one failure. There SHALL be NO `limit-exceeded` surface
+state.
 
 Surface states:
 
-- **error + retrying** (one card): `lastError` set AND `retryState` set. Header shows the error message; the same card shows a "retrying… (attempt N)" sub-line + the animated indicator + a "Stop (ends the session)" action.
-- **retrying only** (one card): `retryState` set, `lastError` undefined. Shows `retryState.reason` sub-line + animated indicator + "Stop (ends the session)".
-- **error only** (one card, settled): `lastError` set, `retryState` undefined. Shows message + Dismiss + copy. No Stop (pi already stopped) and NO manual retry (pi's in-flight auto-retry is the only retry path).
+- **retry pending, expanded** (one card): `retryState` set with `waiting: true`. Header shows
+  the error text (or `retryState.reason`); the same card shows the waiting sub-line — bare
+  attempt number, countdown or elapsed — plus Stop retrying, Copy, and a collapse control.
+- **retry in flight, expanded** (one card): `retryState` set with `waiting: false`. As above
+  with the animated indicator and an in-flight sub-line.
+- **retry pending or in flight, collapsed** (one pill): the same state reduced to a single line
+  carrying error text, attempt, countdown, Stop retrying, and expand.
+- **error only** (one card, settled): `lastError` set, `retryState` undefined. Shows message +
+  Copy + state-clearing dismiss.
 - **hidden**: neither field set → nothing rendered.
 
-The error anchor SHALL persist while a retry runs on top of it; the surface SHALL clear only when `lastError` clears (per `error-detection` "Error state cleared on confirmed-good response") and `retryState` is undefined.
+The error anchor SHALL persist while a retry runs on top of it; the surface SHALL clear only
+when `lastError` clears and `retryState` is undefined.
 
 #### Scenario: Error and retry render in a single card
-- **WHEN** `SessionState.lastError = { message: "overloaded_error", timestamp: 0 }` AND `SessionState.retryState = { attempt: 2, maxAttempts: -1, delayMs: -1, reason: "overloaded", startedAt: 0 }`
-- **THEN** the surface SHALL render exactly ONE card element containing the error message "overloaded_error"
-- **AND** the SAME card SHALL contain the "retrying… (attempt 2)" sub-line
+
+- **WHEN** `SessionState.lastError = { message: "overloaded_error", timestamp: 0 }` AND
+  `SessionState.retryState = { attempt: 2, waiting: false, delayMs: 4000, reason: "overloaded", startedAt: 0, maxAttempts: 3 }`
+- **THEN** the surface SHALL render exactly ONE card element containing the error message
+- **AND** the SAME card SHALL contain the retry sub-line for attempt 2
 - **AND** the surface SHALL NOT render two separate sibling card elements
 
+#### Scenario: Waiting sub-state renders as a pending retry
+
+- **WHEN** `retryState.waiting` is `true`
+- **THEN** the card SHALL render the waiting sub-line and a Stop retrying control
+
+#### Scenario: Collapsed surface is a single line
+
+- **GIVEN** the surface is collapsed while a retry is pending
+- **THEN** the rendered DOM SHALL contain exactly one status element for the session
+- **AND** it SHALL occupy a single line
+
 #### Scenario: Surface uses severity tokens via InlineMessage
+
 - **WHEN** the settled-error surface is rendered
-- **THEN** its background, border, and foreground SHALL resolve from `--severity-error-*` tokens through the shared `InlineMessage` primitive
+- **THEN** its background, border, and foreground SHALL resolve from `--severity-error-*`
+  tokens through the shared `InlineMessage` primitive
 - **AND** the surface SHALL NOT apply raw `red-500`/`amber-500` color literals
 
-#### Scenario: Retrying-only when no terminal error yet
-- **WHEN** `SessionState.retryState` is set AND `SessionState.lastError` is undefined
-- **THEN** the surface SHALL render the single card with the retrying sub-line and `reason`
-- **AND** a "Stop (ends the session)" action SHALL be present
+#### Scenario: Billing error renders as an ordinary error
 
-#### Scenario: Billing error renders as an ordinary error (no limit-exceeded variant)
-- **WHEN** `SessionState.lastError = { message: "usage_limit_reached", timestamp: 1 }` AND `retryState` is undefined
-- **THEN** the surface SHALL render the ordinary settled-error card with message + Dismiss + copy
-- **AND** the surface SHALL NOT render any `limit-exceeded` / 💳 variant
-- **AND** no `USAGE_LIMIT_PATTERN` test SHALL be performed
+- **WHEN** `SessionState.lastError = { message: "usage_limit_reached", timestamp: 1 }` AND
+  `retryState` is undefined
+- **THEN** the surface SHALL render the ordinary settled-error card
+- **AND** the surface SHALL NOT render any `limit-exceeded` variant
 
 #### Scenario: Hidden when neither field is set
+
 - **WHEN** `SessionState.retryState` is undefined AND `SessionState.lastError` is undefined
 - **THEN** the `SessionBanner` SHALL render nothing (no DOM)
 
 ### Requirement: Banner-state selector is a pure function
 
-A helper `deriveBannerState(state: SessionState): BannerState` SHALL be exported from `packages/client/src/lib/event-reducer.ts`. The selector SHALL be pure (no side effects, deterministic on its input) and SHALL be the sole determinant of what the `SessionBanner` renders. The host component SHALL NOT compute composition or precedence inline.
+A helper `deriveBannerState(state: SessionState): BannerState` SHALL be exported from the
+client's event-reducer module. The selector SHALL be pure and SHALL be the sole determinant of
+what the `SessionBanner` renders. The host component SHALL NOT compute composition or
+precedence inline.
 
-The selector's return shape SHALL carry BOTH the optional error anchor and the optional retry sub-status (composition). The error kind is a single value `"error"` — there is NO `"limit-exceeded"` kind and the selector SHALL NOT import or reference `USAGE_LIMIT_PATTERN`:
+The selector's return shape SHALL carry BOTH the optional error anchor and the optional retry
+sub-status, and the retry sub-status SHALL carry the waiting flag and the next-attempt time so
+the component renders the countdown without deriving it:
 
 ```ts
 type BannerState =
   | { variant: "hidden" }
   | {
-      // present iff lastError set
       error?: { kind: "error"; message: string };
-      // present iff retryState set
-      retry?: { attempt: number; maxAttempts: number; delayMs: number; startedAt: number; reason: string };
+      retry?: {
+        attempt: number;
+        maxAttempts: number;
+        delayMs: number;
+        nextAttemptAt?: number;
+        waiting: boolean;
+        startedAt: number;
+        reason: string;
+      };
     };
 ```
 
-The selector SHALL return `{ variant: "hidden" }` only when BOTH `lastError` and `retryState` are undefined.
+The selector SHALL return `{ variant: "hidden" }` only when BOTH `lastError` and `retryState`
+are undefined. Collapse is presentation state owned by the component and SHALL NOT appear in
+the selector's output.
 
 #### Scenario: Selector returns hidden for empty state
+
 - **WHEN** `deriveBannerState({ retryState: undefined, lastError: undefined, … })` is called
 - **THEN** the return SHALL be `{ variant: "hidden" }`
 
 #### Scenario: Selector composes error + retry when both set
-- **WHEN** `deriveBannerState({ retryState: { attempt: 2, maxAttempts: -1, delayMs: -1, reason: "overloaded", startedAt: 0 }, lastError: { message: "overloaded_error", timestamp: 1 }, … })` is called
+
+- **WHEN** `deriveBannerState({ retryState: { attempt: 2, maxAttempts: 3, delayMs: 4000, waiting: true, reason: "overloaded", startedAt: 0 }, lastError: { message: "overloaded_error", timestamp: 1 }, … })` is called
 - **THEN** the return SHALL include `error: { kind: "error", message: "overloaded_error" }`
-- **AND** the return SHALL include `retry: { attempt: 2, … reason: "overloaded" }`
+- **AND** the return SHALL include `retry` carrying `attempt: 2` and `waiting: true`
+
+#### Scenario: Selector propagates the next-attempt time
+
+- **WHEN** the state carries a `waiting: true` retry record with `nextAttemptAt`
+- **THEN** the returned `retry` SHALL carry the same `nextAttemptAt`
 
 #### Scenario: Selector never marks limit-exceeded
+
 - **WHEN** `deriveBannerState({ retryState: undefined, lastError: { message: "quota_exceeded for org x", timestamp: 1 }, … })` is called
 - **THEN** the return SHALL include `error: { kind: "error", message: "quota_exceeded for org x" }`
 - **AND** the return SHALL NOT include any `limit-exceeded` kind
@@ -101,37 +149,87 @@ The legacy `RetryBanner.tsx` component SHALL be removed. The inline `lastError` 
 
 ### Requirement: Banner actions dispatch through existing handlers
 
-The "Stop (ends the session)" action SHALL be the SINGLE control that aborts the session. It SHALL invoke the same `wrappedHandleAbort` callback the main Stop button uses (snapshotting queues into draft before dispatching the WS `abort`). Its label SHALL make clear it ends the session, so the user is aware the action stops the session. Stop SHALL be present only while a retry is live (`retryState` set); on a settled error-only surface Stop SHALL be omitted (pi has already stopped).
+The **"Stop retrying"** action SHALL abort the session — which ends pi's retry chain — by
+invoking the same `wrappedHandleAbort` callback the main Stop button uses (snapshotting queues
+into draft before dispatching the WS `abort`). It SHALL be present whenever a `retry`
+sub-status is carried, in both the waiting and in-flight sub-states. The banner SHALL NOT
+render any second session-abort control: the always-present session Stop is the other entry
+point and has identical effect.
 
-There SHALL be NO manual retry control on the settled error surface. pi's in-flight auto-retry is the only retry path; once a turn has terminally errored the session is idle and the user starts a fresh turn by typing a new prompt. The faulty `findLastUserPrompt` → `send_prompt` re-send is removed (it appended a duplicate user turn).
+The **dismiss control SHALL degrade to collapse while a retry is pending.** While the surface
+carries a `retry` sub-status, the control SHALL collapse the card to a one-line pill and SHALL
+NOT clear state. The pill SHALL carry the error text, the bare attempt number, the countdown
+(when known), a Stop retrying control, and an expand control. A state-clearing dismiss SHALL be
+offered ONLY when no `retry` sub-status is carried. Consequently a pending retry SHALL always
+have an on-screen handle, and dismissing SHALL never leave a running retry chain invisible.
 
-The "Dismiss" (✕) action SHALL be **clear-only in every state**. It SHALL clear `lastError` and `retryState` locally and SHALL NEVER dispatch an abort. Dismissing a retrying surface hides the card while pi continues its own retry/turn in the background; it does NOT stop the session.
+Collapse SHALL be sticky **for the current failure chain only**: once collapsed, subsequent
+attempts of the same chain SHALL remain collapsed; a later failure that begins a new chain
+SHALL render expanded.
 
-#### Scenario: Stop ends the session
+The settled surface SHALL NOT render a Retry control. The removed `findLastUserPrompt` →
+`send_prompt` re-send SHALL NOT return, and no replacement re-drive SHALL be introduced: the
+dashboard has no mechanism to re-run a settled turn without appending input.
+
+#### Scenario: Stop retrying ends the retry chain
+
 - **GIVEN** the surface carries a `retry` sub-status
-- **WHEN** the user clicks "Stop (ends the session)"
+- **WHEN** the user clicks "Stop retrying"
 - **THEN** the client SHALL invoke `wrappedHandleAbort()` for the selected session
 - **AND** an `abort` message SHALL be dispatched for the session
 
-#### Scenario: Dismiss on a retrying surface clears only and does NOT abort
-- **GIVEN** the surface carries a `retry` sub-status (pi is mid-retry)
-- **WHEN** the user clicks Dismiss (✕)
-- **THEN** `SessionState.lastError` AND `SessionState.retryState` SHALL be cleared locally
-- **AND** the client SHALL NOT invoke `wrappedHandleAbort()`
-- **AND** NO `abort` message SHALL be dispatched
-- **AND** pi SHALL continue its in-flight retry/turn uninterrupted
+#### Scenario: Dismiss on a retrying surface collapses instead of clearing
 
-#### Scenario: Dismiss on a settled error clears only
-- **GIVEN** the surface is settled `error`-only (pi already stopped)
-- **WHEN** the user clicks Dismiss (✕)
+- **GIVEN** the surface carries a `retry` sub-status
+- **WHEN** the user activates the dismiss control
+- **THEN** the card SHALL collapse to the one-line pill
+- **AND** `SessionState.lastError` and `SessionState.retryState` SHALL NOT be cleared
+- **AND** NO `abort` message SHALL be dispatched
+
+#### Scenario: Collapsed pill retains status and Stop
+
+- **GIVEN** the surface is collapsed while a retry is pending
+- **THEN** the pill SHALL show the error text, the bare attempt number, and the countdown when
+  known
+- **AND** the pill SHALL render a Stop retrying control and an expand control
+
+#### Scenario: Session Stop overrules retry even while the card is collapsed
+
+- **GIVEN** a retry is pending AND the user has collapsed the surface to the pill
+- **WHEN** the user activates the always-present session Stop (outside the banner)
+- **THEN** pi's retry chain SHALL be ended, identically to the pill's own Stop retrying
+- **AND** the collapsed state SHALL NOT prevent or delay that abort
+
+#### Scenario: Collapse is sticky within the failure chain
+
+- **GIVEN** the user collapsed the surface at attempt 3
+- **WHEN** attempts 4 and 5 of the same chain fail
+- **THEN** the surface SHALL remain collapsed without re-expanding
+
+#### Scenario: A new failure chain renders expanded
+
+- **GIVEN** the user collapsed the surface and the retry chain then ended
+- **WHEN** a later, separate turn fails and a new chain begins
+- **THEN** the surface SHALL render expanded
+
+#### Scenario: Dismiss clears only once retrying has stopped
+
+- **GIVEN** the surface carries no `retry` sub-status
+- **WHEN** the user activates the dismiss control
 - **THEN** `SessionState.lastError` SHALL be cleared
 - **AND** no abort SHALL be dispatched
 
-#### Scenario: Settled error surface offers no manual retry
+#### Scenario: Settled surface offers no Retry control
+
 - **GIVEN** the surface is settled `error`-only
-- **THEN** the card SHALL render the message + copy + clear-only Dismiss
-- **AND** the card SHALL NOT render any "Retry" / "Try again" control
-- **AND** no `send_prompt` re-send path SHALL exist for the banner
+- **THEN** no Retry control SHALL be rendered
+- **AND** no `send_prompt` or `resume` SHALL be dispatchable from the banner
+
+#### Scenario: Banner renders no second session-abort control
+
+- **WHEN** the surface is rendered in any state
+- **THEN** the only abort-capable control SHALL be "Stop retrying"
+- **AND** no separate "Stop session" pill SHALL be rendered
 
 ### Requirement: Shared error-pattern module
 


### PR DESCRIPTION
Spec-only follow-up to #410, which archived retry-forever with `--skip-specs` due to develop's parallel retry-spec evolution.

Reconciles our retry change's spec deltas onto develop's current specs: our change is authoritative for the requirements it rewrote (merged `retry-tracker.ts` implements the computed/pi-owns model), develop's independently-added requirements (persistent-abort scheduler, wire-ordering invariant, auto_retry_end-on-abort, reducer-drops-when-lastError-fresh, forward-synthetic-shape) preserved, 2 renames reconciled, obsolete manual retry-action removed, new `pi-retry-settings` capability added.

All 5 specs pass `openspec validate`. No code change.