### PR TITLE
fix(test): repair CI — zombie-resume test drift left develop red

### DIFF
--- a/packages/server/src/__tests__/session-action-handler-headless-reload.test.ts
+++ b/packages/server/src/__tests__/session-action-handler-headless-reload.test.ts
@@ -54,6 +54,12 @@ function makeCtx(
     },
     piGateway: {
       sendToSession: vi.fn().mockReturnValue(true),
+      // A live bridge. `handleSendPrompt` / `handleResumeSession` probe this via
+      // `isSessionProcessGone` to tell a genuinely-running session from a
+      // crash-orphaned zombie (change: resume-zombie-active-session). These
+      // tests all assert the FORWARD-to-bridge path, which is exactly the
+      // "process is live" branch, so it must report connected.
+      isSessionConnected: vi.fn().mockReturnValue(true),
     },
     headlessPidRegistry: {
       getPid: (sid: string) => pidBySession[sid],

--- a/packages/server/src/__tests__/session-api.test.ts
+++ b/packages/server/src/__tests__/session-api.test.ts
@@ -8,12 +8,25 @@ let httpPort: number;
 let piPort: number;
 let server: DashboardServer;
 
+// Sessions whose process carrier (keeper) is genuinely alive. `resume` rejects
+// "already active" ONLY when the process is provably live; a session that is
+// merely RECORDED as active with a dead carrier is a crash-orphaned zombie and
+// must fall through to reopen. See change: resume-zombie-active-session.
+// `vi.hoisted` because `vi.mock` factories are hoisted above module init.
+const { liveCarriers } = vi.hoisted(() => ({ liveCarriers: new Set<string>() }));
+
 // Mock spawnPiSession to avoid actually spawning processes
 vi.mock("../spawn-process/process-manager.js", async (importOriginal) => {
   const orig: any = await importOriginal();
   return {
     ...orig,
     spawnPiSession: vi.fn().mockResolvedValue({ success: true, message: "spawned" }),
+    // No bridge is connected in these tests, so the keeper probe is the only
+    // thing that can make a session read as genuinely live.
+    getKeeperManager: () => ({
+      ...orig.getKeeperManager(),
+      isKeeperAlive: (sessionId: string) => liveCarriers.has(sessionId),
+    }),
   };
 });
 
@@ -173,8 +186,26 @@ describe("Session Control REST API", () => {
 
   it("POST /api/session/:id/resume — 409 if session still active", async () => {
     registerSession("resume-active", { sessionFile: "/path/session.jsonl" });
-    const res = await postJson("/api/session/resume-active/resume", { mode: "continue" });
-    expect(res.status).toBe(409);
+    // Genuinely live: a keeper still carries the process. Reopening this would
+    // double-spawn (the gateway session→connection map is last-write-wins).
+    liveCarriers.add("resume-active");
+    try {
+      const res = await postJson("/api/session/resume-active/resume", { mode: "continue" });
+      expect(res.status).toBe(409);
+    } finally {
+      liveCarriers.delete("resume-active");
+    }
+  });
+
+  // Counterpart of the above, and the REST-layer coverage the zombie fix never
+  // got: same "active" record, but NO live carrier and no bridge. This is the
+  // crash/OOM/kill-9 case that used to be permanently unrecoverable — 409 on
+  // resume, prompt dropped on send. It MUST fall through to reopen.
+  it("POST /api/session/:id/resume — reopens a crash-orphaned zombie whose process is gone", async () => {
+    registerSession("resume-zombie", { sessionFile: "/path/zombie.jsonl" });
+    expect(liveCarriers.has("resume-zombie")).toBe(false);
+    const res = await postJson("/api/session/resume-zombie/resume", { mode: "continue" });
+    expect(res.status).toBe(200);
   });
 
   // ── flow-control ────────────────────────────────────────────────


### PR DESCRIPTION
## Why

`develop` has been red since **d24979d0e** (`resume-zombie-active-session`), and it is blocking every open PR (#439, `os/fix-openspec-board-drop-targeting`, `os/add-folder-actions-menu` all failed in the same window with identical signatures).

That commit added `piGateway.isSessionConnected` probes to the send/resume guards and updated `session-action-handler.test.ts` — but missed two other suites:

| Failure | Suite | Cause |
|---|---|---|
| 5× `TypeError: piGateway.isSessionConnected is not a function` | `session-action-handler-headless-reload.test.ts` | builds its **own** `piGateway` mock, which never gained the new method |
| `AssertionError: expected 200 to be 409` | `session-api.test.ts` | drives the **real** server, so the semantics moved under it |

The second is the interesting one. `"409 if session still active"` registers a session that is merely *recorded* active. With no bridge and no keeper, that is now exactly the crash-orphaned **zombie** the change made recoverable — so returning 200 is *correct*. The test was asserting the old contract.

## Fix

- Add `isSessionConnected: () => true` to the headless-reload mock. Those tests all assert the forward-to-bridge path, which **is** the "process is live" branch, so it's the semantically right value — not a value picked to make red go green.
- Give `session-api.test.ts` a `liveCarriers` set behind a `getKeeperManager` mock (with no bridge connected, the keeper probe is the only liveness signal available) and have the 409 test mark its session genuinely live. This **restores the test's original intent** rather than weakening the assertion to match current behaviour.

Also adds the REST-layer coverage the zombie fix never got: same `"active"` record, no live carrier → must reopen (200). That is the case which used to be permanently unrecoverable (409 on resume, prompt dropped on send), and nothing at this layer pinned it — which is precisely how the drift reached `develop` unnoticed.

## Verification

- Both suites: **38/38** (37 + the new zombie case).
- Full suite: the 6 target failures are gone. 5 unrelated failures remain, and I checked them rather than assuming — they pass in isolation **both with and without** this change, i.e. full-suite-only flakes under CPU oversubscription (a mode this repo already documents and raised `asyncUtilTimeout` for). They are not touched by a 2-file mock change.
- Biome: findings on the changed files are **3 → 3**; all pre-existing, none introduced.
- **No production code touched.**

## Note

`openspec/specs/session-resume/spec.md` still states *"Resume already active session → error"* unqualified, with no scenario for the zombie fall-through. d24979d0e shipped no spec update. Out of scope here (this PR only unblocks CI), but worth a follow-up so the spec matches the implemented contract.
