### PR TITLE
Align faux harness pi-settings seed with the split default-model schema

### DIFF
--- a/docker/test-entrypoint.sh
+++ b/docker/test-entrypoint.sh
@@ -229,9 +229,12 @@ if [ "${PI_E2E_SEED:-}" = "1" ]; then
     echo "[test-entrypoint] PI_E2E_SEED: staged notify driver → ${NOTIFY_EXT_DIR}"
   fi
 
-  # Also seed pi's own settings.json defaultModel (read at pi startup) so the
-  # faux model is selected even before the bridge gate runs. Merge — never
-  # clobber existing keys. No-op when already set.
+  # Also seed pi's own settings.json default model (read at pi startup) so the
+  # faux model is selected even before the bridge gate runs. pi 0.84 resolves
+  # the default model from the SPLIT pair `defaultProvider` + `defaultModel`, not
+  # the legacy combined `"provider/model"` string; seed the split pair so the
+  # faux model resolves at pi startup rather than depending on the bridge to
+  # correct it afterwards. Merge — never clobber existing keys. No-op when set.
   SETTINGS="${PI_DIR}/agent/settings.json"
   if [ ! -f "${SETTINGS}" ] || ! grep -q '"defaultModel"' "${SETTINGS}" 2>/dev/null; then
     node -e '
@@ -239,11 +242,12 @@ if [ "${PI_E2E_SEED:-}" = "1" ]; then
       const p = process.argv[1];
       let cfg = {};
       try { cfg = JSON.parse(fs.readFileSync(p, "utf8")); } catch { cfg = {}; }
-      if (!cfg.defaultModel) cfg.defaultModel = "faux/faux-1";
+      if (!cfg.defaultProvider) cfg.defaultProvider = "faux";
+      if (!cfg.defaultModel) cfg.defaultModel = "faux-1";
       fs.mkdirSync(require("node:path").dirname(p), { recursive: true });
       fs.writeFileSync(p, JSON.stringify(cfg, null, 2) + "\n");
     ' "${SETTINGS}"
-    echo "[test-entrypoint] PI_E2E_SEED: seeded defaultModel → settings.json"
+    echo "[test-entrypoint] PI_E2E_SEED: seeded defaultProvider + defaultModel → settings.json"
   fi
 
   # --- Faux role-preset: every role -> faux/faux-1 (change: add-flow-plugin-e2e-tests) ---

--- a/openspec/changes/align-faux-settings-seed-schema/proposal.md
+++ b/openspec/changes/align-faux-settings-seed-schema/proposal.md
@@ -1,0 +1,34 @@
+# Align the faux harness pi-settings seed with the split default-model schema
+
+## Why
+
+When `PI_E2E_SEED=1`, `docker/test-entrypoint.sh` seeds pi's own
+`~/.pi/agent/settings.json` so the faux model is selected the moment pi starts —
+before the bridge's default-model gate runs. It writes the legacy **combined**
+form `defaultModel: "faux/faux-1"`.
+
+Current pi resolves the startup default model from the **split** pair
+`defaultProvider` + `defaultModel`, not from a combined `"provider/model"`
+string. With only the combined value seeded, the faux model does not resolve at
+pi startup and the harness relies on the bridge to correct the model afterwards.
+
+Seeding the split pair makes the faux model resolve deterministically at pi
+startup, matching the schema pi actually reads. This is strictly faux-harness
+seed correctness; no runtime spawn plane changes.
+
+## What Changes
+
+- `docker/test-entrypoint.sh` (`PI_E2E_SEED` path): the `settings.json` seed
+  writer emits the split pair `defaultProvider: "faux"` + `defaultModel: "faux-1"`
+  instead of the combined `defaultModel: "faux/faux-1"`. The merge stays
+  non-clobbering (each key is only written when absent) and the guard is
+  unchanged.
+
+No dashboard runtime code, no spawn plane, and no other seed block (the
+`config.json` model-proxy seed keeps its own combined value) is touched.
+
+## Discipline Skills
+
+None apply. This is a one-block schema alignment in a test-only harness seed
+script; it touches no auth/untrusted-input/secrets/PII path, no latency budget,
+and adds no new endpoint or external call.

--- a/openspec/changes/align-faux-settings-seed-schema/specs/docker-test-harness/spec.md
+++ b/openspec/changes/align-faux-settings-seed-schema/specs/docker-test-harness/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: The faux seed writes pi's startup default model as a split provider/model pair
+
+When the harness seeds pi's own `~/.pi/agent/settings.json` under `PI_E2E_SEED`,
+it SHALL write the default model as the split pair `defaultProvider` +
+`defaultModel` (the schema pi reads at startup) rather than a legacy combined
+`"provider/model"` string, so the faux model resolves at pi startup without
+depending on a later correction. The seed SHALL remain non-clobbering: each key
+is written only when absent, and an existing value is preserved.
+
+#### Scenario: Seed emits the split faux pair on a fresh settings file
+
+- **WHEN** the harness seeds `settings.json` for a container with no prior pi
+  default-model configuration
+- **THEN** the written file SHALL contain `defaultProvider: "faux"`
+- **AND** the written file SHALL contain `defaultModel: "faux-1"`
+- **AND** it SHALL NOT write the combined `defaultModel: "faux/faux-1"` string
+
+#### Scenario: Existing default-model config is preserved
+
+- **WHEN** the harness seed runs against a `settings.json` that already carries a
+  `defaultProvider` or `defaultModel` value
+- **THEN** the existing value SHALL be preserved (the seed only fills an absent
+  key)

--- a/openspec/changes/align-faux-settings-seed-schema/tasks.md
+++ b/openspec/changes/align-faux-settings-seed-schema/tasks.md
@@ -1,0 +1,19 @@
+# Tasks — align-faux-settings-seed-schema
+
+## 1. Seed the split default-model schema
+
+- [x] 1.1 `docker/test-entrypoint.sh` (`PI_E2E_SEED` settings.json block):
+  change the seed writer to emit the split pair
+  `defaultProvider: "faux"` + `defaultModel: "faux-1"` (each written only when
+  absent) instead of the combined `defaultModel: "faux/faux-1"`; update the log
+  line and comment accordingly. Leave the guard and every other seed block
+  untouched.
+
+## 2. Verify
+
+- [x] 2.1 Reproduce the seed writer in isolation: run the block's node snippet
+  against a scratch file and assert the emitted JSON carries
+  `defaultProvider: "faux"` and `defaultModel: "faux-1"`.
+- [x] 2.2 `bash -n docker/test-entrypoint.sh` (syntax) clean.
+- [x] 2.3 `npm run build` clean.
+- [x] 2.4 `openspec validate align-faux-settings-seed-schema --strict`.


### PR DESCRIPTION
## Why

The `PI_E2E_SEED` path in `docker/test-entrypoint.sh` seeds pi's own `~/.pi/agent/settings.json` so the faux model is selected at pi startup. It wrote the legacy combined form `defaultModel: "faux/faux-1"`, but pi resolves the startup default model from the split pair `defaultProvider` + `defaultModel`. With only the combined value seeded the faux model did not resolve at startup and relied on the bridge to correct it afterwards.

## What

- `docker/test-entrypoint.sh` settings.json seed writer now emits the split pair `defaultProvider: "faux"` + `defaultModel: "faux-1"`. Non-clobbering merge and guard unchanged; no other seed block (e.g. the config.json model-proxy seed) touched. No runtime/spawn-plane code changes.

## Verify

- Seed-writer isolation: emits split pair on fresh file; preserves existing config — both PASS.
- `bash -n docker/test-entrypoint.sh` clean.
- `npm run build` clean.
- `openspec validate align-faux-settings-seed-schema --strict` OK.