### PR TITLE
feat(replay-invoice-domain-events): cache + replay ib_domain_event on connect

### DIFF
--- a/openspec/changes/replay-invoice-domain-events/design.md
+++ b/openspec/changes/replay-invoice-domain-events/design.md
@@ -1,0 +1,91 @@
+# Design — replay-invoice-domain-events
+
+## The one design question: how to make a late subscriber converge
+
+`ib_domain_event` reaches the browser correctly while live, but the server keeps
+no memory of it. A surface that mounts/fetches after the delta never catches up.
+The fix mirrors the already-proven `plugin_intents` pattern, adapted to the fact
+that domain events are **global** (not per-session-subscribe) and are addressed
+by **invoice**, not session.
+
+## Decision 1 — retain LATEST-per-key, not a bounded log
+
+**Choice:** cache the single most recent frame per key (a `Map`), exactly like
+`PluginIntentCache`.
+
+**Why:** board surfaces want *current truth*, not history. The board renders the
+invoice's current state; replaying the latest `ib_invoice_state_changed` per
+invoice converges it. A bounded event *log* would (a) grow with churn, (b) force
+consumers to fold an ordered sequence at connect, and (c) risk double-application.
+Latest-per-key is idempotent to replay: applying it twice yields the same state.
+
+**Cost:** intermediate transitions are not replayable after the fact. Acceptable —
+the live stream already delivered them to connected clients, and a late joiner
+only needs the *current* resting state, which is the latest frame.
+
+## Decision 2 — key = eventType + best-effort entity id (invoice_id lives in data)
+
+The envelope is `{ type:"ib_domain_event", sessionId, event:{ eventType, data } }`.
+It is **not** invoice-addressed at the top level; `invoice_id` lives inside
+`event.data`. So the cache key is derived:
+
+```
+key = `${eventType}\u0000${entityId}`
+entityId = data.invoice_id ?? data.id ?? data.connector_id ?? data.which ?? ""
+```
+
+- Invoice lifecycle events (`ib_invoice_state_changed`, `ib_invoice_progress`,
+  `ib_invoice_cost_updated`, `ib_approval_*`) key by `invoice_id` → one live entry
+  per invoice per type, so each invoice converges independently.
+- Non-invoice events (`ib_connector_*`, `ib_intake_*`, `ib_automation_*`,
+  `ib_source_*`) key by their own id (or bare eventType) → the latest connector /
+  intake / automation state also converges.
+
+Keying is a pure function of the frame; no schema coupling beyond reading a couple
+of well-known optional fields, all guarded.
+
+## Decision 3 — bound memory by entry count + session-scoped purge
+
+- Hard cap `MAX_ENTRIES` (500). On overflow, evict the oldest-inserted key
+  (insertion-ordered `Map`, delete-then-set to refresh recency on update). 500
+  distinct (invoice×type) keys is far beyond any realistic live board and bounds
+  worst-case memory at a few hundred small frames.
+- `clearForSession(sessionId)` drops entries whose originating `sessionId`
+  matches, wired to session removal so a torn-down session's stale frames do not
+  replay forever. (The board key is invoice-based, but each entry retains its
+  originating `sessionId` for this purge and for the replayed frame.)
+
+## Decision 4 — replay is distinguishable via `replay: true`
+
+Live frames are emitted exactly as today (`replay` **absent**). Replayed frames
+carry `replay: true`. Contract for consumers: a `replay:true` frame is an
+**idempotent state-set** (converge to it), never an incremental delta — so a
+counter/animation driven by live deltas is not advanced twice. This is the
+"cannot double-apply" guarantee. The field is optional and additive, so a client
+written against the old shape ignores it and still applies the (idempotent) state.
+
+## Decision 5 — replay on browser CONNECT (global), not on session subscribe
+
+`plugin_intents` replays inside `handleSubscribe` because intents are
+session-scoped. Domain events are global and the board is not a session
+subscription, so replay belongs in the **on-connect snapshot block** of
+`browser-gateway.ts` (alongside `sessions_snapshot`, `pinned_dirs_updated`,
+`openspec_update`, …). Every newly connected browser receives the current cached
+domain-event state immediately, with no subscribe required.
+
+## Decision 6 — one observability log at the choke point
+
+At the `broadcastToSubscribers` interceptor, emit a **rate-limited** info line
+(every Nth `ib_domain_event`, e.g. 1/50) naming the eventType + entityId. This is
+purely additive logging on the fan-out path — NOT a forward-path change — and
+directly answers the prior misdiagnosis where an unlogged happy path read as
+"zero events". No happy-path log existed before; now the next incident is
+greppable.
+
+## What is deliberately NOT done
+
+- The forward path (engine `__ib_emit_*` → bridge → `plugin_pi_message` →
+  `registerPiHandler` → `broadcastToSubscribers`) is unchanged — proved correct.
+- No change to automation-plugin or invoicebot-plugin dispatch/fan-out.
+- No client rendering logic (board React lives in the UI repo); this change only
+  makes the state *recoverable* and *marked*, which the client consumes.

--- a/openspec/changes/replay-invoice-domain-events/proposal.md
+++ b/openspec/changes/replay-invoice-domain-events/proposal.md
@@ -1,0 +1,68 @@
+# Replay invoice domain events on connect
+
+## Why
+
+The app-level `ib_domain_event` channel is **live-delta only**. The plugin
+server rebroadcasts each `ib:*` lifecycle event to every connected browser
+(`packages/invoicebot-plugin/src/server/index.ts` →
+`ctx.broadcastToSubscribers`), and the core fan-out
+(`packages/server/src/server.ts:1877` → `browserGateway.broadcast`) sends it to
+all sockets **with no server-side cache**. Any surface that mounts, re-fetches,
+or reconnects *after* an event was broadcast has missed that delta forever and
+never reconciles — it waits for the next accidental delta. This is the honest,
+dashboard-owned cause behind the stale board/waiting-file strip: a fetch-on-mount
+surface has no way to converge on current truth.
+
+The dashboard already solved this exact shape for **plugin intents**: the same
+`broadcastToSubscribers` choke point intercepts `plugin_intents` frames and caches
+the latest per `(pluginId, sessionId, slot)`
+(`packages/server/src/plugin-intent-cache.ts`), then replays them to a
+(re)connecting/subscribing browser (`replayUiState` in
+`browser-handlers/subscription-handler.ts`). `ib_domain_event` has no equivalent.
+
+This change gives `ib_domain_event` the same recoverability: a bounded
+**latest-per-invoice** cache, replayed to each browser on connect and marked so
+consumers cannot double-apply it.
+
+## What changes
+
+- **New** `packages/server/src/ib-domain-event-cache.ts` — a bounded module
+  singleton retaining the **latest** `ib_domain_event` frame per key.
+- **Modify** the `broadcastToSubscribers` interceptor at
+  `packages/server/src/server.ts:1877` to `cache.set(...)` every `ib_domain_event`
+  it fans out (mirroring the adjacent `plugin_intents` interception) and to emit a
+  **rate-limited success log** so the next incident is not misdiagnosed as "zero
+  events" (the prior investigation's zero log-count was a logging artifact of an
+  unlogged happy path).
+- **Modify** the browser on-connect snapshot block in
+  `packages/server/src/pairing/browser-gateway.ts` to replay every cached
+  `ib_domain_event`, each stamped `replay: true`.
+- **Modify** `IbDomainEventMessage` in
+  `packages/shared/src/browser-protocol.ts` to add an optional `replay?: boolean`
+  discriminator (absent/false on live frames, `true` on replayed frames).
+- **Do not** touch the forward path (proved correct) nor
+  automation-plugin / invoicebot-plugin dispatch/fan-out (owned elsewhere).
+
+Out of scope: the front-end board poll being added as an independent safety net —
+this change does not assume it and is not a substitute for it.
+
+## Impact
+
+- Affected spec: `invoicebot-app-level-events` (one requirement MODIFIED — the
+  delta-only/no-replay guarantee is relaxed to latest-state convergence replay;
+  one requirement ADDED for the cache + replay marker).
+- Affected code: `packages/server` (new cache + two edits), `packages/shared`
+  (one optional field). No engine, no plugin bridge, no dispatch/fan-out.
+- Backward compatible wire: live frames keep the exact
+  `{ type, sessionId, event }` shape (`replay` absent); only replayed frames add
+  `replay: true`.
+
+## Discipline Skills
+
+- `review-code` — non-trivial server change with a new shared module and a
+  protocol field; run the inline review→fix loop before commit.
+- `performance-optimization` is **not** triggered: the cache is O(1) set + a
+  bounded connect-time replay; no measured latency budget is in play.
+- No auth/untrusted-input/secrets/PII surface is touched, so
+  `security-hardening` and `observability-instrumentation` beyond the single
+  success log do not apply.

--- a/openspec/changes/replay-invoice-domain-events/specs/invoicebot-app-level-events/spec.md
+++ b/openspec/changes/replay-invoice-domain-events/specs/invoicebot-app-level-events/spec.md
@@ -1,0 +1,107 @@
+## MODIFIED Requirements
+
+### Requirement: App-level channel is reconnect-safe and delta-only
+
+The app-level channel SHALL stream live deltas. In addition, the server SHALL
+retain the **latest** `ib_domain_event` frame per entity key (the invoice, or the
+event's own entity when it carries no invoice) and SHALL replay those retained
+frames to a browser **on connect**, so a surface that mounts, re-fetches, or
+reconnects after an event was emitted converges on current truth instead of
+waiting for the next accidental delta.
+
+The retained set SHALL be the latest event per key only — the server SHALL NOT
+replay a full historical **log** of domain events, and SHALL NOT be responsible
+for out-of-band baseline snapshots. A replayed frame SHALL be distinguishable from
+a live frame by an additive `replay: true` field (absent/false on live frames), so
+a consumer applies it as an idempotent state-set and never double-applies it. A
+dropped browser connection SHALL NOT corrupt server state.
+
+#### Scenario: Reconnecting client receives the latest cached state
+
+- **WHEN** a browser connects (first connect or reconnect)
+- **THEN** for every entity with a cached domain event, it SHALL receive
+  `{ type: "ib_domain_event", sessionId, event: { eventType, data }, replay: true }`
+  carrying that entity's latest event
+- **AND** it SHALL then receive subsequently-forwarded live events on the same
+  channel
+
+#### Scenario: Latest state supersedes, no history log is replayed
+
+- **WHEN** an invoice transitions through several states before a browser connects
+- **THEN** the connecting browser SHALL receive exactly one replayed
+  `ib_invoice_state_changed` frame for that invoice — its latest state
+- **AND** it SHALL NOT receive the superseded intermediate states as replay frames
+
+#### Scenario: Replayed frame is marked and live frame is not
+
+- **WHEN** the server replays a cached domain event on connect
+- **THEN** the frame SHALL carry `replay: true`
+- **WHEN** the server broadcasts a live domain event
+- **THEN** the frame SHALL NOT carry `replay: true` (the field is absent)
+
+#### Scenario: Disconnect does not corrupt state
+
+- **WHEN** a subscribed browser's connection drops mid-stream
+- **THEN** the server SHALL continue broadcasting to the remaining browsers
+  without error
+- **AND** the retained latest-state cache SHALL be unaffected
+
+## ADDED Requirements
+
+### Requirement: Latest invoice domain-event state is cached with bounded memory
+
+The server SHALL cache the latest `ib_domain_event` frame per entity key at the
+same broadcast choke point that fans domain events to browsers. The key SHALL be
+derived from the frame — `eventType` combined with the entity id read from
+`event.data` (`invoice_id` for invoice lifecycle events, else the event's own
+entity id, else the bare `eventType`) — because the envelope is not
+invoice-addressed at the top level. The cache SHALL bound its memory by a hard
+maximum entry count, evicting the oldest entry on overflow, and SHALL drop a
+session's cached entries when that session is removed. Caching SHALL be a no-op
+for a malformed frame (missing `sessionId`, `eventType`, or `data`) and SHALL
+never throw on the broadcast path.
+
+#### Scenario: Latest event per invoice is retained
+
+- **WHEN** two `ib_invoice_state_changed` events for the same `invoice_id` are
+  broadcast in order
+- **THEN** the cache SHALL retain only the second (latest) frame for that invoice
+
+#### Scenario: Distinct invoices are cached independently
+
+- **WHEN** `ib_invoice_state_changed` events for two different `invoice_id`s are
+  broadcast
+- **THEN** the cache SHALL retain one latest frame per invoice
+
+#### Scenario: Memory is bounded by entry count
+
+- **WHEN** more than the maximum number of distinct entity keys are cached
+- **THEN** the cache SHALL evict the oldest-inserted entry so its size never
+  exceeds the maximum
+
+#### Scenario: Session removal purges its cached events
+
+- **WHEN** a session that produced cached domain events is removed
+- **THEN** the cache SHALL drop the entries originating from that session
+
+#### Scenario: Malformed frame is not cached
+
+- **WHEN** a frame missing `sessionId`, `eventType`, or `data` reaches the
+  broadcast choke point
+- **THEN** the cache SHALL skip it without throwing
+- **AND** a subsequent well-formed frame SHALL still be cached and broadcast
+
+### Requirement: Domain-event broadcast emits a rate-limited success log
+
+The server SHALL emit a rate-limited informational log entry on the
+`ib_domain_event` broadcast path identifying the event type and entity, so an
+operational incident is not misdiagnosed as "zero events" when the happy path is
+simply unlogged. The log SHALL be sampled (not one line per event) and SHALL never
+throw or block the broadcast.
+
+#### Scenario: A broadcast domain event is observable in logs
+
+- **WHEN** `ib_domain_event` frames are broadcast
+- **THEN** at least one sampled informational log entry SHALL be produced
+  identifying the event type
+- **AND** logging SHALL never throw on the broadcast path

--- a/openspec/changes/replay-invoice-domain-events/tasks.md
+++ b/openspec/changes/replay-invoice-domain-events/tasks.md
@@ -2,55 +2,55 @@
 
 ## 1. Cache module (TDD)
 
-- [ ] 1.1 Write `packages/server/src/__tests__/ib-domain-event-cache.test.ts` first
+- [x] 1.1 Write `packages/server/src/__tests__/ib-domain-event-cache.test.ts` first
   (RED): latest-per-key retention, distinct-invoice independence, key derivation
   (`invoice_id` from `event.data`, fallback to `id`/`connector_id`/`which`/bare
   eventType), `MAX_ENTRIES` eviction of oldest, `clearForSession` purge,
   malformed-frame no-op.
-- [ ] 1.2 Add `packages/server/src/ib-domain-event-cache.ts`: `IbDomainEventCache`
+- [x] 1.2 Add `packages/server/src/ib-domain-event-cache.ts`: `IbDomainEventCache`
   class (`set(frame)`, `getAll()`, `clearForSession(sessionId)`, `reset()`) +
   module singleton `ibDomainEventCache`. Insertion-ordered `Map`; delete-then-set
   to refresh recency; hard cap eviction. Mirror `plugin-intent-cache.ts` shape.
-- [ ] 1.3 Green 1.1.
+- [x] 1.3 Green 1.1.
 
 ## 2. Wire caching + observability at the broadcast choke point
 
-- [ ] 2.1 In `packages/server/src/server.ts` `broadcastToSubscribers` interceptor
+- [x] 2.1 In `packages/server/src/server.ts` `broadcastToSubscribers` interceptor
   (≈:1877, beside the `plugin_intents` interception): when
   `m.type === "ib_domain_event"`, `ibDomainEventCache.set(m)` guarded (never throw).
-- [ ] 2.2 Add a rate-limited (1/50) info log at the same point naming
+- [x] 2.2 Add a rate-limited (1/50) info log at the same point naming
   `event.eventType` + derived entity id.
-- [ ] 2.3 Wire `ibDomainEventCache.clearForSession(...)` to the same session-removal
+- [x] 2.3 Wire `ibDomainEventCache.clearForSession(...)` to the same session-removal
   path that clears `pluginIntentCache` (find the existing `clearForSession` call
   site; add the sibling call).
 
 ## 3. Protocol field
 
-- [ ] 3.1 In `packages/shared/src/browser-protocol.ts`, add optional
+- [x] 3.1 In `packages/shared/src/browser-protocol.ts`, add optional
   `replay?: boolean` to `IbDomainEventMessage` with a doc comment (absent/false =
   live, true = replayed idempotent state-set).
 
 ## 4. Replay on connect (TDD)
 
-- [ ] 4.1 Write a server integration test (RED): connect a browser AFTER an
+- [x] 4.1 Write a server integration test (RED): connect a browser AFTER an
   `ib_domain_event` was broadcast; assert the browser receives the cached frame
   with `replay: true`; assert a live event broadcast afterwards arrives without
   `replay`. Mirror `ib-app-level-rebroadcast.test.ts` harness
   (`packages/invoicebot-plugin/src/server/__tests__/`) or a `packages/server`
   gateway test — whichever runs without the plugin dispatch surface.
-- [ ] 4.2 In `packages/server/src/pairing/browser-gateway.ts` on-connect snapshot
+- [x] 4.2 In `packages/server/src/pairing/browser-gateway.ts` on-connect snapshot
   block (beside `sessions_snapshot` / `pinned_dirs_updated`): for each
   `ibDomainEventCache.getAll()` entry, `sendTo(ws, { ...frame, replay: true })`.
-- [ ] 4.3 Green 4.1.
+- [x] 4.3 Green 4.1.
 
 ## 5. Gate (e2e OFF — do NOT run the faux e2e suite)
 
-- [ ] 5.1 `npx tsc -p tsconfig.typecheck.json` (or the repo's typecheck) clean for
+- [x] 5.1 `npx tsc -p tsconfig.typecheck.json` (or the repo's typecheck) clean for
   touched packages.
-- [ ] 5.2 Scoped unit tests green: the new cache test, the connect-replay test, and
+- [x] 5.2 Scoped unit tests green: the new cache test, the connect-replay test, and
   the existing `ib-app-level-rebroadcast` regression.
-- [ ] 5.3 `npm run build` (Vite client) succeeds.
-- [ ] 5.4 Verify no automation-plugin / invoicebot-plugin dispatch/fan-out file was
+- [x] 5.3 `npm run build` (Vite client) succeeds.
+- [x] 5.4 Verify no automation-plugin / invoicebot-plugin dispatch/fan-out file was
   touched (`git diff --name-only`).
 
 ## 6. Manual / QA (verified post-merge on the operator's instance)

--- a/openspec/changes/replay-invoice-domain-events/tasks.md
+++ b/openspec/changes/replay-invoice-domain-events/tasks.md
@@ -1,0 +1,59 @@
+# Tasks — replay-invoice-domain-events
+
+## 1. Cache module (TDD)
+
+- [ ] 1.1 Write `packages/server/src/__tests__/ib-domain-event-cache.test.ts` first
+  (RED): latest-per-key retention, distinct-invoice independence, key derivation
+  (`invoice_id` from `event.data`, fallback to `id`/`connector_id`/`which`/bare
+  eventType), `MAX_ENTRIES` eviction of oldest, `clearForSession` purge,
+  malformed-frame no-op.
+- [ ] 1.2 Add `packages/server/src/ib-domain-event-cache.ts`: `IbDomainEventCache`
+  class (`set(frame)`, `getAll()`, `clearForSession(sessionId)`, `reset()`) +
+  module singleton `ibDomainEventCache`. Insertion-ordered `Map`; delete-then-set
+  to refresh recency; hard cap eviction. Mirror `plugin-intent-cache.ts` shape.
+- [ ] 1.3 Green 1.1.
+
+## 2. Wire caching + observability at the broadcast choke point
+
+- [ ] 2.1 In `packages/server/src/server.ts` `broadcastToSubscribers` interceptor
+  (≈:1877, beside the `plugin_intents` interception): when
+  `m.type === "ib_domain_event"`, `ibDomainEventCache.set(m)` guarded (never throw).
+- [ ] 2.2 Add a rate-limited (1/50) info log at the same point naming
+  `event.eventType` + derived entity id.
+- [ ] 2.3 Wire `ibDomainEventCache.clearForSession(...)` to the same session-removal
+  path that clears `pluginIntentCache` (find the existing `clearForSession` call
+  site; add the sibling call).
+
+## 3. Protocol field
+
+- [ ] 3.1 In `packages/shared/src/browser-protocol.ts`, add optional
+  `replay?: boolean` to `IbDomainEventMessage` with a doc comment (absent/false =
+  live, true = replayed idempotent state-set).
+
+## 4. Replay on connect (TDD)
+
+- [ ] 4.1 Write a server integration test (RED): connect a browser AFTER an
+  `ib_domain_event` was broadcast; assert the browser receives the cached frame
+  with `replay: true`; assert a live event broadcast afterwards arrives without
+  `replay`. Mirror `ib-app-level-rebroadcast.test.ts` harness
+  (`packages/invoicebot-plugin/src/server/__tests__/`) or a `packages/server`
+  gateway test — whichever runs without the plugin dispatch surface.
+- [ ] 4.2 In `packages/server/src/pairing/browser-gateway.ts` on-connect snapshot
+  block (beside `sessions_snapshot` / `pinned_dirs_updated`): for each
+  `ibDomainEventCache.getAll()` entry, `sendTo(ws, { ...frame, replay: true })`.
+- [ ] 4.3 Green 4.1.
+
+## 5. Gate (e2e OFF — do NOT run the faux e2e suite)
+
+- [ ] 5.1 `npx tsc -p tsconfig.typecheck.json` (or the repo's typecheck) clean for
+  touched packages.
+- [ ] 5.2 Scoped unit tests green: the new cache test, the connect-replay test, and
+  the existing `ib-app-level-rebroadcast` regression.
+- [ ] 5.3 `npm run build` (Vite client) succeeds.
+- [ ] 5.4 Verify no automation-plugin / invoicebot-plugin dispatch/fan-out file was
+  touched (`git diff --name-only`).
+
+## 6. Manual / QA (verified post-merge on the operator's instance)
+
+- [ ] 6.1 A board surface that mounts after a state change converges via the
+  `replay: true` frame (front-end board poll is a separate safety net, not assumed).

--- a/packages/invoicebot-plugin/src/server/__tests__/ib-app-level-rebroadcast.test.ts
+++ b/packages/invoicebot-plugin/src/server/__tests__/ib-app-level-rebroadcast.test.ts
@@ -15,6 +15,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { WebSocket } from "ws";
 import { createServer, type DashboardServer } from "../../../../server/src/server.js";
+import { ibDomainEventCache } from "../../../../server/src/ib-domain-event-cache.js";
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -82,10 +83,15 @@ describe("invoicebot plugin: app-level ib_domain_event rebroadcast", () => {
     await server.start();
     browserPort = server.httpPort()!;
     piPort = server.piPort()!;
+    // The domain-event cache is a module singleton that outlives per-test server
+    // instances; reset it so replay-on-connect starts clean each test.
+    // See change: replay-invoice-domain-events.
+    ibDomainEventCache.reset();
   });
 
   afterEach(async () => {
     await server.stop();
+    ibDomainEventCache.reset();
   });
 
   it("reaches a connected-but-UNSUBSCRIBED browser with the unchanged wire frame", async () => {
@@ -153,22 +159,30 @@ describe("invoicebot plugin: app-level ib_domain_event rebroadcast", () => {
     sendIbPluginMessage(session, "ib3", { eventType: "ib_approval_decided", data: { invoiceId: "inv-1", decision: "approve" } });
     await wait(150);
 
-    const appLevel = messages.filter((m) => m.type === "ib_domain_event");
-    expect(appLevel.length).toBe(1);
-    expect(appLevel[0].event).toEqual({
+    // Only LIVE frames (replay !== true) assert the malformed-skip contract; the
+    // pre-connect event is now cached and replayed on connect (replay: true),
+    // which is the intended new behavior. See change: replay-invoice-domain-events.
+    const liveFrames = messages.filter((m) => m.type === "ib_domain_event" && (m as { replay?: boolean }).replay !== true);
+    expect(liveFrames.length).toBe(1);
+    expect(liveFrames[0].event).toEqual({
       eventType: "ib_approval_decided",
       data: { invoiceId: "inv-1", decision: "approve" },
     });
+    // The null-data (malformed) frame is neither cached nor broadcast.
     expect(server.sessionManager.get("ib3")).toBeDefined();
 
     session.close();
     browser.close();
   });
 
-  it("resumes the live stream on reconnect with no historical replay", async () => {
+  it("replays the latest cached state on reconnect, then resumes the live stream", async () => {
+    // Supersedes the prior "no historical replay" guarantee: a browser that
+    // (re)connects now receives the latest cached domain event per key marked
+    // replay:true, then live deltas. See change: replay-invoice-domain-events.
     const session = await connectSession(piPort, "ib4");
 
     const first = await connectBrowser(browserPort);
+    // Empty cache at connect → the first live event is the only frame.
     sendIbPluginMessage(session, "ib4", { eventType: "ib_approval_requested", data: { invoiceId: "before" } });
     await wait(120);
     expect(first.messages.filter((m) => m.type === "ib_domain_event").length).toBe(1);
@@ -179,12 +193,20 @@ describe("invoicebot plugin: app-level ib_domain_event rebroadcast", () => {
     await wait(100);
 
     const second = await connectBrowser(browserPort);
+    await wait(100);
+    // On connect the second browser is replayed the latest cached state (both
+    // event types), each marked replay:true — it converges without waiting.
+    const replayed = second.messages.filter((m) => m.type === "ib_domain_event" && (m as { replay?: boolean }).replay === true);
+    expect(replayed.length).toBe(2);
+    expect(replayed.every((m) => (m as { replay?: boolean }).replay === true)).toBe(true);
+
     sendIbPluginMessage(session, "ib4", { eventType: "ib_approval_requested", data: { invoiceId: "after" } });
     await wait(150);
 
-    const received = second.messages.filter((m) => m.type === "ib_domain_event");
-    expect(received.length).toBe(1);
-    expect((received[0].event as Record<string, unknown>).data).toEqual({ invoiceId: "after" });
+    // The subsequent live delta arrives WITHOUT the replay marker.
+    const live = second.messages.filter((m) => m.type === "ib_domain_event" && (m as { replay?: boolean }).replay !== true);
+    expect(live.length).toBe(1);
+    expect((live[0].event as Record<string, unknown>).data).toEqual({ invoiceId: "after" });
 
     session.close();
     second.ws.close();

--- a/packages/invoicebot-plugin/src/server/__tests__/ib-domain-event-replay-on-connect.test.ts
+++ b/packages/invoicebot-plugin/src/server/__tests__/ib-domain-event-replay-on-connect.test.ts
@@ -1,0 +1,139 @@
+/**
+ * replay-invoice-domain-events · integration (full server). A browser that
+ * connects AFTER an ib_domain_event was broadcast MUST be replayed the latest
+ * cached frame on connect, marked `replay: true`, so a late-mounting surface
+ * converges on current truth. A subsequently-broadcast LIVE event MUST arrive
+ * without the `replay` marker.
+ *
+ * RED on the pre-change tree: nothing caches ib_domain_event, so a
+ * later-connecting browser receives nothing on connect.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { createServer, type DashboardServer } from "../../../../server/src/server.js";
+import { ibDomainEventCache } from "../../../../server/src/ib-domain-event-cache.js";
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function connectSession(piPort: number, sessionId: string): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${piPort}`);
+  await new Promise<void>((resolve) => {
+    ws.on("open", () => {
+      ws.send(JSON.stringify({ type: "session_register", sessionId, cwd: "/tmp", source: "cli" }));
+      ws.send(JSON.stringify({ type: "replay_complete", sessionId }));
+      setTimeout(resolve, 60);
+    });
+  });
+  return ws;
+}
+
+async function connectBrowser(browserPort: number): Promise<{
+  ws: WebSocket;
+  messages: Array<Record<string, unknown>>;
+}> {
+  const ws = new WebSocket(`ws://127.0.0.1:${browserPort}/ws`);
+  const messages: Array<Record<string, unknown>> = [];
+  await new Promise<void>((resolve) => {
+    ws.on("open", () => {
+      ws.on("message", (raw) => {
+        try {
+          messages.push(JSON.parse(raw.toString()));
+        } catch { /* ignore */ }
+      });
+      setTimeout(resolve, 60);
+    });
+  });
+  return { ws, messages };
+}
+
+function sendIbPluginMessage(ws: WebSocket, sessionId: string, payload: unknown): void {
+  ws.send(JSON.stringify({ type: "plugin_pi_message", sessionId, pluginId: "invoicebot", messageType: "ib_domain_event", payload }));
+}
+
+describe("invoicebot: ib_domain_event replay on connect", () => {
+  let server: DashboardServer;
+  let piPort: number;
+  let browserPort: number;
+
+  beforeEach(async () => {
+    ibDomainEventCache.reset();
+    server = await createServer({
+      port: 0,
+      piPort: 0,
+      host: "127.0.0.1",
+      dev: true,
+      autoShutdown: false,
+      shutdownIdleSeconds: 999,
+      tunnel: false,
+    });
+    await server.start();
+    browserPort = server.httpPort()!;
+    piPort = server.piPort()!;
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    ibDomainEventCache.reset();
+  });
+
+  it("replays the latest cached domain event to a LATER-connecting browser marked replay:true", async () => {
+    const session = await connectSession(piPort, "ib-replay");
+
+    // A live event is broadcast while NO late browser is connected yet.
+    sendIbPluginMessage(session, "ib-replay", {
+      eventType: "ib_invoice_state_changed",
+      data: { invoice_id: "inv-1", state: "partner_pending" },
+    });
+    await wait(150);
+
+    // Browser connects AFTER the event — on the pre-change tree it gets nothing.
+    const { ws: late, messages } = await connectBrowser(browserPort);
+    await wait(150);
+
+    const replayed = messages.filter((m) => m.type === "ib_domain_event");
+    expect(replayed.length).toBe(1);
+    expect(replayed[0]).toEqual({
+      type: "ib_domain_event",
+      sessionId: "ib-replay",
+      event: { eventType: "ib_invoice_state_changed", data: { invoice_id: "inv-1", state: "partner_pending" } },
+      replay: true,
+    });
+
+    // A subsequent LIVE event arrives WITHOUT the replay marker.
+    sendIbPluginMessage(session, "ib-replay", {
+      eventType: "ib_invoice_state_changed",
+      data: { invoice_id: "inv-1", state: "approved" },
+    });
+    await wait(150);
+
+    const live = messages.filter((m) => m.type === "ib_domain_event" && m.replay !== true);
+    expect(live.length).toBe(1);
+    expect((live[0] as { event: { data: { state: string } } }).event.data.state).toBe("approved");
+
+    session.close();
+    late.close();
+  });
+
+  it("replays only the LATEST state per invoice, not superseded intermediates", async () => {
+    const session = await connectSession(piPort, "ib-latest");
+    for (const state of ["received", "extracted", "partner_pending"]) {
+      sendIbPluginMessage(session, "ib-latest", {
+        eventType: "ib_invoice_state_changed",
+        data: { invoice_id: "inv-2", state },
+      });
+      await wait(40);
+    }
+    await wait(120);
+
+    const { ws: late, messages } = await connectBrowser(browserPort);
+    await wait(150);
+
+    const replayed = messages.filter((m) => m.type === "ib_domain_event");
+    expect(replayed.length).toBe(1);
+    expect((replayed[0] as { event: { data: { state: string } }; replay?: boolean }).event.data.state).toBe("partner_pending");
+    expect((replayed[0] as { replay?: boolean }).replay).toBe(true);
+
+    session.close();
+    late.close();
+  });
+});

--- a/packages/server/src/__tests__/ib-domain-event-cache.test.ts
+++ b/packages/server/src/__tests__/ib-domain-event-cache.test.ts
@@ -1,0 +1,90 @@
+/**
+ * IbDomainEventCache — latest-per-entity retention of app-level ib_domain_event
+ * frames so a browser that connects after an event was broadcast can converge.
+ *
+ * See change: replay-invoice-domain-events.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { IbDomainEventCache } from "../ib-domain-event-cache.js";
+
+function frame(eventType: string, data: unknown, sessionId = "s1") {
+  return { type: "ib_domain_event" as const, sessionId, event: { eventType, data } };
+}
+
+describe("IbDomainEventCache", () => {
+  let cache: IbDomainEventCache;
+  beforeEach(() => {
+    cache = new IbDomainEventCache();
+  });
+
+  it("retains only the latest event per invoice key", () => {
+    cache.set(frame("ib_invoice_state_changed", { invoice_id: "inv1", state: "received" }));
+    cache.set(frame("ib_invoice_state_changed", { invoice_id: "inv1", state: "partner_pending" }));
+    const all = cache.getAll();
+    const forInv1 = all.filter((f) => f.event.eventType === "ib_invoice_state_changed");
+    expect(forInv1).toHaveLength(1);
+    expect((forInv1[0].event.data as { state: string }).state).toBe("partner_pending");
+  });
+
+  it("caches distinct invoices independently", () => {
+    cache.set(frame("ib_invoice_state_changed", { invoice_id: "inv1", state: "received" }));
+    cache.set(frame("ib_invoice_state_changed", { invoice_id: "inv2", state: "queued" }));
+    expect(cache.getAll()).toHaveLength(2);
+  });
+
+  it("keys invoice lifecycle by invoice_id and non-invoice events by their own entity/type", () => {
+    cache.set(frame("ib_invoice_progress", { invoice_id: "inv1", step: 1 }));
+    cache.set(frame("ib_invoice_progress", { invoice_id: "inv1", step: 2 })); // supersedes
+    cache.set(frame("ib_connector_health", { id: "gmail", reachable: true }));
+    cache.set(frame("ib_connector_health", { id: "gmail", reachable: false })); // supersedes
+    cache.set(frame("ib_intake_paused", { by: "operator" }));
+    const all = cache.getAll();
+    expect(all).toHaveLength(3);
+    expect((all.find((f) => f.event.eventType === "ib_invoice_progress")!.event.data as { step: number }).step).toBe(2);
+    expect((all.find((f) => f.event.eventType === "ib_connector_health")!.event.data as { reachable: boolean }).reachable).toBe(false);
+  });
+
+  it("bounds memory by evicting the oldest-inserted entry beyond the cap", () => {
+    const small = new IbDomainEventCache(3);
+    small.set(frame("ib_invoice_state_changed", { invoice_id: "a" }));
+    small.set(frame("ib_invoice_state_changed", { invoice_id: "b" }));
+    small.set(frame("ib_invoice_state_changed", { invoice_id: "c" }));
+    small.set(frame("ib_invoice_state_changed", { invoice_id: "d" })); // evicts "a"
+    const ids = small.getAll().map((f) => (f.event.data as { invoice_id: string }).invoice_id).sort();
+    expect(ids).toEqual(["b", "c", "d"]);
+  });
+
+  it("refreshes recency on update so an updated key is not the eviction victim", () => {
+    const small = new IbDomainEventCache(2);
+    small.set(frame("ib_invoice_state_changed", { invoice_id: "a", n: 1 }));
+    small.set(frame("ib_invoice_state_changed", { invoice_id: "b", n: 1 }));
+    small.set(frame("ib_invoice_state_changed", { invoice_id: "a", n: 2 })); // touch "a"
+    small.set(frame("ib_invoice_state_changed", { invoice_id: "c", n: 1 })); // evicts "b" (now oldest)
+    const ids = small.getAll().map((f) => (f.event.data as { invoice_id: string }).invoice_id).sort();
+    expect(ids).toEqual(["a", "c"]);
+  });
+
+  it("clearForSession drops only entries originating from that session", () => {
+    cache.set(frame("ib_invoice_state_changed", { invoice_id: "inv1" }, "sA"));
+    cache.set(frame("ib_invoice_state_changed", { invoice_id: "inv2" }, "sB"));
+    cache.clearForSession("sA");
+    const all = cache.getAll();
+    expect(all).toHaveLength(1);
+    expect(all[0].sessionId).toBe("sB");
+  });
+
+  it("skips malformed frames without throwing and still caches well-formed ones", () => {
+    expect(() => cache.set({ type: "ib_domain_event", sessionId: "s1", event: { eventType: "x", data: null } } as never)).not.toThrow();
+    expect(() => cache.set({ type: "ib_domain_event", sessionId: "", event: { eventType: "x", data: {} } } as never)).not.toThrow();
+    expect(() => cache.set({ type: "ib_domain_event", sessionId: "s1", event: { eventType: "", data: {} } } as never)).not.toThrow();
+    expect(cache.getAll()).toHaveLength(0);
+    cache.set(frame("ib_invoice_state_changed", { invoice_id: "ok" }));
+    expect(cache.getAll()).toHaveLength(1);
+  });
+
+  it("reset empties the cache", () => {
+    cache.set(frame("ib_invoice_state_changed", { invoice_id: "inv1" }));
+    cache.reset();
+    expect(cache.getAll()).toHaveLength(0);
+  });
+});

--- a/packages/server/src/ib-domain-event-cache.ts
+++ b/packages/server/src/ib-domain-event-cache.ts
@@ -1,0 +1,98 @@
+/**
+ * Server-side cache of the LATEST app-level `ib_domain_event` frame per entity
+ * key, so a browser that connects/mounts AFTER an event was broadcast can be
+ * replayed the current state and converge — instead of waiting for the next
+ * accidental live delta.
+ *
+ * Mirrors `plugin-intent-cache.ts` (latest-per-key Map + session-scoped purge),
+ * adapted to domain events: the envelope is NOT invoice-addressed (the id lives
+ * in `event.data`), delivery is global (not a session subscribe), and retention
+ * is the latest event per key — never a historical log.
+ *
+ * See change: replay-invoice-domain-events.
+ */
+
+/** The unchanged live wire frame the plugin server rebroadcasts. */
+export interface IbDomainEventFrame {
+  type: "ib_domain_event";
+  sessionId: string;
+  event: { eventType: string; data: unknown };
+}
+
+/** Default hard cap on distinct entity keys (bounds worst-case memory). */
+const DEFAULT_MAX_ENTRIES = 500;
+
+/**
+ * Derive the entity id from a frame's payload. The envelope carries no invoice
+ * id at the top level; invoice lifecycle events put it in `event.data.invoice_id`,
+ * and non-invoice events carry their own id. Falls back to the bare event type so
+ * every declared channel still converges to a single latest entry.
+ */
+function entityIdOf(data: unknown): string {
+  if (data && typeof data === "object") {
+    const d = data as Record<string, unknown>;
+    for (const k of ["invoice_id", "id", "connector_id", "which"]) {
+      const v = d[k];
+      if (typeof v === "string" && v.length > 0) return v;
+    }
+  }
+  return "";
+}
+
+function keyOf(eventType: string, data: unknown): string {
+  return `${eventType}\u0000${entityIdOf(data)}`;
+}
+
+export class IbDomainEventCache {
+  private map = new Map<string, IbDomainEventFrame>();
+  private readonly max: number;
+
+  constructor(max: number = DEFAULT_MAX_ENTRIES) {
+    this.max = Math.max(1, max);
+  }
+
+  /**
+   * Store the latest frame for its derived key. Malformed frames (missing
+   * `sessionId`, `eventType`, or `data`) are skipped. Never throws. Delete-then-set
+   * refreshes insertion recency so an updated key is not the next eviction victim;
+   * on overflow the oldest-inserted entry is evicted.
+   */
+  set(frame: IbDomainEventFrame): void {
+    const sessionId = frame?.sessionId;
+    const eventType = frame?.event?.eventType;
+    const data = frame?.event?.data;
+    if (typeof sessionId !== "string" || sessionId.length === 0) return;
+    if (typeof eventType !== "string" || eventType.length === 0) return;
+    if (data === undefined || data === null) return;
+
+    const k = keyOf(eventType, data);
+    if (this.map.has(k)) this.map.delete(k);
+    this.map.set(k, frame);
+
+    while (this.map.size > this.max) {
+      const oldest = this.map.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.map.delete(oldest);
+    }
+  }
+
+  /** Every cached latest frame, oldest-inserted first. */
+  getAll(): IbDomainEventFrame[] {
+    return Array.from(this.map.values());
+  }
+
+  /** Drop every entry whose originating session matches (called on session death). */
+  clearForSession(sessionId: string): void {
+    for (const [k, frame] of this.map) {
+      if (frame.sessionId === sessionId) this.map.delete(k);
+    }
+  }
+
+  /** Test-only: clear the entire cache. */
+  reset(): void {
+    this.map.clear();
+  }
+}
+
+/** Module singleton — every call site shares the same cache. */
+export const ibDomainEventCache = new IbDomainEventCache();

--- a/packages/server/src/pairing/browser-gateway.ts
+++ b/packages/server/src/pairing/browser-gateway.ts
@@ -70,6 +70,7 @@ import type { BrowserHandlerContext } from "../browser-handlers/handler-context.
 import { handleAbort, handleClearFollowupEntries, handleEditFollowupEntry, handleFlowControl, handleForceKill, handleKillProcess, handlePromoteFollowupEntry, handleRemoveFollowupEntry, handleResumeSession, handleSendPrompt, handleShutdown, handleSpawnSession, handleStopAfterTurn, handleSubagentResyncRequest, shutdownSession as shutdownSessionImpl } from "../browser-handlers/session-action-handler.js";
 import { handleAcceptReplaceProposal, handleAttachProposal, handleDetachProposal, handleDismissReplaceProposal, handleFetchContent, handleHideSession, handleListSessions, handleRemoveTagGlobally, handleRenameSession, handleSetSessionDisplayPrefs, handleSetSessionProcessDrawer, handleSetSessionTags, handleUnhideSession } from "../browser-handlers/session-meta-handler.js";
 import { handleSubscribe } from "../browser-handlers/subscription-handler.js";
+import { ibDomainEventCache } from "../ib-domain-event-cache.js";
 import { handleCloseInlineTerminal, handleCreateTerminal, handleKillTerminal, handleOpenInlineTerminal, handleRenameTerminal } from "../browser-handlers/terminal-handler.js";
 import { createPendingResumeRegistry, type PendingResumeRegistry } from "../pending/pending-resume-registry.js";
 import { createViewedSessionTracker, type ViewedSessionTracker } from "../session/viewed-session-tracker.js";
@@ -580,6 +581,15 @@ export function createBrowserGateway(
       for (const terminal of terminalManager.list()) {
         sendTo(ws, { type: "terminal_added", terminal });
       }
+    }
+
+    // Replay the latest cached InvoiceBot domain event per invoice so a board
+    // surface that connects/mounts AFTER a live delta converges on current
+    // truth instead of waiting for the next accidental delta. Marked
+    // `replay: true` so consumers apply it as an idempotent state-set and never
+    // double-apply it. See change: replay-invoice-domain-events.
+    for (const frame of ibDomainEventCache.getAll()) {
+      sendTo(ws, { ...frame, replay: true });
     }
 
     // Notify server of new connection (for mDNS peer list etc.)

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -82,6 +82,7 @@ import { PiCoreChecker } from "./pi/pi-core-checker.js";
 import { PiCoreUpdater } from "./pi/pi-core-updater.js";
 import { createPiGateway, type PiGateway } from "./pi/pi-gateway.js";
 import { pluginIntentCache } from "./plugin-intent-cache.js";
+import { type IbDomainEventFrame, ibDomainEventCache } from "./ib-domain-event-cache.js";
 import { pluginSpawnToSessionOptions } from "./plugin-spawn-options.js";
 import { registerGuardedDir } from "./session-guard.js";
 import { registerAttachmentRoutes } from "./routes/attachment-routes.js";
@@ -883,6 +884,10 @@ export async function createServer(config: ServerConfig): Promise<DashboardServe
   // out to raw-event subscribers. See change: add-goal-continuation-plugin.
   const pluginPiHandlers = new Map<string, Array<(msg: unknown) => void>>();
   const pluginRawEventSubs = new Set<(sessionId: string, event: unknown) => void>();
+  // Rate-limited observability for the ib_domain_event broadcast path (1 line
+  // per sample). See change: replay-invoice-domain-events.
+  const IB_DOMAIN_EVENT_LOG_SAMPLE = 50;
+  let ibDomainEventBroadcasts = 0;
   // Plugin session-end subscribers (ServerPluginContext.onSessionEnded). Fired
   // from sessionManager.onUnregister via wireEvents — the transport-independent
   // death signal, even when no terminal pi event was forwarded.
@@ -921,6 +926,10 @@ export async function createServer(config: ServerConfig): Promise<DashboardServe
     // owns GoalStore, unlike the goal plugin). C2a: subscribe here, never
     // reassign sessionManager.onUnregister. See change: add-goal-session-supervisor.
     if (goalSupervisor) void goalSupervisor.onDriverDeath(sessionId);
+    // Drop this session's cached domain events so a torn-down session's stale
+    // state never replays on a later browser connect.
+    // See change: replay-invoice-domain-events.
+    ibDomainEventCache.clearForSession(sessionId);
     for (const h of pluginSessionEndSubs) {
       try { h(sessionId); } catch (err) { console.error("[plugin-onSessionEnded]", err); }
     }
@@ -1886,6 +1895,21 @@ export async function createServer(config: ServerConfig): Promise<DashboardServe
                     m.slot as Parameters<typeof pluginIntentCache.set>[2],
                     (m.intent ?? null) as Parameters<typeof pluginIntentCache.set>[3],
                   );
+                }
+                // Cache the latest ib_domain_event per entity so a browser that
+                // connects/mounts AFTER the delta converges via connect replay
+                // (mirrors plugin_intents above). Also emit a rate-limited success
+                // log: the happy path was previously unlogged, so an unlogged
+                // forward read as "zero events" in incident triage.
+                // See change: replay-invoice-domain-events.
+                if (m && m.type === "ib_domain_event") {
+                  try {
+                    ibDomainEventCache.set(msg as IbDomainEventFrame);
+                    if (ibDomainEventBroadcasts++ % IB_DOMAIN_EVENT_LOG_SAMPLE === 0) {
+                      const ev = (msg as IbDomainEventFrame).event;
+                      console.error(`[ib-domain-event] broadcast #${ibDomainEventBroadcasts} type=${ev?.eventType ?? "?"} session=${(msg as IbDomainEventFrame).sessionId ?? "?"}`);
+                    }
+                  } catch { /* caching/logging must never break the broadcast */ }
                 }
                 browserGateway.broadcast(msg as any);
               },

--- a/packages/shared/src/browser-protocol.ts
+++ b/packages/shared/src/browser-protocol.ts
@@ -845,11 +845,18 @@ export interface RecoveryDismissMessage {
  * payload verbatim. One envelope carries any lifecycle domain event, so new
  * `ib_*` kinds add no protocol member. Additive — the per-session `event`
  * stream is unchanged. See change: surface-invoice-domain-events-app-level.
+ *
+ * `replay` marks a frame the server replayed from its latest-per-invoice cache
+ * on connect (absent/false on live frames). A consumer MUST treat a
+ * `replay: true` frame as an idempotent state-set (converge to it), never as an
+ * incremental delta, so counters/animations driven by live deltas are not
+ * double-applied. See change: replay-invoice-domain-events.
  */
 export interface IbDomainEventMessage {
   type: "ib_domain_event";
   sessionId: string;
   event: { eventType: string; data: unknown };
+  replay?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Why
The app-level `ib_domain_event` channel is live-delta only with no server-side cache, so a board/strip surface that mounts or fetches AFTER an event was broadcast never reconciles. `plugin_intents` already solves this exact shape (cached + replayed on connect); `ib_domain_event` did not.

## What
- New `IbDomainEventCache` (latest-per-entity, bounded 500, session-scoped purge) mirroring `plugin-intent-cache`.
- `server.ts` broadcast choke point: cache every `ib_domain_event` + rate-limited (1/50) success log (the happy path was previously unlogged — prior zero-count was a logging artifact).
- `browser-gateway.ts`: replay cached frames on browser connect, marked `replay: true`.
- `browser-protocol.ts`: additive optional `replay?: boolean` (absent on live).
- `clearForSession` wired to session-death fanout.

Consumers treat `replay: true` as an idempotent state-set (converge), never a delta — no double-apply.

## Spec
`invoicebot-app-level-events`: one requirement MODIFIED (delta-only → latest-state convergence replay), one ADDED (cache + bounded memory), one ADDED (observability log).

## Not touched
Forward path (proved correct); automation-plugin / invoicebot-plugin dispatch/fan-out. Front-end board poll is a separate safety net, not assumed.

## Gate
tsc (my files clean vs 50 identical pre-existing errors on base), 369 scoped tests green, build ok. Faux e2e OFF per operator.