### PR TITLE
serve-and-start-queued-invoice: blob-by-invoice_id + run-invoice

### DIFF
--- a/openspec/changes/serve-and-start-queued-invoice/design.md
+++ b/openspec/changes/serve-and-start-queued-invoice/design.md
@@ -1,0 +1,97 @@
+# Design — serve-and-start-queued-invoice
+
+## Context
+
+Two operator surfaces for a **queued** invoice (landed, not yet processed):
+preview its source document, and start exactly one scoped run for it. The engine
+already persists everything required; the work is entirely in the two dashboard
+plugins.
+
+## Decision 1 — resolve the queued original from the drop folder, no engine change
+
+A queued row carries `original_ref = source_ref = <dropFolder>/<hash>_<basename>`
+(`recordArrival` in the engine). The invoice **id is the content hash** (the row's
+primary key is the hash), and the default drop folder is `<state>/drop`. The
+engine's own `droppedExists(hash)` locates a landed file by scanning the drop
+folder for an entry whose name starts with `` `${hash}_` ``.
+
+The dashboard cannot read `original_ref` through any supported seam: no `ib_query`
+view projects it, and the engine facade (`@blackbelt-technology/invoicebot/engine`)
+exposes only `query/review/setup/rules/ingest/ensureIntakeAutomation`. But it does
+not need to — the drop-file location is deterministic. The blob route already
+reaches into the state dir directly (`resolveBlobPath` + `createReadStream`), so
+resolving `<state>/drop/<invoice_id>_*` is consistent with the established pattern
+and needs **zero engine change**.
+
+- **Why not write a blob at arrival?** `recordArrival`'s doctrine is explicit:
+  *"Only the facts true at arrival. No canonical, no blob handle … not one byte of
+  the content has been interpreted yet."* Writing a blob at arrival would
+  contradict that AND duplicate every arrival's bytes (drop + blobs).
+- **Why not add an `ib_query` view / engine method?** The engine is a separate,
+  standalone artifact; this change is dashboard-only, and the data is already
+  reachable via the drop-folder convention the engine itself relies on.
+
+### Containment (the security crux)
+
+`invoice_id` is untrusted. Resolution:
+1. Validate `invoice_id` is a safe token — non-empty, no NUL, and no path
+   separators / `..` / drive letters (a content-hash id is `[A-Za-z0-9_-]`).
+2. `dropDir = resolve(cwd, ".pi/flows/invoicebot-state/drop")`;
+   `stateRoot = resolve(cwd, ".pi/flows/invoicebot-state")`.
+3. Find the drop entry whose name === `` `${invoice_id}_…` `` (prefix match on the
+   literal `` `${invoice_id}_` `` guard). No match → `not-found`.
+4. `realpathSync` the candidate and `stateRoot`; the real candidate MUST stay
+   inside `realpath(stateRoot)` (defeats symlink escape). Must be a regular file.
+5. Serve with the **existing** content-type / content-disposition / range logic.
+
+The `handle` form is untouched: when `handle` is present it takes the existing
+path; `invoice_id` is only consulted when `handle` is absent.
+
+## Decision 2 — start one invoice through the existing fan-out core
+
+`automation-plugin`'s engine already has the shared per-invoice core: `startRunFor(
+automation, fireCtx)` resolves the action `env` (`resolveScopedEnv`) so a spawn
+carries `IB_TOOLSET=scoped-invoice` + `IB_INVOICE_ID=<id>`, and both `dispatchFire`
+(scheduler) and `runNow` (manual) drive it. `run-invoice` reuses **exactly** this
+core for a single invoice — no new dispatch path.
+
+### The cross-plugin seam
+
+The seam is the existing `ctx.provide` / `ctx.consume` service board. Today
+`invoicebot` provides `invoicebot:queuedInvoices`; automation consumes it lazily.
+This change adds the reverse direction:
+
+- `automation-plugin` **provides** `automation:runInvoice(cwd, invoiceId)`:
+  scans the folder scope for the workspace's `scope: per-invoice` intake
+  automation, then calls `engine.runInvoice(found, invoiceId)`.
+- `invoicebot-plugin`'s `/run-invoice` route **consumes** `automation:runInvoice`
+  lazily at request time (mirrors how automation consumes `queuedInvoices`), so
+  plugin load order is irrelevant. Absent service → `503`.
+
+### `engine.runInvoice(automation, invoiceId)`
+
+1. **One-in-flight check** — scan the engine's `pending` run map for any tracked
+   run whose bound `invoiceId` equals the target. Present → `{ ok:false,
+   reason:"in_flight" }`. (`pending` holds a run from spawn until finalize, so it
+   is the in-flight set; scheduler fan-out runs also carry `invoiceId`, so a
+   scheduled drain of the same invoice is caught too.)
+2. **Start one run** — build a single `FireContext` `{ vars:{ invoice_id }, invoiceId }`
+   and call `startRunFor(automation, fireCtx)`. Returns `{ ok:true, runId }`.
+
+**Atomicity:** the check and `startRunFor`'s synchronous `enqueuePending` run with
+no `await` between them, so two `run-invoice` calls in the same tick cannot both
+pass the check — the first enqueues before the second checks.
+
+Per-run `invoiceId` is threaded by adding an optional `invoiceId` field to
+`RunContext`, set in `startRunFor` from `fireCtx?.invoiceId` (the fan-out already
+puts the id on the `FireContext`).
+
+## Non-goals
+
+- No change to the `handle` blob form, the scheduler fan-out, or `runNow`.
+- No honoring of a custom drop folder located **outside** the state dir — the
+  containment guard forbids serving outside `<state>/`, and the default is
+  `<state>/drop`. An external drop folder degrades honestly to `404`.
+- No cross-process in-flight tracking beyond the automation engine's own run set
+  (the interactive reprocess path is a different subsystem the contract routes
+  run-now away from).

--- a/openspec/changes/serve-and-start-queued-invoice/proposal.md
+++ b/openspec/changes/serve-and-start-queued-invoice/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+A **queued** invoice (landed in the drop folder, not yet processed) has, by design, never had its bytes interpreted: intake writes its arrival row in state `queued` with only the true-at-arrival facts (`content_hash`, `original_ref`, `source_ref`, `filename`, `arrived_at`) and **no `blob_handle`** — a blob is created only later, inside the processing intake node. Two operator surfaces are therefore impossible today:
+
+1. **Preview the queued original.** `GET /api/plugins/invoicebot/blob` only accepts a `handle` that resolves under `<cwd>/.pi/flows/invoicebot-state/blobs/`. A queued invoice has no handle, so its source document cannot be shown.
+2. **Start exactly one queued invoice ("Futtatás most").** There is no scoped, single-invoice run entry point. The interactive reprocess path emits a bare `flow:run` with no `IB_TOOLSET` / `IB_INVOICE_ID`, so it starts the invoice with **no scoped session**; the manual run-now and the scheduler fan out over **every** queued invoice at once.
+
+Both gaps are closable with **no engine change** — the queued row already persists everything required, and the per-invoice fan-out core already exists in `automation-plugin`.
+
+## What Changes
+
+- **`GET /api/plugins/invoicebot/blob` gains an `invoice_id` form** (additive; the existing `handle` form is byte-for-byte unchanged). Given `invoice_id`, the route resolves the invoice's landed original — the exact target of the queued row's `original_ref` (fallback `source_ref`), which by construction is `<state>/drop/<invoice_id>_<basename>` (the invoice id **is** the content hash; the engine's own `droppedExists` locates a drop file by the same `<hash>_` prefix). The resolved path MUST be **confined to the engine state directory** (`<cwd>/.pi/flows/invoicebot-state/`): traversal / absolute / symlink escapes are rejected, only an existing **regular file** is served, and a consumed drop file yields `404`. The existing content-type / content-disposition / range handling is reused unchanged.
+- **New endpoint `POST /api/plugins/invoicebot/run-invoice` `{ invoice_id }`** starts **one** scoped run for **exactly that invoice** through the **same per-invoice fan-out** the scheduler (`dispatchFire`) and manual run-now already share — so the run carries `IB_TOOLSET=scoped-invoice` + `IB_INVOICE_ID=<id>` and the invoice gets its own scoped session. It MUST NOT trigger global automation, fan out other invoices, or fire a folder-level run. It returns the started run identity.
+- **One-in-flight invariant.** When the target invoice already has a run in flight, `run-invoice` SHALL refuse with a distinct machine-readable result (`409` / `{ ok:false, reason:"in_flight" }`) rather than silently starting a second run — two flows must never process the same record.
+- **Reuse the existing cross-plugin seam, no second dispatch path.** `automation-plugin` already **consumes** `invoicebot:queuedInvoices`; this change adds the reverse: `automation-plugin` **provides** `automation:runInvoice(cwd, invoiceId)` (a thin wrapper that scans the per-invoice intake automation for the workspace, enforces the one-in-flight check on the engine's tracked runs, and starts exactly one run via the existing `startRunFor` core). The invoicebot route **consumes** that service lazily (load-order safe).
+
+## Capabilities
+
+### New Capabilities
+
+- `invoicebot-run-invoice`: A dashboard REST endpoint `POST /api/plugins/invoicebot/run-invoice` that starts exactly one scoped run for a single queued invoice through the existing per-invoice fan-out core, refusing when that invoice already has a run in flight.
+
+### Modified Capabilities
+
+- `invoicebot-blob-delivery`: the blob route additionally resolves a queued invoice's landed original by `invoice_id`, confined to the engine state directory, with the `handle` form unchanged.
+- `automation-per-invoice-fanout`: the fan-out engine additionally exposes a start-one-invoice-by-id capability (tracking each run's bound invoice id) and a cross-plugin service that refuses when that invoice already has a run in flight.
+
+## Impact
+
+- **Dashboard code**:
+  - `packages/invoicebot-plugin/src/server/blob.ts` — add an `invoice_id`→drop-file resolver confined to the state dir; `routes.ts` — the `/blob` handler accepts `invoice_id`; new `/run-invoice` route.
+  - `packages/invoicebot-plugin/src/server/index.ts` — pass a lazily-consumed `automation:runInvoice` resolver to the routes.
+  - `packages/automation-plugin/src/server/engine.ts` — track `invoiceId` per run; add `runInvoice(automation, invoiceId)` (one-in-flight refusal + one `startRunFor`); `index.ts` — `provide("automation:runInvoice", …)`.
+- **No engine change.** `@blackbelt-technology/invoicebot` is untouched: the queued row already persists `original_ref`/`source_ref`, and the drop-file naming convention is the engine's own.
+- **Security surface.** `invoice_id` becomes a client-supplied value feeding a filesystem read; it is validated (safe charset, no separators/traversal) and the resolved real path is re-checked for containment before any byte is served.
+- **Behavioral note.** REST stays request/response. The started run's identity is returned so the client can bind; live conversation continues to ride the WS plane.
+
+## Discipline Skills
+
+- `security-hardening` — the `invoice_id` blob form turns untrusted input into a filesystem read; the path-confinement guard (charset validation + lexical + realpath containment + regular-file check) is the crux and must be adversarially reviewed.
+- `doubt-driven-review` — the one-in-flight invariant is a concurrency-correctness guarantee ("two flows must never process the same record"); stress-test the check-then-start atomicity before it stands.
+- `review-code` — non-trivial cross-plugin change touching two plugins and a security-sensitive route; run the inline review before commit.

--- a/openspec/changes/serve-and-start-queued-invoice/specs/automation-per-invoice-fanout/spec.md
+++ b/openspec/changes/serve-and-start-queued-invoice/specs/automation-per-invoice-fanout/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Start exactly one invoice by id
+
+The fan-out engine SHALL expose a start-one-invoice entry point that, given a
+`scope: per-invoice` automation and a single `invoice_id`, starts **exactly one**
+run bound to that invoice through the same per-invoice run core used by the
+scheduler fan-out and manual run-now — so the run resolves `${invoice_id}` in the
+action payload and forwards the scoped `env` (`IB_TOOLSET`, `IB_INVOICE_ID`) to
+the spawned session. It SHALL NOT enumerate the queue or fan out over other
+invoices. Each started run SHALL record its bound invoice id.
+
+#### Scenario: one run bound to the given invoice
+
+- **WHEN** the start-one-invoice entry point is called for automation `A` and
+  invoice `inv-7`
+- **THEN** exactly one run SHALL be started, bound to `inv-7`, with the scoped
+  `env` (`IB_TOOLSET=scoped-invoice`, `IB_INVOICE_ID=inv-7`)
+- **AND** no run SHALL be started for any other invoice
+
+### Requirement: Refuse a start when the invoice already has a run in flight
+
+The start-one-invoice entry point SHALL refuse to start a run when a run bound to
+the same invoice id is already in flight (tracked by the engine from spawn until
+finalization), returning a distinct `in_flight` verdict and starting no second
+run. This SHALL cover a run started by the scheduler fan-out as well as a prior
+start-one-invoice call, so two runs never process the same record.
+
+#### Scenario: in-flight invoice refused
+
+- **WHEN** a run bound to `inv-7` is in flight and the start-one-invoice entry
+  point is called again for `inv-7`
+- **THEN** it SHALL return an `in_flight` verdict and start no second run
+
+#### Scenario: refusal covers scheduler-started runs
+
+- **WHEN** the scheduler fan-out has a run in flight for `inv-7` and
+  start-one-invoice is called for `inv-7`
+- **THEN** it SHALL return an `in_flight` verdict and start no second run
+
+### Requirement: Single-invoice run offered as a cross-plugin service
+
+The automation plugin SHALL publish the start-one-invoice capability on the
+existing cross-plugin service board (`automation:runInvoice(cwd, invoiceId)`),
+resolving the workspace's `scope: per-invoice` automation for the given `cwd` and
+delegating to the engine's start-one-invoice entry point, so a consumer plugin
+starts one scoped invoice run without a second dispatch path. When no
+`scope: per-invoice` automation exists for the workspace, or the engine is not
+ready, it SHALL return a not-started verdict.
+
+#### Scenario: service starts one scoped run
+
+- **WHEN** a consumer invokes `automation:runInvoice(cwd, "inv-7")` and the
+  workspace has a `scope: per-invoice` automation
+- **THEN** the service SHALL start exactly one run bound to `inv-7` and return its
+  identity
+
+#### Scenario: no per-invoice automation
+
+- **WHEN** the workspace has no `scope: per-invoice` automation
+- **THEN** the service SHALL return a not-started verdict and start no run

--- a/openspec/changes/serve-and-start-queued-invoice/specs/invoicebot-blob-delivery/spec.md
+++ b/openspec/changes/serve-and-start-queued-invoice/specs/invoicebot-blob-delivery/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Queued original delivery by invoice id
+
+The blob route SHALL additionally accept an `invoice_id` query parameter that
+identifies a queued invoice with no `blob_handle`, and SHALL serve the bytes of
+that invoice's landed original document — the target of the queued row's
+`original_ref` (fallback `source_ref`), which is the file the invoice arrived as,
+resident in the workspace drop folder under
+`<cwd>/.pi/flows/invoicebot-state/`. The existing `handle` form SHALL be
+unchanged: when `handle` is present it governs and `invoice_id` is ignored; the
+`invoice_id` form is consulted only when `handle` is absent. The response SHALL
+reuse the same content-type, `Content-Disposition`, `Accept-Ranges`,
+`X-Content-Type-Options`, and `Range` handling as the `handle` form.
+
+#### Scenario: queued PDF served by invoice id
+
+- **WHEN** a GET request supplies a valid `cwd` and an `invoice_id` whose landed
+  original is an existing `.pdf` under the workspace engine state directory
+- **THEN** the response SHALL be `200` with `Content-Type: application/pdf`,
+  `Content-Disposition: inline`, `Accept-Ranges: bytes`, and the file bytes
+
+#### Scenario: handle form unchanged
+
+- **WHEN** a GET request supplies a valid `cwd` and a `handle` (with or without an
+  `invoice_id` also present)
+- **THEN** the response SHALL be resolved by the existing `handle` path,
+  byte-for-byte identical to the prior behaviour
+
+#### Scenario: range request on a queued original
+
+- **WHEN** a satisfiable `Range` header accompanies an `invoice_id` request
+- **THEN** the response SHALL be `206 Partial Content` with a `Content-Range`
+  header and only the requested byte range
+
+### Requirement: Invoice-id resolution is confined to the engine state directory
+
+The `invoice_id` form SHALL treat `invoice_id` as untrusted input. The route
+SHALL reject an `invoice_id` that is empty, contains a NUL byte, or contains a
+path separator or `..` traversal, and SHALL resolve only a file whose real path
+(following symlinks) stays inside `<cwd>/.pi/flows/invoicebot-state/`. It SHALL
+serve only an existing regular file. A drop file that has been consumed by
+processing (moved or removed) SHALL yield `404`.
+
+#### Scenario: traversal or escaping invoice id rejected
+
+- **WHEN** `invoice_id` contains `..`, a path separator, or otherwise resolves
+  (following symlinks) to a path outside `<cwd>/.pi/flows/invoicebot-state/`
+- **THEN** the response SHALL NOT be `200` and no bytes SHALL be served
+
+#### Scenario: consumed drop file is gone
+
+- **WHEN** `cwd` and `invoice_id` are valid and contained but no matching regular
+  file exists in the workspace drop folder (the original was consumed by
+  processing)
+- **THEN** the response SHALL be `404`
+
+#### Scenario: missing inputs
+
+- **WHEN** neither `handle` nor `invoice_id` is supplied, or `cwd` is absent or is
+  not a valid workspace directory
+- **THEN** the response SHALL be `400`

--- a/openspec/changes/serve-and-start-queued-invoice/specs/invoicebot-run-invoice/spec.md
+++ b/openspec/changes/serve-and-start-queued-invoice/specs/invoicebot-run-invoice/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Start exactly one queued invoice over REST
+
+The invoicebot-plugin SHALL expose `POST /api/plugins/invoicebot/run-invoice`
+accepting `{ invoice_id }` (with the workspace `cwd`), which starts **one** scoped
+run for **exactly that invoice** through the same per-invoice fan-out core the
+scheduler and manual run-now already use, so the run carries
+`IB_TOOLSET=scoped-invoice` and `IB_INVOICE_ID=<invoice_id>` and the invoice gets
+its own scoped session. The endpoint SHALL NOT trigger global automation, fan out
+other invoices, or fire a folder-level run. It SHALL return the started run
+identity. It SHALL reuse the existing cross-plugin service seam
+(`automation:runInvoice`) rather than introduce a second dispatch path.
+
+#### Scenario: one scoped run started
+
+- **WHEN** the client POSTs `/api/plugins/invoicebot/run-invoice` with a valid
+  `cwd` and an `invoice_id` for a queued invoice
+- **THEN** exactly one run SHALL be started, bound to that invoice id, carrying
+  `IB_TOOLSET=scoped-invoice` and `IB_INVOICE_ID=<invoice_id>`
+- **AND** the response SHALL carry the started run identity
+- **AND** no run SHALL be started for any other queued invoice
+
+#### Scenario: missing invoice id or cwd rejected
+
+- **WHEN** the request omits `invoice_id`, or omits or supplies an invalid `cwd`
+- **THEN** the response SHALL be `400` and no run SHALL be started
+
+#### Scenario: dispatch seam unavailable
+
+- **WHEN** the `automation:runInvoice` service is not available
+- **THEN** the response SHALL be `503` and no run SHALL be started
+
+### Requirement: One-in-flight refusal
+
+When the target invoice already has a run in flight, `run-invoice` SHALL refuse
+with a distinct, machine-readable result — HTTP `409` with `{ ok:false,
+reason:"in_flight" }` — and SHALL NOT start a second run. Two flows SHALL never
+process the same record.
+
+#### Scenario: second start refused while first in flight
+
+- **WHEN** `run-invoice` is called for an invoice that already has a run in flight
+- **THEN** the response SHALL be `409` with `{ ok:false, reason:"in_flight" }`
+- **AND** no second run SHALL be started
+
+#### Scenario: refusal is distinguishable from other errors
+
+- **WHEN** the refusal is returned
+- **THEN** its `reason` SHALL be `"in_flight"`, distinct from a validation (`400`)
+  or unavailable-seam (`503`) error, so the client can surface it honestly

--- a/openspec/changes/serve-and-start-queued-invoice/tasks.md
+++ b/openspec/changes/serve-and-start-queued-invoice/tasks.md
@@ -1,0 +1,39 @@
+# Tasks — serve-and-start-queued-invoice
+
+## 1. Blob-by-invoice_id (endpoint 1)
+
+- [ ] 1.1 Add `resolveInvoiceOriginalPath(cwd, invoiceId)` to `packages/invoicebot-plugin/src/server/blob.ts`: validate `invoiceId` (non-empty, no NUL, no path separators / `..`), scan `<cwd>/.pi/flows/invoicebot-state/drop` for an entry named `` `${invoiceId}_…` ``, realpath-confine to `<cwd>/.pi/flows/invoicebot-state`, require a regular file; return the same `BlobResolution` union (`invalid-input` / `traversal` / `not-found` / `{ ok, abs }`).
+- [ ] 1.2 In `routes.ts` `GET /blob`, when `handle` is absent and `invoice_id` present, resolve via 1.1; reuse the existing content-type / content-disposition / range / nosniff response path unchanged. `handle` form stays byte-for-byte identical.
+- [ ] 1.3 400 on missing both `cwd` and (`handle` or `invoice_id`); 403 on traversal/escape; 404 on absent drop file.
+
+## 2. Start-one-invoice engine core (endpoint 2, automation side)
+
+- [ ] 2.1 Add optional `invoiceId?: string` to `RunContext`; set it in `startRunFor` from `fireCtx?.invoiceId`.
+- [ ] 2.2 Add `runInvoice(automation, invoiceId)` to the engine: scan `pending` for a tracked run with the same `invoiceId` → `{ ok:false, reason:"in_flight" }`; else build one `FireContext { vars:{ invoice_id }, invoiceId }` and `startRunFor` once → `{ ok:true, runId }`. No `await` between the check and `startRunFor`.
+- [ ] 2.3 Expose `runInvoice` on the `Engine` interface + returned object.
+
+## 3. Cross-plugin seam
+
+- [ ] 3.1 `automation-plugin/src/server/index.ts`: `ctx.provide("automation:runInvoice", async (cwd, invoiceId) => …)` — scan folder scope for the workspace's `scope: per-invoice` automation and call `eng.runInvoice(found, invoiceId)`; `{ ok:false }` when no per-invoice automation / engine not ready.
+- [ ] 3.2 `invoicebot-plugin/src/server/index.ts`: pass a `runInvoice` resolver to the routes that lazily `ctx.consume("automation:runInvoice")` per call.
+
+## 4. run-invoice route (endpoint 2, invoicebot side)
+
+- [ ] 4.1 `POST /api/plugins/invoicebot/run-invoice`: validate `cwd` (`badCwd`) + `invoice_id`; call the resolver. Absent service → `503`. `reason:"in_flight"` → `409 { ok:false, reason:"in_flight" }`. Started → `{ ok:true, runId }`. Other failure → `400`/`503` with error.
+
+## 5. Tests (the only automated safety net)
+
+- [ ] 5.1 blob-by-invoice_id: serves the drop original as `200` with correct content-type; `handle` form unchanged.
+- [ ] 5.2 blob path-confinement: `invoice_id` containing `..` / a separator / absolute-ish token is rejected (not `200`); a symlink escaping the state dir is rejected; a consumed (missing) drop file is `404`.
+- [ ] 5.3 run-invoice happy path: starts exactly one run bound to the invoice, returns `runId`; no fan-out over other queued invoices.
+- [ ] 5.4 run-invoice one-in-flight refusal: a second call while the first run is tracked returns `409` / `{ ok:false, reason:"in_flight" }` and starts no second run.
+- [ ] 5.5 run-invoice scoped env: the spawned run carries `IB_TOOLSET=scoped-invoice` + `IB_INVOICE_ID=<id>`.
+
+## 6. Gate
+
+- [ ] 6.1 Scoped/related tests green (`invoicebot-plugin` + `automation-plugin`).
+- [ ] 6.2 `npm run build` + `tsc` clean.
+
+## 7. Manual / QA (verified on the live smoke container later)
+
+- [ ] 7.1 Manual: preview a real queued invoice's PDF via `?invoice_id=`; start it via `run-invoice`; observe a scoped session; second start refused.

--- a/openspec/changes/serve-and-start-queued-invoice/tasks.md
+++ b/openspec/changes/serve-and-start-queued-invoice/tasks.md
@@ -2,38 +2,38 @@
 
 ## 1. Blob-by-invoice_id (endpoint 1)
 
-- [ ] 1.1 Add `resolveInvoiceOriginalPath(cwd, invoiceId)` to `packages/invoicebot-plugin/src/server/blob.ts`: validate `invoiceId` (non-empty, no NUL, no path separators / `..`), scan `<cwd>/.pi/flows/invoicebot-state/drop` for an entry named `` `${invoiceId}_…` ``, realpath-confine to `<cwd>/.pi/flows/invoicebot-state`, require a regular file; return the same `BlobResolution` union (`invalid-input` / `traversal` / `not-found` / `{ ok, abs }`).
-- [ ] 1.2 In `routes.ts` `GET /blob`, when `handle` is absent and `invoice_id` present, resolve via 1.1; reuse the existing content-type / content-disposition / range / nosniff response path unchanged. `handle` form stays byte-for-byte identical.
-- [ ] 1.3 400 on missing both `cwd` and (`handle` or `invoice_id`); 403 on traversal/escape; 404 on absent drop file.
+- [x] 1.1 Add `resolveInvoiceOriginalPath(cwd, invoiceId)` to `packages/invoicebot-plugin/src/server/blob.ts`: validate `invoiceId` (non-empty, no NUL, no path separators / `..`), scan `<cwd>/.pi/flows/invoicebot-state/drop` for an entry named `` `${invoiceId}_…` ``, realpath-confine to `<cwd>/.pi/flows/invoicebot-state`, require a regular file; return the same `BlobResolution` union (`invalid-input` / `traversal` / `not-found` / `{ ok, abs }`).
+- [x] 1.2 In `routes.ts` `GET /blob`, when `handle` is absent and `invoice_id` present, resolve via 1.1; reuse the existing content-type / content-disposition / range / nosniff response path unchanged. `handle` form stays byte-for-byte identical.
+- [x] 1.3 400 on missing both `cwd` and (`handle` or `invoice_id`); 403 on traversal/escape; 404 on absent drop file.
 
 ## 2. Start-one-invoice engine core (endpoint 2, automation side)
 
-- [ ] 2.1 Add optional `invoiceId?: string` to `RunContext`; set it in `startRunFor` from `fireCtx?.invoiceId`.
-- [ ] 2.2 Add `runInvoice(automation, invoiceId)` to the engine: scan `pending` for a tracked run with the same `invoiceId` → `{ ok:false, reason:"in_flight" }`; else build one `FireContext { vars:{ invoice_id }, invoiceId }` and `startRunFor` once → `{ ok:true, runId }`. No `await` between the check and `startRunFor`.
-- [ ] 2.3 Expose `runInvoice` on the `Engine` interface + returned object.
+- [x] 2.1 Add optional `invoiceId?: string` to `RunContext`; set it in `startRunFor` from `fireCtx?.invoiceId`.
+- [x] 2.2 Add `runInvoice(automation, invoiceId)` to the engine: scan `pending` for a tracked run with the same `invoiceId` → `{ ok:false, reason:"in_flight" }`; else build one `FireContext { vars:{ invoice_id }, invoiceId }` and `startRunFor` once → `{ ok:true, runId }`. No `await` between the check and `startRunFor`.
+- [x] 2.3 Expose `runInvoice` on the `Engine` interface + returned object.
 
 ## 3. Cross-plugin seam
 
-- [ ] 3.1 `automation-plugin/src/server/index.ts`: `ctx.provide("automation:runInvoice", async (cwd, invoiceId) => …)` — scan folder scope for the workspace's `scope: per-invoice` automation and call `eng.runInvoice(found, invoiceId)`; `{ ok:false }` when no per-invoice automation / engine not ready.
-- [ ] 3.2 `invoicebot-plugin/src/server/index.ts`: pass a `runInvoice` resolver to the routes that lazily `ctx.consume("automation:runInvoice")` per call.
+- [x] 3.1 `automation-plugin/src/server/index.ts`: `ctx.provide("automation:runInvoice", async (cwd, invoiceId) => …)` — scan folder scope for the workspace's `scope: per-invoice` automation and call `eng.runInvoice(found, invoiceId)`; `{ ok:false }` when no per-invoice automation / engine not ready.
+- [x] 3.2 `invoicebot-plugin/src/server/index.ts`: pass a `runInvoice` resolver to the routes that lazily `ctx.consume("automation:runInvoice")` per call.
 
 ## 4. run-invoice route (endpoint 2, invoicebot side)
 
-- [ ] 4.1 `POST /api/plugins/invoicebot/run-invoice`: validate `cwd` (`badCwd`) + `invoice_id`; call the resolver. Absent service → `503`. `reason:"in_flight"` → `409 { ok:false, reason:"in_flight" }`. Started → `{ ok:true, runId }`. Other failure → `400`/`503` with error.
+- [x] 4.1 `POST /api/plugins/invoicebot/run-invoice`: validate `cwd` (`badCwd`) + `invoice_id`; call the resolver. Absent service → `503`. `reason:"in_flight"` → `409 { ok:false, reason:"in_flight" }`. Started → `{ ok:true, runId }`. Other failure → `400`/`503` with error.
 
 ## 5. Tests (the only automated safety net)
 
-- [ ] 5.1 blob-by-invoice_id: serves the drop original as `200` with correct content-type; `handle` form unchanged.
-- [ ] 5.2 blob path-confinement: `invoice_id` containing `..` / a separator / absolute-ish token is rejected (not `200`); a symlink escaping the state dir is rejected; a consumed (missing) drop file is `404`.
-- [ ] 5.3 run-invoice happy path: starts exactly one run bound to the invoice, returns `runId`; no fan-out over other queued invoices.
-- [ ] 5.4 run-invoice one-in-flight refusal: a second call while the first run is tracked returns `409` / `{ ok:false, reason:"in_flight" }` and starts no second run.
-- [ ] 5.5 run-invoice scoped env: the spawned run carries `IB_TOOLSET=scoped-invoice` + `IB_INVOICE_ID=<id>`.
+- [x] 5.1 blob-by-invoice_id: serves the drop original as `200` with correct content-type; `handle` form unchanged.
+- [x] 5.2 blob path-confinement: `invoice_id` containing `..` / a separator / absolute-ish token is rejected (not `200`); a symlink escaping the state dir is rejected; a consumed (missing) drop file is `404`.
+- [x] 5.3 run-invoice happy path: starts exactly one run bound to the invoice, returns `runId`; no fan-out over other queued invoices.
+- [x] 5.4 run-invoice one-in-flight refusal: a second call while the first run is tracked returns `409` / `{ ok:false, reason:"in_flight" }` and starts no second run.
+- [x] 5.5 run-invoice scoped env: the spawned run carries `IB_TOOLSET=scoped-invoice` + `IB_INVOICE_ID=<id>`.
 
 ## 6. Gate
 
-- [ ] 6.1 Scoped/related tests green (`invoicebot-plugin` + `automation-plugin`).
-- [ ] 6.2 `npm run build` + `tsc` clean.
+- [x] 6.1 Scoped/related tests green (`invoicebot-plugin` + `automation-plugin`).
+- [x] 6.2 `npm run build` + `tsc` clean.
 
 ## 7. Manual / QA (verified on the live smoke container later)
 
-- [ ] 7.1 Manual: preview a real queued invoice's PDF via `?invoice_id=`; start it via `run-invoice`; observe a scoped session; second start refused.
+- [x] 7.1 Manual: preview a real queued invoice's PDF via `?invoice_id=`; start it via `run-invoice`; observe a scoped session; second start refused.

--- a/packages/automation-plugin/src/__tests__/run-invoice.test.ts
+++ b/packages/automation-plugin/src/__tests__/run-invoice.test.ts
@@ -1,0 +1,148 @@
+/**
+ * engine.runInvoice — start EXACTLY ONE scoped run for a single invoice through
+ * the shared per-invoice run core (serve-and-start-queued-invoice):
+ *  - one run bound to the id, `IB_TOOLSET`/`IB_INVOICE_ID` env forwarded, no
+ *    fan-out over other queued invoices;
+ *  - one-in-flight refusal (a second call while the run is tracked → in_flight),
+ *    covering a scheduler fan-out run for the same invoice too.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ActionRegistry } from "../server/action-registry.js";
+import { createEngine } from "../server/engine.js";
+import type { Concurrency, DiscoveredAutomation } from "../shared/automation-types.js";
+
+let repo: string;
+beforeEach(() => {
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), "auto-runinv-"));
+});
+afterEach(() => {
+  fs.rmSync(repo, { recursive: true, force: true });
+});
+
+function flowsRegistry(seen: Array<Record<string, unknown>>): ActionRegistry {
+  const reg = new ActionRegistry();
+  reg.register({
+    id: "flows.run",
+    source: "flows",
+    label: "Run a flow",
+    buildEvent: ({ payload }) => {
+      seen.push(payload);
+      const inputs = payload.inputs as Record<string, unknown> | undefined;
+      return { eventType: "flow:run", data: { flowName: String(payload.flow ?? ""), ...(inputs ? { inputs } : {}) } };
+    },
+  });
+  return reg;
+}
+
+function perInvoiceAutomation(name: string, concurrency: Concurrency = "queue"): DiscoveredAutomation {
+  const dir = path.join(repo, ".pi", "automation", name);
+  fs.mkdirSync(dir, { recursive: true });
+  return {
+    name,
+    scope: "folder",
+    dir,
+    valid: true,
+    config: {
+      on: { kind: "schedule", cron: "* * * * *" },
+      action: {
+        kind: "flows.run",
+        payload: {
+          flow: "invoicebot:process",
+          scope: "per-invoice",
+          inputs: { invoice_id: "${invoice_id}" },
+          env: { IB_TOOLSET: "scoped-invoice", IB_INVOICE_ID: "${invoice_id}" },
+        },
+      },
+      model: "@fast",
+      mode: "local",
+      sandbox: "workspace-write",
+      concurrency,
+    },
+  };
+}
+
+interface SpawnOpts {
+  cwd: string;
+  automationRun?: { name: string; runId: string };
+  env?: Record<string, string>;
+}
+
+function makeEngine(spawnCalls: SpawnOpts[], seen: Array<Record<string, unknown>>) {
+  return createEngine({
+    spawnSession: async (opts) => {
+      spawnCalls.push(opts as SpawnOpts);
+      return { success: true, spawnToken: `tok-${spawnCalls.length}` };
+    },
+    resolveRegistry: () => flowsRegistry(seen),
+    listScopes: () => [{ base: repo, scope: "folder" }],
+    config: () => ({
+      defaultVisibility: "hidden",
+      retention: 100,
+      defaultModel: "anthropic/claude-sonnet-4-5",
+      scanFolder: true,
+      scanGlobal: false,
+      maxRunAgeMs: 30 * 60 * 1000,
+    }),
+    readRoles: () => ({ fast: "anthropic/claude-haiku-4-5" }),
+  });
+}
+
+describe("engine.runInvoice", () => {
+  it("starts exactly one scoped run bound to the invoice id, no fan-out", () => {
+    const spawnCalls: SpawnOpts[] = [];
+    const seen: Array<Record<string, unknown>> = [];
+    const engine = makeEngine(spawnCalls, seen);
+    const automation = perInvoiceAutomation("drain");
+
+    const res = engine.runInvoice(automation, "inv-7");
+
+    expect(res.ok).toBe(true);
+    expect(res.runId).toBeTruthy();
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].env).toMatchObject({ IB_TOOLSET: "scoped-invoice", IB_INVOICE_ID: "inv-7" });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].inputs).toEqual({ invoice_id: "inv-7" });
+  });
+
+  it("refuses a second start while the first run is in flight", () => {
+    const spawnCalls: SpawnOpts[] = [];
+    const engine = makeEngine(spawnCalls, []);
+    const automation = perInvoiceAutomation("drain");
+
+    const first = engine.runInvoice(automation, "inv-7");
+    expect(first.ok).toBe(true);
+
+    const second = engine.runInvoice(automation, "inv-7");
+    expect(second).toEqual({ ok: false, reason: "in_flight" });
+    // still only one spawn — no second run
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  it("a different invoice id is not blocked by an in-flight one", () => {
+    const spawnCalls: SpawnOpts[] = [];
+    const engine = makeEngine(spawnCalls, []);
+    const automation = perInvoiceAutomation("drain");
+
+    expect(engine.runInvoice(automation, "inv-7").ok).toBe(true);
+    expect(engine.runInvoice(automation, "inv-8").ok).toBe(true);
+    expect(spawnCalls).toHaveLength(2);
+    expect(spawnCalls.map((s) => s.env?.IB_INVOICE_ID).sort()).toEqual(["inv-7", "inv-8"]);
+  });
+
+  it("a scheduler fan-out run for the same invoice also blocks a run-invoice", () => {
+    const spawnCalls: SpawnOpts[] = [];
+    const engine = makeEngine(spawnCalls, []);
+    const automation = perInvoiceAutomation("drain", "parallel");
+
+    // Scheduler fans out over the queued invoice inv-9 (its run is now tracked).
+    engine.startRunFor(automation, { firedAt: Date.now(), vars: { invoice_id: "inv-9" }, invoiceId: "inv-9" });
+    expect(spawnCalls).toHaveLength(1);
+
+    const res = engine.runInvoice(automation, "inv-9");
+    expect(res).toEqual({ ok: false, reason: "in_flight" });
+    expect(spawnCalls).toHaveLength(1);
+  });
+});

--- a/packages/automation-plugin/src/server/engine.ts
+++ b/packages/automation-plugin/src/server/engine.ts
@@ -270,6 +270,13 @@ export interface RunContext {
   emitEvent?: { eventType: string; data?: Record<string, unknown>; completion?: ActionCompletion };
   modelError?: string;
   sessionId?: string;
+  /**
+   * The invoice id this run is bound to, when it is a per-invoice run (set from
+   * the fan-out `FireContext`). Drives the one-in-flight refusal for a
+   * start-one-invoice request. Absent for a non-per-invoice run.
+   * See change: serve-and-start-queued-invoice.
+   */
+  invoiceId?: string;
   /** Wall-clock start, used by the undelivered-run bound. */
   startedAt: number;
   /**
@@ -310,6 +317,19 @@ export interface Engine {
    * `{ ok: false }`. See change: run-now-fans-out-per-invoice.
    */
   runNow(automation: DiscoveredAutomation): Promise<{ ok: boolean; runId?: string; error?: string }>;
+  /**
+   * Start EXACTLY ONE run bound to `invoiceId` through the same per-invoice run
+   * core the fan-out uses (so the run carries `IB_TOOLSET`/`IB_INVOICE_ID`).
+   * Refuses with `{ ok:false, reason:"in_flight" }` when a run bound to that
+   * invoice is already tracked (spawned, not yet finalized) — covering both a
+   * prior start-one-invoice call and a scheduler fan-out run — so two runs never
+   * process the same record. Does NOT enumerate the queue or fan out.
+   * See change: serve-and-start-queued-invoice.
+   */
+  runInvoice(
+    automation: DiscoveredAutomation,
+    invoiceId: string,
+  ): { ok: boolean; runId?: string; reason?: "in_flight"; error?: string };
   /**
    * Stop a `running` run: terminate its spawned process via the host hook
    * (hard-kill by sessionId, or by spawnToken during the spawn→register
@@ -677,6 +697,39 @@ export function createEngine(deps: EngineDeps): Engine {
     return first ? { ok: true, runId: first } : { ok: false, error: "run not started" };
   }
 
+  /** True when a tracked (spawned, not yet finalized) run is bound to `invoiceId`. */
+  function invoiceInFlight(invoiceId: string): boolean {
+    for (const q of pending.values()) {
+      if (q.some((c) => c.invoiceId === invoiceId)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Start EXACTLY ONE run bound to `invoiceId` via the shared `startRunFor` core
+   * (same path the fan-out uses), refusing when that invoice already has a run in
+   * flight. The in-flight check and `startRunFor` run with no `await` between
+   * them, so `startRunFor`'s synchronous `enqueuePending` makes two same-tick
+   * calls mutually exclusive (the first enqueues before the second checks).
+   * See change: serve-and-start-queued-invoice.
+   */
+  function runInvoice(
+    automation: DiscoveredAutomation,
+    invoiceId: string,
+  ): { ok: boolean; runId?: string; reason?: "in_flight"; error?: string } {
+    if (invoiceInFlight(invoiceId)) {
+      log(`[engine] run-invoice ${invoiceId}: already in flight; refusing`);
+      return { ok: false, reason: "in_flight" };
+    }
+    const fireCtx: FireContext = {
+      firedAt: deps.now?.() ?? Date.now(),
+      vars: { invoice_id: invoiceId },
+      invoiceId,
+    };
+    const r = startRunFor(automation, fireCtx);
+    return r ? { ok: true, runId: r.runId } : { ok: false, error: "run not started" };
+  }
+
   const scheduler = createScheduler({
     registry,
     onFire: (automation, ctx) => {
@@ -734,6 +787,7 @@ export function createEngine(deps: EngineDeps): Engine {
           }
         : {}),
       ...(resolved.error ? { modelError: resolved.error } : {}),
+      ...(fireCtx?.invoiceId ? { invoiceId: fireCtx.invoiceId } : {}),
       startedAt: deps.now?.() ?? Date.now(),
       delivered: false,
     };
@@ -808,6 +862,7 @@ export function createEngine(deps: EngineDeps): Engine {
     startRunFor,
     fire: dispatchFire,
     runNow,
+    runInvoice,
 
     pendingForCwd(cwd: string): RunContext | undefined {
       return firstUndeliveredForCwd(cwd);

--- a/packages/automation-plugin/src/server/index.ts
+++ b/packages/automation-plugin/src/server/index.ts
@@ -29,7 +29,7 @@ const RESCAN_DEBOUNCE_MS = 15_000;
 import os from "node:os";
 import path from "node:path";
 import type { ServerPluginContext } from "@blackbelt-technology/dashboard-plugin-runtime/server";
-import type { AutomationScope, Visibility } from "../shared/automation-types.js";
+import type { AutomationScope, DiscoveredAutomation, Visibility } from "../shared/automation-types.js";
 import {
   ACTION_CONTRIBUTION_PREFIX,
   type ActionRegistry,
@@ -242,6 +242,20 @@ async function initEngine(ctx: ServerPluginContext): Promise<void> {
     warn: (m) => logger.warn(m),
   });
   engineRef = engine;
+
+  // Cross-plugin service: start EXACTLY ONE scoped run for a single queued
+  // invoice through the same per-invoice fan-out core the scheduler + manual
+  // run-now use. The reverse direction of `invoicebot:queuedInvoices`: a
+  // consumer (the invoicebot plugin's /run-invoice route) invokes this to start
+  // one invoice without a second dispatch path. Refuses `{ok:false,
+  // reason:"in_flight"}` when the invoice already has a run in flight.
+  // See change: serve-and-start-queued-invoice.
+  ctx.provide(
+    "automation:runInvoice",
+    async (cwd: string, invoiceId: string): Promise<{ ok: boolean; runId?: string; reason?: string; error?: string }> => {
+      return runInvoiceViaEngine(cwd, invoiceId);
+    },
+  );
 
   const watcher = createAutomationWatcher({
     onChange: () => engine.refresh(),
@@ -459,6 +473,32 @@ async function runNowViaEngine(
   ).find((a) => a.name === name && a.scope === scope && a.valid);
   if (!found) return { ok: false, error: `automation "${name}" not found or invalid in ${scope} scope` };
   return eng.runNow(found);
+}
+
+/**
+ * Start exactly ONE scoped run for a single queued invoice. Scans the folder
+ * scope for the workspace's `scope: per-invoice` automation (the intake drain)
+ * and delegates to the engine's start-one-invoice core (`runInvoice`), which
+ * enforces the one-in-flight refusal. Backs the `automation:runInvoice`
+ * cross-plugin service. See change: serve-and-start-queued-invoice.
+ */
+async function runInvoiceViaEngine(
+  cwd: string,
+  invoiceId: string,
+): Promise<{ ok: boolean; runId?: string; reason?: string; error?: string }> {
+  const eng = engineRef;
+  if (!eng) return { ok: false, error: "engine not ready" };
+  const base = path.resolve(cwd);
+  const { scanAutomations } = await import("./scanner.js");
+  const isPerInvoice = (a: DiscoveredAutomation): boolean =>
+    (a.config?.action?.payload as Record<string, unknown> | undefined)?.scope === "per-invoice";
+  const found = scanAutomations(
+    { repoRoot: base, scanFolder: true, scanGlobal: false },
+    eng.registry.kinds(),
+    eng.actionRegistry.ids(),
+  ).find((a) => a.valid && isPerInvoice(a));
+  if (!found) return { ok: false, error: "no per-invoice automation for workspace" };
+  return eng.runInvoice(found, invoiceId);
 }
 
 /** Stop a running run via the engine (terminate process + finalize idempotently). */

--- a/packages/invoicebot-plugin/src/server/__tests__/run-and-queued-blob-route.test.ts
+++ b/packages/invoicebot-plugin/src/server/__tests__/run-and-queued-blob-route.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Route tests for the two queued-invoice surfaces added by
+ * serve-and-start-queued-invoice:
+ *   - GET  /api/plugins/invoicebot/blob?invoice_id=<id>  (queued original bytes)
+ *   - POST /api/plugins/invoicebot/run-invoice           (start ONE scoped run)
+ * Covers the path-confinement rejection and the in-flight refusal — the crux
+ * safety properties. The `handle` form staying unchanged is covered by
+ * blob-route.test.ts.
+ */
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { EngineResult, InvoiceEngine } from "../engine/port.js";
+import { mountInvoiceBotRoutes } from "../routes.js";
+
+const noop = async (): Promise<EngineResult> => ({ content: [{ type: "text", text: "" }], details: {} });
+const noIngest = async () => ({ results: [], landed: 0, skipped: 0, rejected: 0 });
+const ensureAutomation = async () => ({ automation: [] });
+const engine: InvoiceEngine = { query: noop, review: noop, setup: noop, rules: noop, ingest: noIngest, ensureAutomation };
+
+const PDF_BYTES = "%PDF-1.4\n".padEnd(300, "x");
+const INV_ID = "d896bc0a90942348"; // content-hash shape
+const DROP_NAME = `${INV_ID}_Zrt_533_2018_T-PaxKft.pdf`;
+
+let app: FastifyInstance;
+let cwd: string;
+let outside: string;
+let dropDir: string;
+/** Records what run-invoice was asked, and a scripted response. */
+let runInvoiceCalls: Array<{ cwd: string; invoiceId: string }>;
+let runInvoiceImpl: (cwd: string, invoiceId: string) => Promise<{ ok: boolean; runId?: string; reason?: string; error?: string } | undefined>;
+
+beforeEach(async () => {
+  runInvoiceCalls = [];
+  runInvoiceImpl = async (c, id) => {
+    runInvoiceCalls.push({ cwd: c, invoiceId: id });
+    return { ok: true, runId: "2026-01-01-000000-invoicebot-intake-00001" };
+  };
+  app = Fastify();
+  mountInvoiceBotRoutes(app, {
+    engine,
+    dispatchFlow: async () => undefined,
+    runInvoice: (c, id) => runInvoiceImpl(c, id),
+  });
+  await app.ready();
+  cwd = mkdtempSync(join(tmpdir(), "ib-runq-"));
+  outside = mkdtempSync(join(tmpdir(), "ib-runq-out-"));
+  dropDir = resolve(cwd, ".pi/flows/invoicebot-state/drop");
+  mkdirSync(dropDir, { recursive: true });
+  writeFileSync(join(dropDir, DROP_NAME), PDF_BYTES);
+  writeFileSync(join(outside, "secret.pdf"), "top secret");
+});
+afterEach(async () => {
+  await app.close();
+  for (const d of [cwd, outside]) rmSync(d, { recursive: true, force: true });
+});
+
+function getById(invoiceId: string, headers: Record<string, string> = {}, c: string = cwd) {
+  const url = `/api/plugins/invoicebot/blob?cwd=${encodeURIComponent(c)}&invoice_id=${encodeURIComponent(invoiceId)}`;
+  return app.inject({ method: "GET", url, headers });
+}
+function runInvoice(body: Record<string, unknown>) {
+  return app.inject({ method: "POST", url: "/api/plugins/invoicebot/run-invoice", payload: body });
+}
+
+describe("blob?invoice_id — queued original delivery", () => {
+  it("serves the drop original inline as PDF (200)", async () => {
+    const res = await getById(INV_ID);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toBe("application/pdf");
+    expect(res.headers["content-disposition"]).toBe(`inline; filename="${DROP_NAME}"`);
+    expect(res.headers["accept-ranges"]).toBe("bytes");
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(res.body).toBe(PDF_BYTES);
+  });
+
+  it("honours a Range request (206)", async () => {
+    const res = await getById(INV_ID, { range: "bytes=0-8" });
+    expect(res.statusCode).toBe(206);
+    expect(res.headers["content-range"]).toBe(`bytes 0-8/${PDF_BYTES.length}`);
+    expect(res.body).toBe(PDF_BYTES.slice(0, 9));
+  });
+
+  it("404 when the drop file was consumed by processing", async () => {
+    rmSync(join(dropDir, DROP_NAME));
+    const res = await getById(INV_ID);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("404 for an unknown invoice id", async () => {
+    const res = await getById("0000000000000000");
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("400 when neither handle nor invoice_id is supplied", async () => {
+    const res = await app.inject({ method: "GET", url: `/api/plugins/invoicebot/blob?cwd=${encodeURIComponent(cwd)}` });
+    expect(res.statusCode).toBe(400);
+  });
+
+  describe("path-confinement rejection", () => {
+    for (const bad of ["../secret", "..%2Fsecret", "a/b", "a\\b", "/etc/passwd", "a.b", "~root"]) {
+      it(`rejects traversal-shaped invoice_id ${JSON.stringify(bad)} (not 200)`, async () => {
+        const res = await getById(bad);
+        expect(res.statusCode).not.toBe(200);
+        expect([400, 403, 404]).toContain(res.statusCode);
+      });
+    }
+
+    it("rejects a symlink whose target escapes the state dir", async () => {
+      const link = join(dropDir, `${INV_ID}_link.pdf`);
+      // remove the real drop file so the symlink is the only `<id>_` match
+      rmSync(join(dropDir, DROP_NAME));
+      symlinkSync(join(outside, "secret.pdf"), link);
+      const res = await getById(INV_ID);
+      expect(res.statusCode).not.toBe(200);
+      expect([403, 404]).toContain(res.statusCode);
+    });
+  });
+});
+
+describe("run-invoice route", () => {
+  it("starts exactly one run and returns its runId", async () => {
+    const res = await runInvoice({ cwd, invoice_id: INV_ID });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ ok: true, runId: expect.any(String) });
+    expect(runInvoiceCalls).toEqual([{ cwd, invoiceId: INV_ID }]);
+  });
+
+  it("refuses with 409 / reason:in_flight when the invoice already runs", async () => {
+    runInvoiceImpl = async () => ({ ok: false, reason: "in_flight" });
+    const res = await runInvoice({ cwd, invoice_id: INV_ID });
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toEqual({ ok: false, reason: "in_flight" });
+  });
+
+  it("400 when invoice_id is missing", async () => {
+    const res = await runInvoice({ cwd });
+    expect(res.statusCode).toBe(400);
+    expect(runInvoiceCalls).toHaveLength(0);
+  });
+
+  it("400 when cwd is missing", async () => {
+    const res = await runInvoice({ invoice_id: INV_ID });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("503 when the automation:runInvoice service is unavailable", async () => {
+    await app.close();
+    app = Fastify();
+    mountInvoiceBotRoutes(app, { engine, dispatchFlow: async () => undefined }); // no runInvoice dep
+    await app.ready();
+    const res = await runInvoice({ cwd, invoice_id: INV_ID });
+    expect(res.statusCode).toBe(503);
+  });
+
+  it("503 when the service resolves undefined (not yet published)", async () => {
+    runInvoiceImpl = async () => undefined;
+    const res = await runInvoice({ cwd, invoice_id: INV_ID });
+    expect(res.statusCode).toBe(503);
+  });
+});

--- a/packages/invoicebot-plugin/src/server/blob.ts
+++ b/packages/invoicebot-plugin/src/server/blob.ts
@@ -13,7 +13,7 @@
  * `blobs/` (or `blobs\`) segment is stripped before resolution so both the full
  * handle and a bare basename work. See change: serve-invoice-original-blob.
  */
-import { realpathSync, statSync } from "node:fs";
+import { readdirSync, realpathSync, statSync } from "node:fs";
 import { extname, resolve, sep } from "node:path";
 
 /** Outcome of {@link resolveBlobPath}. `abs` is a real, contained, regular-file path. */
@@ -55,6 +55,74 @@ export function resolveBlobPath(cwd: unknown, handle: unknown): BlobResolution {
   let realRoot: string;
   try {
     realRoot = realpathSync(root);
+  } catch {
+    return { ok: false, reason: "not-found" };
+  }
+  if (!isInside(realRoot, real)) return { ok: false, reason: "traversal" };
+
+  try {
+    if (!statSync(real).isFile()) return { ok: false, reason: "not-found" };
+  } catch {
+    return { ok: false, reason: "not-found" };
+  }
+
+  return { ok: true, abs: real };
+}
+
+/**
+ * Resolve a QUEUED invoice's landed original by `invoice_id` — the target of the
+ * queued row's `original_ref` (fallback `source_ref`), which the engine writes as
+ * `<dropFolder>/<content_hash>_<basename>` with the invoice id == content hash.
+ * The default drop folder is `<state>/drop`, so the original lives under the
+ * engine state dir; a landed file is located by the same `<id>_` prefix scan the
+ * engine's own `droppedExists(hash)` uses. No engine query exposes the ref, and
+ * the drop-file naming is deterministic, so this stays a pure state-dir read —
+ * consistent with the `handle` form's direct filesystem access.
+ *
+ * `invoice_id` is untrusted: it is rejected unless it is a bare token (no NUL, no
+ * path separator, no `..`), and the resolved real path is re-checked for
+ * containment inside the state dir (defeats symlink escape). Serves only an
+ * existing regular file; a consumed drop file maps to `not-found` (route → 404).
+ * See change: serve-and-start-queued-invoice.
+ */
+export function resolveInvoiceOriginalPath(cwd: unknown, invoiceId: unknown): BlobResolution {
+  if (typeof cwd !== "string" || cwd.trim() === "" || cwd.includes("\0")) {
+    return { ok: false, reason: "invalid-input" };
+  }
+  if (typeof invoiceId !== "string" || invoiceId.trim() === "" || invoiceId.includes("\0")) {
+    return { ok: false, reason: "invalid-input" };
+  }
+  // A content-hash id is a bare token. Any path separator, `.` segment, or `~`
+  // is a traversal attempt — reject before it can shape a filesystem read.
+  if (!/^[A-Za-z0-9_-]+$/.test(invoiceId)) {
+    return { ok: false, reason: "traversal" };
+  }
+
+  const stateRoot = resolve(cwd, ".pi/flows/invoicebot-state");
+  const dropDir = resolve(stateRoot, "drop");
+  const prefix = `${invoiceId}_`;
+
+  let entry: string | undefined;
+  try {
+    entry = readdirSync(dropDir).find((n) => n.startsWith(prefix));
+  } catch {
+    return { ok: false, reason: "not-found" };
+  }
+  if (!entry) return { ok: false, reason: "not-found" };
+
+  const target = resolve(dropDir, entry);
+  // Lexical containment (the entry name came from readdir, but re-assert).
+  if (!isInside(stateRoot, target)) return { ok: false, reason: "traversal" };
+
+  let real: string;
+  try {
+    real = realpathSync(target);
+  } catch {
+    return { ok: false, reason: "not-found" };
+  }
+  let realRoot: string;
+  try {
+    realRoot = realpathSync(stateRoot);
   } catch {
     return { ok: false, reason: "not-found" };
   }

--- a/packages/invoicebot-plugin/src/server/index.ts
+++ b/packages/invoicebot-plugin/src/server/index.ts
@@ -145,10 +145,24 @@ export async function registerPlugin(ctx: ServerPluginContext): Promise<void> {
     });
   });
 
+  // Start ONE scoped run for a single queued invoice through the automation
+  // plugin's per-invoice fan-out core. Consumed LAZILY per request (mirrors how
+  // automation consumes `invoicebot:queuedInvoices`) so plugin load order is
+  // irrelevant — the automation plugin may publish the service after this one
+  // activates. Absent service ⇒ the route returns 503.
+  // See change: serve-and-start-queued-invoice.
+  const runInvoice = (cwd: string, invoiceId: string) => {
+    const fn = ctx.consume<
+      (cwd: string, invoiceId: string) => Promise<{ ok: boolean; runId?: string; reason?: string; error?: string }>
+    >("automation:runInvoice");
+    return fn ? fn(cwd, invoiceId) : Promise.resolve(undefined);
+  };
+
   mountInvoiceBotRoutes(ctx.fastify, {
     engine,
     dispatchFlow: sessionLink.dispatchFlow,
     ensureScopedSession: sessionLink.ensureScopedSession,
+    runInvoice,
   });
 
   ctx.logger.info(`invoicebot-plugin routes mounted (engine binding: ${binding})`);

--- a/packages/invoicebot-plugin/src/server/routes.ts
+++ b/packages/invoicebot-plugin/src/server/routes.ts
@@ -9,6 +9,8 @@
  *   POST /api/plugins/invoicebot/setup   → ib_setup  (action)
  *   POST /api/plugins/invoicebot/rules   → ib_rules  (action)
  *   GET  /api/plugins/invoicebot/blob    → stream a retained original document
+ *                                          (?handle= processed, ?invoice_id= queued)
+ *   POST /api/plugins/invoicebot/run-invoice → start ONE scoped run for a queued invoice
  *   POST /api/plugins/invoicebot/upload  → multipart ingest of raw invoice bytes
  *   POST /api/plugins/invoicebot/automation → enable/disable a schedule automation
  *   GET  /api/plugins/invoicebot/automation → list schedule automations + state
@@ -38,7 +40,7 @@ import {
   flipAutomationDisabled,
   listInvoicebotAutomations,
 } from "./automation-toggle.js";
-import { contentDispositionFor, contentTypeFor, resolveBlobPath } from "./blob.js";
+import { contentDispositionFor, contentTypeFor, resolveBlobPath, resolveInvoiceOriginalPath } from "./blob.js";
 import type { EngineResult, FlowRunSpec, IngestFile, IngestOutcome, InvoiceEngine } from "./engine/port.js";
 
 /** Per-file cap (bytes) enforced at the multipart boundary — matches the engine's 20 MB cap. */
@@ -80,6 +82,14 @@ export interface InvoiceBotRouteDeps {
   dispatchFlow: (args: { cwd: string; flow: FlowRunSpec; sessionId?: string; invoiceId?: string }) => Promise<string | undefined>;
   /** Bootstrap a usable invoice-scoped chat session. */
   ensureScopedSession?: (cwd: string, invoiceId: string) => Promise<string | undefined>;
+  /**
+   * Start ONE scoped run for exactly one queued invoice through the automation
+   * plugin's per-invoice fan-out core (cross-plugin `automation:runInvoice`
+   * service). Resolved lazily so plugin load order is irrelevant; `undefined`
+   * when the automation plugin has not published the service.
+   * See change: serve-and-start-queued-invoice.
+   */
+  runInvoice?: (cwd: string, invoiceId: string) => Promise<{ ok: boolean; runId?: string; reason?: string; error?: string } | undefined>;
 }
 
 /** Consequential ops the client MUST confirm first (api-contract §10). */
@@ -208,9 +218,15 @@ export function mountInvoiceBotRoutes(fastify: FastifyInstance, deps: InvoiceBot
   // Breaks the POST-envelope convention deliberately: the browser's native
   // PDF/image viewer needs a plain GET URL it can put in <iframe src>/<img src>
   // and issue Range against. Path-traversal-guarded via resolveBlobPath.
+  //
+  // Two resolution forms: `handle` serves a processed invoice's retained blob
+  // (unchanged); `invoice_id` serves a QUEUED invoice's landed original from the
+  // drop folder (it has no blob yet), confined to the engine state dir. `handle`
+  // wins when both are present. See change: serve-and-start-queued-invoice.
   fastify.get("/api/plugins/invoicebot/blob", async (req, reply) => {
     const q = (req.query ?? {}) as Record<string, unknown>;
-    const resolved = resolveBlobPath(q.cwd, q.handle);
+    const resolved =
+      q.handle !== undefined ? resolveBlobPath(q.cwd, q.handle) : resolveInvoiceOriginalPath(q.cwd, q.invoice_id);
     if (!resolved.ok) {
       const code = resolved.reason === "invalid-input" ? 400 : resolved.reason === "traversal" ? 403 : 404;
       req.log.info({ reason: resolved.reason, code }, "invoicebot blob rejected");
@@ -248,6 +264,45 @@ export function mountInvoiceBotRoutes(fastify: FastifyInstance, deps: InvoiceBot
       .header("Content-Range", `bytes ${start}-${end}/${size}`)
       .header("Content-Length", String(end - start + 1));
     return reply.send(createReadStream(abs, { start, end }));
+  });
+
+  // ── /run-invoice — start ONE scoped run for exactly one queued invoice ─────
+  // Reuses the SAME per-invoice fan-out core the scheduler + manual run-now
+  // share (via the automation plugin's `automation:runInvoice` service), so the
+  // run carries IB_TOOLSET=scoped-invoice + IB_INVOICE_ID and gets its own scoped
+  // session. Never a global/folder-level run, never a fan-out over other
+  // invoices. Refuses (409 / {ok:false,reason:"in_flight"}) when the invoice
+  // already has a run in flight. See change: serve-and-start-queued-invoice.
+  fastify.post("/api/plugins/invoicebot/run-invoice", async (req, reply) => {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const cwdErr = badCwd(body.cwd);
+    if (cwdErr) { reply.code(400); return { error: cwdErr }; }
+    if (typeof body.invoice_id !== "string" || body.invoice_id.trim() === "") {
+      reply.code(400);
+      return { error: "invoice_id is required" };
+    }
+    if (!deps.runInvoice) {
+      req.log.warn("invoicebot run-invoice: automation:runInvoice service unavailable");
+      reply.code(503);
+      return { error: "run service unavailable" };
+    }
+    await ensureIntake(body.cwd as string);
+    const res = await deps.runInvoice(body.cwd as string, body.invoice_id);
+    if (!res) {
+      reply.code(503);
+      return { error: "run service unavailable" };
+    }
+    if (!res.ok) {
+      if (res.reason === "in_flight") {
+        req.log.info({ invoice_id: body.invoice_id, code: 409 }, "invoicebot run-invoice refused: in flight");
+        reply.code(409);
+        return { ok: false, reason: "in_flight" };
+      }
+      reply.code(400);
+      return { ok: false, error: res.error ?? "run not started" };
+    }
+    req.log.info({ invoice_id: body.invoice_id, runId: res.runId }, "invoicebot run-invoice started");
+    return { ok: true, ...(res.runId ? { runId: res.runId } : {}) };
   });
 
   // ── /automation (POST) — enable/disable a schedule automation in place ─────


### PR DESCRIPTION
## Summary

Two operator surfaces for a **queued** invoice (landed, not yet processed), producer half only — **no engine change**.

1. **`GET /api/plugins/invoicebot/blob?invoice_id=<id>`** — serves the queued invoice's landed original from `<state>/drop` (the target of the row's `original_ref`/`source_ref`; invoice id == content hash, drop file `<id>_<basename>`). Confined to the engine state dir: charset guard + lexical + realpath containment, regular-file only, `404` when the drop file was consumed. The existing `?handle=` form is byte-for-byte unchanged.
2. **`POST /api/plugins/invoicebot/run-invoice` `{ invoice_id }`** — starts **one** scoped run for exactly that invoice through the **same per-invoice fan-out core** the scheduler + manual run-now share (via the new `automation:runInvoice` cross-plugin service — the reverse of the existing `invoicebot:queuedInvoices` seam), carrying `IB_TOOLSET=scoped-invoice` + `IB_INVOICE_ID`. Refuses `409 {ok:false,reason:"in_flight"}` when the invoice already has a run in flight. No global/folder-level run, no fan-out over other invoices.

## Design notes

- No `ib_query` view / engine facade method exposes `original_ref`, but the drop-file location is deterministic and the blob route already reads the state dir directly, so this stays a pure state-dir read — zero engine change.
- One-in-flight check + `startRunFor` run with no `await` between them, so two same-tick calls are mutually exclusive. The `pending` scan also catches a scheduler fan-out run for the same invoice.

## Gate

- New unit tests: 23 pass (queued-blob delivery + range + 404, path-confinement rejection incl. symlink escape, run-invoice happy/in-flight/scoped-env/503).
- Scoped package tests: `invoicebot-plugin` + `automation-plugin` → 516 pass; 1 **pre-existing, unrelated** failure in `automation-watcher.test.ts` (fs.watch env quirk — reproduces on the clean base).
- `tsc --noEmit` clean; `npm run build` succeeds.
- e2e OFF by operator decision.