### PR TITLE
feat(harden-greeting-collapse-latest): newest ib-greeting always wins the collapse

### DIFF
--- a/openspec/changes/archive/2026-08-17-harden-greeting-collapse-latest/proposal.md
+++ b/openspec/changes/archive/2026-08-17-harden-greeting-collapse-latest/proposal.md
@@ -1,0 +1,40 @@
+# Harden the greeting collapse so the NEWEST greeting always wins
+
+## Why
+
+The `ib-greeting` custom message is a singleton current-state overlay: a newer
+greeting REPLACES the prior one in place via a stable id (`custom-ib-greeting`),
+keyed collapse in the event reducer. The reducer's replace-in-place is blind to
+event **arrival order** — it simply overwrites the existing row with whatever
+greeting event arrives last.
+
+That blindness leaves the head one state behind on open. Replay events are built
+from a session snapshot; a live tick can persist a newer greeting *after* that
+snapshot is taken but the snapshot's (stale) greeting events can still arrive at
+the client *after* the newer live greeting. The blind collapse then clobbers the
+newer greeting with the stale one, and the head renders one state behind the
+newest — the exact symptom users see when opening an invoice.
+
+## What Changes
+
+- Add a monotonicity guard to the reducer's `ib-greeting` collapse: a greeting
+  event whose timestamp is **older** than the shown greeting's timestamp SHALL
+  NOT overwrite it. The newest greeting wins regardless of arrival order; an
+  equal timestamp still replaces (idempotent re-replay of the same state).
+- Track the greeting row's timestamp so the guard has an authoritative
+  comparison anchor; advance it on every accepted replacement.
+- Non-greeting `role:"custom"` messages keep per-entry ids and are unaffected.
+
+## Impact
+
+- Affected specs: `event-reducer`
+- Affected code: `packages/client/src/lib/chat/event-reducer.ts`
+  (`message_end` custom greeting branch)
+
+## Discipline Skills
+
+- `systematic-debugging` — the fix follows an evidence-first root-cause of a
+  live/replay ordering race reproduced by a failing unit test before any change.
+
+No other `eng-disciplines` skills apply: the change touches no auth, untrusted
+input, secrets/PII, external calls, latency budget, or irreversible step.

--- a/openspec/changes/archive/2026-08-17-harden-greeting-collapse-latest/specs/event-reducer/spec.md
+++ b/openspec/changes/archive/2026-08-17-harden-greeting-collapse-latest/specs/event-reducer/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Greeting custom message is a singleton replacement
+A `role:"custom"` message with `customType:"ib-greeting"` and `display:true` SHALL build
+a single `ChatMessage` row keyed by a STABLE id `custom-ib-greeting` (not
+`custom-<entryId>`), so a newer greeting REPLACES the prior greeting in place rather than
+appending a new history row. The latest greeting's content SHALL win, and the row SHALL
+retain the latest entry's `entryId`. The collapse SHALL be monotonic in event timestamp:
+a greeting `message_end` whose event timestamp is OLDER than the shown greeting row's
+timestamp SHALL NOT overwrite it, so the NEWEST greeting wins regardless of event ARRIVAL
+order (a stale replay-snapshot greeting arriving after a newer live greeting SHALL be
+ignored). An equal timestamp SHALL still replace (idempotent re-replay of the same state).
+The greeting row SHALL carry the timestamp of the greeting event that produced its current
+content, advanced on every accepted replacement. Other `role:"custom"` messages (any
+`customType` other than `"ib-greeting"`) SHALL keep their per-entry id, are NOT collapsed,
+and are NOT subject to the timestamp guard. A `role:"custom"` message whose `display` is
+falsy or absent SHALL still produce no row.
+
+#### Scenario: Newer greeting replaces the prior greeting in place
+- **WHEN** a `message_end` for `role:"custom"`, `customType:"ib-greeting"`, `display:true`
+  with content A arrives, followed by another with content B at an equal-or-newer timestamp
+- **THEN** `messages` SHALL contain exactly one greeting row
+- **AND** its content SHALL be B (the latest)
+- **AND** its id SHALL be `custom-ib-greeting`
+
+#### Scenario: A stale greeting arriving after a newer one does not overwrite it
+- **WHEN** a `message_end` `ib-greeting` with content B and timestamp T2 arrives
+- **AND** a later `message_end` `ib-greeting` with content A and an OLDER timestamp T1 (T1 < T2) arrives
+- **THEN** `messages` SHALL contain exactly one greeting row
+- **AND** its content SHALL remain B (the newest), not the stale A
+- **AND** its id SHALL be `custom-ib-greeting`
+
+#### Scenario: Unrelated custom messages are not collapsed
+- **WHEN** two `ib-greeting` messages (A then B) and one `customType:"x-note"` message
+  arrive in any order
+- **THEN** `messages` SHALL contain one greeting row (content B) and one separate
+  `x-note` row, each with distinct ids
+
+#### Scenario: Hidden greeting produces no row
+- **WHEN** a `role:"custom"`, `customType:"ib-greeting"` message with `display` falsy or
+  absent arrives
+- **THEN** no `ChatMessage` SHALL be added to `messages`

--- a/openspec/changes/archive/2026-08-17-harden-greeting-collapse-latest/tasks.md
+++ b/openspec/changes/archive/2026-08-17-harden-greeting-collapse-latest/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## 1. Reproduce (TDD)
+
+- [x] 1.1 Add a failing reducer unit test: a newer `ib-greeting` (higher ts)
+  arrives first, then a stale one (lower ts) arrives late; assert the shown
+  greeting stays the newest.
+- [x] 1.2 Add a test proving a newer greeting still replaces an older shown one.
+- [x] 1.3 Add a test proving an equal-ts greeting replaces in place (idempotent
+  re-replay tolerant).
+
+## 2. Fix
+
+- [x] 2.1 Add a monotonicity guard to the `message_end` `ib-greeting` collapse:
+  skip the replace when the incoming event timestamp is older than the shown
+  greeting's timestamp.
+- [x] 2.2 Persist the greeting row's timestamp and advance it on every accepted
+  replacement.
+
+## 3. Verify
+
+- [x] 3.1 Scoped tests green: `event-reducer.custom-display-message.test.ts` +
+  `state-replay-custom-message.test.ts`.
+- [x] 3.2 `npm run build` succeeds.

--- a/openspec/specs/event-reducer/spec.md
+++ b/openspec/specs/event-reducer/spec.md
@@ -616,15 +616,29 @@ A `role:"custom"` message with `customType:"ib-greeting"` and `display:true` SHA
 a single `ChatMessage` row keyed by a STABLE id `custom-ib-greeting` (not
 `custom-<entryId>`), so a newer greeting REPLACES the prior greeting in place rather than
 appending a new history row. The latest greeting's content SHALL win, and the row SHALL
-retain the latest entry's `entryId`. Other `role:"custom"` messages (any `customType`
-other than `"ib-greeting"`) SHALL keep their per-entry id and are NOT collapsed. A
-`role:"custom"` message whose `display` is falsy or absent SHALL still produce no row.
+retain the latest entry's `entryId`. The collapse SHALL be monotonic in event timestamp:
+a greeting `message_end` whose event timestamp is OLDER than the shown greeting row's
+timestamp SHALL NOT overwrite it, so the NEWEST greeting wins regardless of event ARRIVAL
+order (a stale replay-snapshot greeting arriving after a newer live greeting SHALL be
+ignored). An equal timestamp SHALL still replace (idempotent re-replay of the same state).
+The greeting row SHALL carry the timestamp of the greeting event that produced its current
+content, advanced on every accepted replacement. Other `role:"custom"` messages (any
+`customType` other than `"ib-greeting"`) SHALL keep their per-entry id, are NOT collapsed,
+and are NOT subject to the timestamp guard. A `role:"custom"` message whose `display` is
+falsy or absent SHALL still produce no row.
 
 #### Scenario: Newer greeting replaces the prior greeting in place
 - **WHEN** a `message_end` for `role:"custom"`, `customType:"ib-greeting"`, `display:true`
-  with content A arrives, followed by another with content B
+  with content A arrives, followed by another with content B at an equal-or-newer timestamp
 - **THEN** `messages` SHALL contain exactly one greeting row
 - **AND** its content SHALL be B (the latest)
+- **AND** its id SHALL be `custom-ib-greeting`
+
+#### Scenario: A stale greeting arriving after a newer one does not overwrite it
+- **WHEN** a `message_end` `ib-greeting` with content B and timestamp T2 arrives
+- **AND** a later `message_end` `ib-greeting` with content A and an OLDER timestamp T1 (T1 < T2) arrives
+- **THEN** `messages` SHALL contain exactly one greeting row
+- **AND** its content SHALL remain B (the newest), not the stale A
 - **AND** its id SHALL be `custom-ib-greeting`
 
 #### Scenario: Unrelated custom messages are not collapsed

--- a/packages/client/src/lib/chat/__tests__/event-reducer.custom-display-message.test.ts
+++ b/packages/client/src/lib/chat/__tests__/event-reducer.custom-display-message.test.ts
@@ -136,4 +136,41 @@ describe("ib-greeting singleton replacement (change: replace-replayed-greeting)"
     s = reduceEvent(s, greetingEnd("secret", false, "g1"));
     expect(s.messages).toHaveLength(0);
   });
+
+  // Change: harden-greeting-collapse-latest. The rendered greeting must always
+  // be the NEWEST regardless of event ARRIVAL order. A live/replay race delivers
+  // events out of timestamp order: the newest greeting (live) can land BEFORE a
+  // stale replay snapshot whose latest greeting is one state behind. Without a
+  // monotonicity guard the stable-id collapse blindly replaces in place, so the
+  // stale replay clobbers the newer live greeting and the head shows one behind.
+  it("T7: a stale (older-ts) greeting arriving AFTER a newer one does NOT overwrite it", () => {
+    let s = createInitialState();
+    // Newest greeting arrives first (live tick), ts=2000.
+    s = reduceEvent(s, greetingEnd("B", true, "g2", 2000));
+    expect(s.messages[0].content).toBe("B");
+    // Stale replay snapshot (taken before B persisted) arrives late, ts=1000.
+    s = reduceEvent(s, greetingEnd("A", true, "g1", 1000));
+    expect(s.messages).toHaveLength(1);
+    expect(s.messages[0].id).toBe("custom-ib-greeting");
+    // NEWEST wins: content stays B, not the stale A.
+    expect(s.messages[0].content).toBe("B");
+    expect(s.messages[0].entryId).toBe("g2");
+  });
+
+  it("T8: a newer (higher-ts) greeting still replaces an older shown one", () => {
+    let s = createInitialState();
+    s = reduceEvent(s, greetingEnd("A", true, "g1", 1000));
+    s = reduceEvent(s, greetingEnd("B", true, "g2", 2000));
+    expect(s.messages).toHaveLength(1);
+    expect(s.messages[0].content).toBe("B");
+    expect(s.messages[0].entryId).toBe("g2");
+  });
+
+  it("T9: an equal-ts greeting replaces in place (idempotent re-replay tolerant)", () => {
+    let s = createInitialState();
+    s = reduceEvent(s, greetingEnd("A", true, "g1", 1500));
+    s = reduceEvent(s, greetingEnd("A2", true, "g1b", 1500));
+    expect(s.messages).toHaveLength(1);
+    expect(s.messages[0].content).toBe("A2");
+  });
 });

--- a/packages/client/src/lib/chat/event-reducer.ts
+++ b/packages/client/src/lib/chat/event-reducer.ts
@@ -1751,10 +1751,26 @@ export function reduceEvent(
         const customId = isGreeting ? "custom-ib-greeting" : `custom-${entryId ?? next.messages.length}`;
         const existingIdx = next.messages.findLastIndex((m) => m.id === customId);
         if (existingIdx !== -1) {
+          // Monotonicity guard (change: harden-greeting-collapse-latest). The
+          // greeting is a singleton overlay collapsed by a STABLE id, so the
+          // replace-in-place is blind to arrival order. A live/replay race can
+          // deliver a STALE replay-snapshot greeting AFTER the newest live one
+          // (the snapshot was taken one state behind, but its events land
+          // late); a blind replace would then clobber the newer greeting and
+          // leave the head one state behind. Only advance when the incoming
+          // greeting is not older than the shown one — the NEWEST always wins
+          // regardless of arrival order. Equal ts still replaces (idempotent
+          // re-replay of the same state). Non-greeting customs keep per-entry
+          // ids, so they never collapse and are unaffected.
+          const shownTs = next.messages[existingIdx].timestamp;
+          if (isGreeting && typeof shownTs === "number" && event.timestamp < shownTs) {
+            break;
+          }
           next.messages = [...next.messages];
           next.messages[existingIdx] = {
             ...next.messages[existingIdx],
             content,
+            ...(isGreeting ? { timestamp: event.timestamp } : {}),
             ...(entryId ? { entryId } : {}),
           };
         } else {


### PR DESCRIPTION
Implements OpenSpec change `harden-greeting-collapse-latest`.

Adds a monotonicity guard to the event reducer ib-greeting stable-id collapse so
the NEWEST greeting always wins regardless of event arrival order. A live/replay
race could deliver a stale replay-snapshot greeting after a newer live greeting;
the blind replace-in-place then clobbered the newer greeting, leaving the head
one state behind on open. The guard skips a replacement when the incoming event
timestamp is older than the shown greeting row timestamp.

QA/manual tasks deferred to post-merge verification.
