### PR TITLE
docs: harden CI and OpenSpec recovery guides

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -11,7 +11,7 @@
     "gate": "test ! -e node_modules/.modules.yaml || test ! -d .pi/skills/openspec-explore || test ! -f .pi/dashboard/kb/index.db",
     "run": {
       "type": "script",
-      "command": "command -v corepack >/dev/null 2>&1 && corepack enable; pnpm install && npx --no-install openspec init --tools pi --force && pnpm --filter @blackbelt-technology/pi-dashboard-kb run build && NODE_OPTIONS=--experimental-sqlite npx kb index"
+      "command": "command -v corepack >/dev/null 2>&1 && corepack enable; pnpm install && pnpm exec openspec init --tools pi --force && pnpm --filter @blackbelt-technology/pi-dashboard-kb run build && NODE_OPTIONS=--experimental-sqlite npx kb index"
     }
   },
   "flows": {

--- a/.pi/skills/AGENTS.md
+++ b/.pi/skills/AGENTS.md
@@ -5,12 +5,12 @@ Files in this directory. One row per file. Non-source area (migrated from `docs/
 | File | Purpose |
 |------|---------|
 | `ci-troubleshoot/references/common-failures.md` | Detailed CI failure catalog: repo-lint tests (`no-raw-node-import`, `no-direct-process-kill`,… → see `ci-troubleshoot/references/common-failures.md.AGENTS.md` |
-| `ci-troubleshoot/references/release-pipeline.md` | `publish.yml` deep dive. Gated 7-job graph: resolve → parallel checks/smoke → tag → publish → Electron → GitHub Release. |
-| `ci-troubleshoot/references/workflow-taxonomy.md` | Current 10 workflow files: 8 entry workflows, 2 reusable matrices, triggers, purposes, and release-mutation boundaries. |
+| `ci-troubleshoot/references/release-pipeline.md` | `publish.yml` gated 7-job graph, input semantics, literal diagnostics, recovery, post-release checks. → see `ci-troubleshoot/references/release-pipeline.md.AGENTS.md` |
+| `ci-troubleshoot/references/workflow-taxonomy.md` | Current 10 workflow files: 8 entry workflows, 2 reusable workflows, triggers, purposes, release boundaries. → see `ci-troubleshoot/references/workflow-taxonomy.md.AGENTS.md` |
 | `ci-troubleshoot/scripts/list-recent-runs.ts` | Wrap `gh run list`. Flags `--failed`, `--workflow <name>`, `-L <n>`. Ensures `gh` installed + authenticated. Filters tabular output to failure rows when `--failed`. Cross-platform (`shell:false`). |
 | `ci-troubleshoot/scripts/retrigger-failed.ts` | Re-run failed jobs of a GitHub Actions run. `<run-id>` defaults to latest failed run (`findLatestFailedRun`). → see `ci-troubleshoot/scripts/retrigger-failed.ts.AGENTS.md` |
 | `ci-troubleshoot/scripts/show-failed-run.ts` | Show failed steps + log tails. `<run-id>` defaults to latest failed run. Flag `--full` switches `gh run view --log` (full) over `--log-failed` (default). Prints run summary then failed-step logs. |
-| `ci-troubleshoot/SKILL.md` | Diagnose failed GitHub Actions runs. Maps the 10 workflow files, verified helper commands, release gates, and common failures. |
+| `ci-troubleshoot/SKILL.md` | Diagnose GitHub Actions failures: 10 workflows, verified helpers, release gates, diagnostics, recovery. → see `ci-troubleshoot/SKILL.md.AGENTS.md` |
 | `code-quality/SKILL.md` | code-quality skill. Biome analyze→fix→test. changed-files (goal-loop) + whole-repo (cleanup) modes. → see `code-quality/SKILL.md.AGENTS.md` |
 | `debug-dashboard/references/isolated-verification.md` | Isolated UI/worktree verification. Live :8000 runs MAIN-repo code; `npm run build` leaks to `packages/client/dist`. Temp HOME + non-8000 ports + `PI_DASHBOARD_NO_MDNS=1`. Mockup-serve + worktree-harness recipe. |
 | `debug-dashboard/references/known-issues.md` | Known-issue catalogue distilled from `docs/faq.md`: server won't start (Electron Node bin fallback… + new-session spawn_register_timeout (pi-crash vs overload split) → see `debug-dashboard/references/known-issues.md.AGENTS.md` |

--- a/.pi/skills/AGENTS.md
+++ b/.pi/skills/AGENTS.md
@@ -5,12 +5,12 @@ Files in this directory. One row per file. Non-source area (migrated from `docs/
 | File | Purpose |
 |------|---------|
 | `ci-troubleshoot/references/common-failures.md` | Detailed CI failure catalog: repo-lint tests (`no-raw-node-import`, `no-direct-process-kill`,… → see `ci-troubleshoot/references/common-failures.md.AGENTS.md` |
-| `ci-troubleshoot/references/release-pipeline.md` | `publish.yml` deep dive. 4-job flow (prepare→publish→electron→github-release) with per-job steps, outputs,… → see `ci-troubleshoot/references/release-pipeline.md.AGENTS.md` |
-| `ci-troubleshoot/references/workflow-taxonomy.md` | All 6 `.github/workflows/` files: triggers, jobs, permissions, what each cannot do. → see `ci-troubleshoot/references/workflow-taxonomy.md.AGENTS.md` |
+| `ci-troubleshoot/references/release-pipeline.md` | `publish.yml` deep dive. Gated 7-job graph: resolve → parallel checks/smoke → tag → publish → Electron → GitHub Release. |
+| `ci-troubleshoot/references/workflow-taxonomy.md` | Current 10 workflow files: 8 entry workflows, 2 reusable matrices, triggers, purposes, and release-mutation boundaries. |
 | `ci-troubleshoot/scripts/list-recent-runs.ts` | Wrap `gh run list`. Flags `--failed`, `--workflow <name>`, `-L <n>`. Ensures `gh` installed + authenticated. Filters tabular output to failure rows when `--failed`. Cross-platform (`shell:false`). |
 | `ci-troubleshoot/scripts/retrigger-failed.ts` | Re-run failed jobs of a GitHub Actions run. `<run-id>` defaults to latest failed run (`findLatestFailedRun`). → see `ci-troubleshoot/scripts/retrigger-failed.ts.AGENTS.md` |
 | `ci-troubleshoot/scripts/show-failed-run.ts` | Show failed steps + log tails. `<run-id>` defaults to latest failed run. Flag `--full` switches `gh run view --log` (full) over `--log-failed` (default). Prints run summary then failed-step logs. |
-| `ci-troubleshoot/SKILL.md` | Diagnose failed GitHub Actions runs. Maps 6-workflow taxonomy (ci, ci-electron, _electron-build, publish,… → see `ci-troubleshoot/SKILL.md.AGENTS.md` |
+| `ci-troubleshoot/SKILL.md` | Diagnose failed GitHub Actions runs. Maps the 10 workflow files, verified helper commands, release gates, and common failures. |
 | `code-quality/SKILL.md` | code-quality skill. Biome analyze→fix→test. changed-files (goal-loop) + whole-repo (cleanup) modes. → see `code-quality/SKILL.md.AGENTS.md` |
 | `debug-dashboard/references/isolated-verification.md` | Isolated UI/worktree verification. Live :8000 runs MAIN-repo code; `npm run build` leaks to `packages/client/dist`. Temp HOME + non-8000 ports + `PI_DASHBOARD_NO_MDNS=1`. Mockup-serve + worktree-harness recipe. |
 | `debug-dashboard/references/known-issues.md` | Known-issue catalogue distilled from `docs/faq.md`: server won't start (Electron Node bin fallback… + new-session spawn_register_timeout (pi-crash vs overload split) → see `debug-dashboard/references/known-issues.md.AGENTS.md` |

--- a/.pi/skills/ci-troubleshoot/SKILL.md
+++ b/.pi/skills/ci-troubleshoot/SKILL.md
@@ -48,7 +48,7 @@ flowchart TD
   ci --> common[Tests, lint, build<br/>references/common-failures.md]
   other --> taxonomy[references/workflow-taxonomy.md]
   publish --> releaseJob{Which release job?}
-  releaseJob --> prepare[prepare]
+  releaseJob --> tag[tag-and-push]
   releaseJob --> npmOrder[publish: npm ordering]
   releaseJob --> matrix[electron: matrix leg]
   releaseJob --> assets[github-release: asset collision]
@@ -80,8 +80,8 @@ Maintained in [`references/common-failures.md`](references/common-failures.md). 
 
 | Failure | Where | Diagnosis | Fix |
 |---------|-------|-----------|-----|
-| `verify-lockfile-versions.mjs` fails | `prepare` | Cross-ref specifier in lockfile doesn't match bumped version | Regenerate lockfile + commit; or fix `scripts/sync-versions.js` |
-| CHANGELOG already has `## [X.Y.Z]` | `prepare` | You're re-dispatching with a version that was already promoted | Bump to a new version, or revert the CHANGELOG section |
+| `verify-lockfile-versions.mjs` fails | `tag-and-push` | Cross-ref specifier in lockfile doesn't match bumped version | Regenerate lockfile + commit; or fix `scripts/sync-versions.js` |
+| CHANGELOG already has `## [X.Y.Z]` | `tag-and-push` | You're re-dispatching with a version that was already promoted | Bump to a new version, or revert the CHANGELOG section |
 | `npm publish` 403 | `publish` | OIDC trusted publisher not configured for that package | Configure in npm web UI; or temporarily use NPM_TOKEN |
 | Electron matrix leg fails | `electron` | Missing prebuild for node-pty/better-sqlite3 on that OS/arch | Check `bundle-server.mjs` GO/NO-GO guard; rebuild prebuilds |
 | `shell: bash` on Windows runner | any | Lint test `no-bash-on-windows.test.ts` flags it | Remove `shell: bash` or guard with `if: runner.os != 'Windows'` |
@@ -100,7 +100,7 @@ Maintained in [`references/common-failures.md`](references/common-failures.md). 
 gh run list -L 10
 
 # Last 5 failed runs across all workflows
-gh run list -L 50 | grep -E 'failure|cancelled' | head -5
+gh run list -L 50 | grep -E 'failure|cancelled' | awk 'NR <= 5'
 
 # Get a specific run, only the failed steps
 gh run view <run-id> --log-failed
@@ -113,9 +113,14 @@ gh run rerun <run-id> --failed
 
 # Re-run from scratch (rare; usually for flakes)
 gh run rerun <run-id>
+
+# Cancel a stuck run
+gh run cancel <run-id>
 ```
 
 `gh run view --log-failed` is the highest-leverage one — it pulls only failed-step output, which is what you want 95% of the time.
+
+**Never bypass the release pipeline with a manual `npm publish`.** That loses OIDC trusted publishing, lockfile synchronization, changelog promotion, smoke gates, and Electron dependency ordering.
 
 **Rerun gotcha (tag-push releases):** `gh run rerun <id> --failed` does NOT re-dispatch skipped downstream reusable-workflow jobs (e.g. `electron`) even after `publish` flips green — they stay `skipped`. After a smoke-**gate** flake on a tag-push release, re-push the tag for a clean single-pass run instead: `git push --delete origin vX.Y.Z && git push origin vX.Y.Z`. `publish` is idempotent (skips already-published packages), so re-pushing the tag is safe.
 

--- a/.pi/skills/ci-troubleshoot/SKILL.md
+++ b/.pi/skills/ci-troubleshoot/SKILL.md
@@ -1,31 +1,24 @@
 ---
 name: ci-troubleshoot
-description: 'Diagnose failed GitHub Actions runs for pi-agent-dashboard: the 6-workflow taxonomy, the release pipeline, known failure modes, and how to read `gh run` logs and retrigger jobs. Use when a CI run is red, a release is stuck, a workflow won''t dispatch, or you need to know which workflow does what. See `release-cut` to trigger a release, `release-revoke` to revoke one.'
+description: 'Diagnose failed GitHub Actions runs for pi-agent-dashboard: the 10-file workflow taxonomy, the release pipeline, known failure modes, and how to read `gh run` logs and retrigger jobs. Use when a CI run is red, a release is stuck, a workflow won''t dispatch, or you need to know which workflow does what. See `release-cut` to trigger a release, `release-revoke` to revoke one.'
 ---
 
 # CI Troubleshoot
 
-Diagnose CI failures for pi-agent-dashboard. The repo has 6 workflows arranged in two flows:
+Diagnose CI failures for pi-agent-dashboard. The repo has 10 workflow files: 8 entry workflows and 2 reusable workflows.
 
 ```mermaid
 flowchart LR
-  subgraph push[Every push]
-    ci[ci.yml] --> test[tests + lint + type-check]
-    ci --> linux[standalone Linux matrix]
-    ci --> windows[standalone Windows matrix]
-    site[deploy-site.yml] --> siteRule[site/** changes only]
-  end
-  subgraph release[Release]
-    publish[publish.yml] --> prepare[prepare]
-    prepare --> npmPublish[publish packages]
-    npmPublish --> electron[electron matrix]
-    electron --> githubRelease[GitHub Release]
-    githubRelease --> sync[sync-release-version.yml]
-  end
-  subgraph manual[Manual installer smoke]
-    ciElectron[ci-electron.yml] --> sourceBundle[source_only_bundle=true]
-    sourceBundle --> safe[no publish, release, or tag mutation]
-  end
+  ci[ci.yml] --> checks[tests + lint + build]
+  deploy[deploy-site.yml] --> pages[GitHub Pages]
+  native[ci-e2e-electron.yml] --> nativeTests[native Electron E2E]
+  ciSmoke[ci-smoke.yml] --> smoke[_smoke.yml]
+  publish[publish.yml] --> smoke
+  ciElectron[ci-electron.yml] --> electron[_electron-build.yml]
+  nightly[nightly.yml] --> electron
+  publish --> electron
+  publish --> release[GitHub Release]
+  release --> sync[sync-release-version.yml]
 ```
 
 Full per-workflow detail: [`references/workflow-taxonomy.md`](references/workflow-taxonomy.md).
@@ -41,7 +34,7 @@ pnpm exec tsx .pi/skills/ci-troubleshoot/scripts/show-failed-run.ts             
 
 These wrap `gh run list`, `gh run view --log-failed`, and similar. You need `gh auth status` to be authenticated.
 
-> Scripts are TypeScript (cross-platform). All invocations use `npx tsx` so they work on Linux, macOS, and Windows. `tsx` is already a project dep; `gh` CLI is cross-platform.
+> Scripts are TypeScript and cross-platform. All invocations use `pnpm exec tsx`, which resolves the declared local dependency and fails if dependencies are absent. `gh` CLI is cross-platform.
 
 ## Triage decision tree
 
@@ -51,7 +44,9 @@ flowchart TD
   workflow --> ci[ci.yml]
   workflow --> publish[publish.yml]
   workflow --> electron[ci-electron.yml]
-  ci --> common[Tests, lint, smoke<br/>references/common-failures.md]
+  workflow --> other[Other workflow]
+  ci --> common[Tests, lint, build<br/>references/common-failures.md]
+  other --> taxonomy[references/workflow-taxonomy.md]
   publish --> releaseJob{Which release job?}
   releaseJob --> prepare[prepare]
   releaseJob --> npmOrder[publish: npm ordering]
@@ -62,16 +57,20 @@ flowchart TD
 
 ## Release pipeline — `publish.yml`
 
-The release flow runs 4 jobs strictly in this order:
+The release flow uses a gated 7-job graph:
 
 ```mermaid
 flowchart LR
-  prepare[prepare<br/>deps + tag] --> publish[publish<br/>ordered npm OIDC]
-  publish --> electron[electron<br/>6 matrix legs]
-  electron --> release[github-release<br/>create release]
+  resolve[resolve] --> checks[ci-checks]
+  resolve --> smoke[smoke via _smoke.yml]
+  checks --> tag[tag-and-push]
+  smoke --> tag
+  tag --> publish[publish packages]
+  publish --> electron[electron via _electron-build.yml]
+  electron --> release[github-release]
 ```
 
-`needs:` chains lock this order. **Do not remove `needs: [prepare, publish]` from `electron`** — the electron build's bundled server runs `npm install` for `@blackbelt-technology/*`, which must already exist on npm. Locked by `packages/shared/src/__tests__/publish-workflow-contract.test.ts`.
+Tag-push runs skip `tag-and-push`; `publish.if` accepts that skip while still requiring checks and smoke. **Do not remove `needs: [resolve, publish]` from `electron`**. The bundled server installs the just-published packages. Locked by `packages/shared/src/__tests__/publish-workflow-contract.test.ts`.
 
 Full walkthrough with per-job failure modes: [`references/release-pipeline.md`](references/release-pipeline.md).
 
@@ -86,7 +85,7 @@ Maintained in [`references/common-failures.md`](references/common-failures.md). 
 | `npm publish` 403 | `publish` | OIDC trusted publisher not configured for that package | Configure in npm web UI; or temporarily use NPM_TOKEN |
 | Electron matrix leg fails | `electron` | Missing prebuild for node-pty/better-sqlite3 on that OS/arch | Check `bundle-server.mjs` GO/NO-GO guard; rebuild prebuilds |
 | `shell: bash` on Windows runner | any | Lint test `no-bash-on-windows.test.ts` flags it | Remove `shell: bash` or guard with `if: runner.os != 'Windows'` |
-| Electron job missing `needs:` | repo-lint | `publish-workflow-contract.test.ts` failed | Restore `needs: [prepare, publish]` |
+| Electron job missing `needs:` | repo-lint | `publish-workflow-contract.test.ts` failed | Restore `needs: [resolve, publish]` |
 | `Cannot find module @blackbelt-technology/...` in electron | `electron` | `publish` job didn't run or failed; bundled server can't resolve from npm | Check `publish` job — re-run only if it failed; never bypass |
 | Fastify crashes in bundled server smoke | any using node | Bad Node version pinned in workflow | Bump `node-version:` to ≥ 22.18.0 |
 | Loud-but-harmless `EADDRINUSE` in smoke | smoke job | Concurrent server spawns | Usually self-recovering; check next log lines |

--- a/.pi/skills/ci-troubleshoot/SKILL.md.AGENTS.md
+++ b/.pi/skills/ci-troubleshoot/SKILL.md.AGENTS.md
@@ -1,3 +1,3 @@
 # ci-troubleshoot/SKILL.md — index
 
-Diagnose failed GitHub Actions runs. Maps the current 10 workflow files, direct helper commands under `.pi/skills/ci-troubleshoot/scripts/`, release gates, triage routes, and common failures. Uses repository-pinned `pnpm exec tsx`.
+Diagnose GitHub Actions failures across the current 10 workflow files. Uses repository-pinned helpers under `.pi/skills/ci-troubleshoot/scripts/`, routes release job failures, preserves literal diagnostics, and provides rerun/cancel recovery without bypassing the release pipeline.

--- a/.pi/skills/ci-troubleshoot/SKILL.md.AGENTS.md
+++ b/.pi/skills/ci-troubleshoot/SKILL.md.AGENTS.md
@@ -1,3 +1,3 @@
 # ci-troubleshoot/SKILL.md — index
 
-Diagnose failed GitHub Actions runs. Maps 6-workflow taxonomy (ci, ci-electron, _electron-build, publish, sync-release-version, deploy-site), release pipeline prepare→publish→electron→github-release, triage decision tree, known-failure catalog, `gh run` log recipes. First moves: `list-recent-runs.ts`, `show-failed-run.ts`.
+Diagnose failed GitHub Actions runs. Maps the current 10 workflow files, direct helper commands under `.pi/skills/ci-troubleshoot/scripts/`, release gates, triage routes, and common failures. Uses repository-pinned `pnpm exec tsx`.

--- a/.pi/skills/ci-troubleshoot/references/release-pipeline.md
+++ b/.pi/skills/ci-troubleshoot/references/release-pipeline.md
@@ -44,20 +44,54 @@ Needs `resolve`, `ci-checks`, `smoke`, and `tag-and-push`. It accepts `tag-and-p
 
 Needs `[resolve, publish]` and calls `_electron-build.yml`. Do not remove the publish dependency: the bundled server installs the just-published `@blackbelt-technology/*` packages.
 
+#### `_electron-build.yml` inputs
+
+| Input | Meaning |
+|---|---|
+| `version` | SemVer string applied to every workspace |
+| `ref` | Exact Git ref to check out |
+| `legs` | `all`; one platform (`darwin`, `linux`, `win32`); or a comma-list such as `darwin-arm64,linux-x64` |
+| `source_only_bundle` | When `true`, pass `--source-only` to `bundle-server.mjs`, skip host-side `npm install`, and resolve `@blackbelt-technology/*` from workspace source. This supports unpublished dev versions. Current release and on-demand installer callers use `false` to produce runnable bundles. |
+| `artifact_retention_days` | Artifact retention; normally 14 for CI and 90 for release |
+| `artifact_name_suffix` | Optional suffix, commonly a short SHA for CI traceability |
+| `registry_url` | Optional loopback Verdaccio URL for the nightly publish-install-bundle round-trip |
+
 ### `github-release`
 
 Needs the completed publish and Electron artifacts, then creates the GitHub Release.
 
 ## Common failures
 
-| Failure | Likely cause | Action |
-|---|---|---|
-| `ci-checks` fails | Lint, test, type, or build regression | Inspect the failed step; fix before release |
-| `smoke` fails | Published-install shape or platform regression | Inspect the failing `_smoke.yml` matrix leg |
-| Lockfile verification fails | Workspace versions and cross-package ranges differ | Re-run version sync and lockfile generation |
-| npm publish returns 403 | Trusted publisher or OIDC configuration is missing | Repair npm trusted-publisher configuration |
-| Electron cannot resolve a Dashboard package | `publish` failed or dependency ordering changed | Restore `electron.needs: [resolve, publish]`; never bypass publish |
-| Native prebuild gate fails | Required platform artifact is absent | Fix the package or bundle guard before release |
-| GitHub Release step fails on existing assets | Tag or release already exists | Inspect the existing release; do not overwrite blindly |
+| Literal symptom | Job | Cause | Action |
+|---|---|---|---|
+| `CHANGELOG.md already contains a section for X.Y.Z` | `tag-and-push` | Version was already promoted | Choose a new version or revert the prior release commit |
+| `Could not find '## [Unreleased]' heading` | `tag-and-push` | Changelog structure is incomplete | Restore the `## [Unreleased]` heading |
+| `verify-lockfile-versions.mjs` exits non-zero | `tag-and-push` | Workspace versions and cross-package ranges differ | Run `scripts/sync-versions.js`, regenerate the lockfile, and verify again |
+| `git push` fails | `tag-and-push` | Branch protection or token permissions reject the release commit/tag | Repair the workflow's push authority; do not bypass the gate |
+| npm publish returns `403` | `publish` | OIDC trusted publisher is not configured | Repair the npm trusted-publisher configuration |
+| npm publish returns `409 Conflict` | `publish` | The version already exists | Confirm the idempotency check; otherwise select a new version |
+| `Cannot find module @blackbelt-technology/...` | `electron` | Publish failed or dependency ordering changed | Restore `electron.needs: [resolve, publish]`; never bypass publish |
+| Missing node-pty or other native prebuild triple | `electron` | Required platform artifact is absent | Repair the native dependency/prebuild set before release |
+| DMG signing fails | `electron` | Apple certificate or signing secret is invalid | Renew the certificate or secret, then rerun the affected leg |
+| Linux maker or Docker build fails | `electron` | Linux packaging or `Dockerfile.build` regressed | Reproduce with `packages/electron/scripts/docker-make.sh` |
+| `builder-debug.yml` asset basename collision or release upload `404` | `github-release` | Several matrix legs produced the same debug filename | Preserve or expand the `Drop builder-debug logs (avoid asset basename collision)` step in `publish.yml` |
+| Release notes are empty | `github-release` | The versioned changelog section is missing or malformed | Repair the changelog section created by `tag-and-push` |
+| Release asset already exists | `github-release` | Tag/release state was reused | Inspect the existing release; do not overwrite blindly |
+
+## After the release
+
+`sync-release-version.yml` updates `site/src/data/latest-release.json`, then `deploy-site.yml` redeploys. If the site is not updated within about five minutes, inspect those two workflows in that order.
+
+## Recovery
+
+```bash
+# Re-run only failed jobs and preserve successful jobs.
+gh run rerun <run-id> --failed
+
+# Cancel a stuck run.
+gh run cancel <run-id>
+```
+
+For a fully broken release, use the `release-revoke` skill. **Do not bypass the pipeline with a manual `npm publish`.** That loses OIDC trusted publishing, lockfile synchronization, changelog promotion, smoke gates, and Electron dependency ordering.
 
 Current job details and invariants live in `.github/workflows/AGENTS.md` and `packages/shared/src/__tests__/publish-workflow-contract.test.ts`.

--- a/.pi/skills/ci-troubleshoot/references/release-pipeline.md
+++ b/.pi/skills/ci-troubleshoot/references/release-pipeline.md
@@ -1,141 +1,63 @@
-# Release Pipeline — `publish.yml` Deep Dive
+# Release Pipeline: `publish.yml`
 
-The 4-job release flow with per-job failure modes and recovery paths.
+`publish.yml` gates public release mutation behind tests and standalone installation smoke.
 
-```
-   prepare ──▶ publish ──▶ electron ──▶ github-release
-```
-
-## Job 1 — `prepare`
-
-**Purpose:** Resolve the version, optionally bump+commit+tag (on dispatch), produce outputs consumed by downstream jobs.
-
-### Steps (dispatch path)
-
-1. **Checkout** with `fetch-depth: 0` (needed for `git tag` uniqueness check).
-2. **Resolve version** — from tag (on push) or input (on dispatch).
-3. **Set up Node.js** — installs from `.nvmrc` or workflow-pinned version.
-4. **Install dependencies** — `npm ci`.
-5. **Bump workspace versions** — `npm version <X.Y.Z> --no-git-tag-version --allow-same-version --workspaces --include-workspace-root`.
-6. **Sync inter-package dep specifiers** — `node scripts/sync-versions.js`.
-7. **Regenerate package-lock.json** — `npm install --package-lock-only --no-audit --no-fund`. The lockfile must be regenerated because the workspace symlink graph just changed; otherwise strict prerelease semver causes consumer `npm ci` to fall back to the registry on every install.
-8. **Verify lockfile matches workspace versions** — `node scripts/verify-lockfile-versions.mjs`. **Fails fast** if any cross-ref is not `^<root.version>`.
-9. **Promote CHANGELOG** — Python inlined script. Inserts a new `## [Unreleased]` template before the now-versioned section.
-10. **Commit, tag, push** — `chore(release): v<X.Y.Z>` + `v<X.Y.Z>` tag, pushed to the dispatched branch.
-
-### Outputs
-
-- `version` — e.g. `0.4.1`
-- `tag` — e.g. `v0.4.1`
-- `is_prerelease` — boolean derived from semver
-
-### Common failures
-
-| Failure | Cause | Fix |
-|---------|-------|-----|
-| `CHANGELOG.md already contains a section for X.Y.Z` | Re-dispatching with a previously-promoted version | Bump to a new version; or `git revert` the prior `chore(release): vX.Y.Z` commit |
-| `verify-lockfile-versions.mjs` exits non-zero | A cross-ref specifier in lockfile is not `^<root.version>` | Check `scripts/sync-versions.js` ran; re-regenerate lockfile; commit |
-| `Could not find '## [Unreleased]' heading` | CHANGELOG manually edited; Unreleased section missing | Restore `## [Unreleased]` heading at top of CHANGELOG |
-| `git push` fails | Branch protection blocks bot pushes | Configure branch protection to allow `github-actions[bot]` OR push via PAT |
-| `npm ci` fails | Lockfile out of sync with package.jsons | Locally: `npm install`, commit `package-lock.json`, re-dispatch |
-
-## Job 2 — `publish`
-
-**Purpose:** Publish all packages to npm via OIDC trusted publishing.
-
-### Steps
-
-1. **Checkout** at the resolved ref (the freshly-pushed tag on dispatch).
-2. **Set up Node.js** with registry URL.
-3. **Upgrade npm to latest** — required for OIDC trusted publishing.
-4. **Set version from resolved tag** — `npm version` on every workspace (idempotent if already set).
-5. **Sync inter-package dep specifiers to bumped version**.
-6. **Publish to npm** — idempotent, ordered: sub-packages first (`packages/shared`, `packages/extension`, `packages/server`, `packages/client`), root last (`@blackbelt-technology/pi-agent-dashboard`).
-
-### Why the order matters
-
-The root package depends on the sub-packages via workspace specifiers. If root publishes before subs, the published root resolves to npm-registry versions of subs that don't exist yet — installs fail for end users for a brief window.
-
-### Common failures
-
-| Failure | Cause | Fix |
-|---------|-------|-----|
-| `403 Forbidden` on `npm publish` | OIDC trusted publisher not configured for that package | Configure in npm web UI: package → Settings → Trusted Publishers → GitHub Actions → repo + workflow path |
-| `409 Conflict` | Version already exists on npm | Idempotency check should skip — if it doesn't, there's a real conflict. Bump version. |
-| Package not found in workspace | Sub-package missing from publish list | Check the publish step's loop matches the actual workspace |
-| OIDC `id-token: write` permission missing | Workflow permissions wrong | Ensure `permissions: { id-token: write, contents: read }` on publish job |
-
-## Job 3 — `electron`
-
-**Purpose:** Build Electron installers across the 6-leg matrix.
-
-### Critical constraint
-
-```yaml
-electron:
-  needs: [prepare, publish]   # ← LOCKED by repo-lint
+```mermaid
+flowchart LR
+  resolve[resolve] --> checks[ci-checks]
+  resolve --> smoke[smoke via _smoke.yml]
+  checks --> tag[tag-and-push]
+  smoke --> tag
+  tag --> publish[publish]
+  publish --> electron[electron via _electron-build.yml]
+  electron --> release[github-release]
 ```
 
-**Do not remove `needs: [prepare, publish]`.** The electron build's bundled server runs `npm install` for `@blackbelt-technology/*` packages, which must already be available on npm. Removing this dependency would cause electron to attempt installs of versions that haven't published yet.
+## Entry paths
 
-Locked by `packages/shared/src/__tests__/publish-workflow-contract.test.ts`.
+- **Tag push:** `resolve` reads the `v*` tag. `tag-and-push` is skipped. `publish.if` accepts the skip only when `ci-checks` and `smoke` pass.
+- **Manual dispatch:** `resolve` validates the version input. After both gates pass, `tag-and-push` updates workspace versions and cross-package ranges, regenerates and verifies the lockfile, promotes the changelog, commits, tags, and pushes.
 
-### Delegation
+## Jobs
 
-This job is a single `uses: ./.github/workflows/_electron-build.yml` call with:
-- `version`: from prepare outputs
-- `ref`: the freshly-pushed tag
-- `legs`: `all`
-- `source_only_bundle`: `false` (releases bundle from npm)
-- `artifact_retention_days`: 90
+### `resolve`
 
-### Common failures
+Computes `version`, `tag`, prerelease state, and the exact ref. It has no release side effects.
 
-| Failure | Cause | Fix |
-|---------|-------|-----|
-| `Cannot find module @blackbelt-technology/...` | Publish job didn't run / failed | Check `publish` job; re-run if it failed. Never bypass the dependency. |
-| node-pty prebuild missing for a triple | bundle-server.mjs GO/NO-GO guard fires | Rebuild prebuilds; add the missing triple to node-pty deps |
-| `forge.config.ts` crash | Recent change broke a maker | `ci-electron.yml` should have caught this earlier — run it on the feature branch before merging |
-| DMG signing fails (macOS) | Code signing certs expired or wrong | Update Apple Developer cert + secrets |
-| Docker build fails (Linux) | `Dockerfile.build` issue | Test locally with `packages/electron/scripts/docker-make.sh` |
+### `ci-checks`
 
-## Job 4 — `github-release`
+Runs install, lint, full tests, and build on Node 22. A failure prevents tagging and publishing.
 
-**Purpose:** Create the GitHub Release with extracted release notes and uploaded artifacts.
+### `smoke`
 
-### Steps
+Calls `_smoke.yml` against the resolved ref. The reusable workflow runs the standalone installation matrix without public release mutation.
 
-1. **Checkout** at the tag.
-2. **Download all artifacts** from electron job.
-3. **Extract release notes from CHANGELOG** — pulls the `## [X.Y.Z]` section.
-4. **Drop builder-debug logs** — avoids asset basename collision (multiple platforms ship `builder-debug.yml` etc.).
-5. **Create GitHub Release** — `gh release create` with all assets uploaded.
+### `tag-and-push`
 
-### Common failures
+Runs only for manual dispatch after both gates pass. It creates the release commit and tag. Tag-push entry skips this job.
 
-| Failure | Cause | Fix |
-|---------|-------|-----|
-| Asset basename collision | `builder-debug.yml` from multiple platforms | Already handled by drop step; if it reappears, expand the drop pattern |
-| Release notes empty | CHANGELOG section missing or malformed | Check `prepare` job's CHANGELOG promotion |
-| `gh release create` 403 | `contents: write` permission missing | Verify job permissions |
-| Release marked prerelease incorrectly | `is_prerelease` output mis-derived | Check semver parser in `prepare` step |
+### `publish`
 
-## After the release
+Needs `resolve`, `ci-checks`, `smoke`, and `tag-and-push`. It accepts `tag-and-push` as `success` for dispatch or `skipped` for tag push. Packages publish in dependency order; already-published versions are skipped.
 
-`sync-release-version.yml` fires on the `release: published` event, updates `site/src/data/latest-release.json`, commits to develop. Then `deploy-site.yml` redeploys. If the site doesn't update within ~5 min after release, check those two workflows.
+### `electron`
 
-## Recovery
+Needs `[resolve, publish]` and calls `_electron-build.yml`. Do not remove the publish dependency: the bundled server installs the just-published `@blackbelt-technology/*` packages.
 
-If the release pipeline fails partway:
+### `github-release`
 
-```bash
-# Re-run only failed jobs (preserves successful ones)
-gh run rerun <run-id> --failed
+Needs the completed publish and Electron artifacts, then creates the GitHub Release.
 
-# Cancel a stuck run
-gh run cancel <run-id>
+## Common failures
 
-# For a fully-broken release, see the release-revoke skill
-```
+| Failure | Likely cause | Action |
+|---|---|---|
+| `ci-checks` fails | Lint, test, type, or build regression | Inspect the failed step; fix before release |
+| `smoke` fails | Published-install shape or platform regression | Inspect the failing `_smoke.yml` matrix leg |
+| Lockfile verification fails | Workspace versions and cross-package ranges differ | Re-run version sync and lockfile generation |
+| npm publish returns 403 | Trusted publisher or OIDC configuration is missing | Repair npm trusted-publisher configuration |
+| Electron cannot resolve a Dashboard package | `publish` failed or dependency ordering changed | Restore `electron.needs: [resolve, publish]`; never bypass publish |
+| Native prebuild gate fails | Required platform artifact is absent | Fix the package or bundle guard before release |
+| GitHub Release step fails on existing assets | Tag or release already exists | Inspect the existing release; do not overwrite blindly |
 
-**Do not bypass the pipeline** — manually running `npm publish` outside the workflow loses OIDC trusted publishing, lockfile sync, and CHANGELOG promotion guarantees.
+Current job details and invariants live in `.github/workflows/AGENTS.md` and `packages/shared/src/__tests__/publish-workflow-contract.test.ts`.

--- a/.pi/skills/ci-troubleshoot/references/release-pipeline.md.AGENTS.md
+++ b/.pi/skills/ci-troubleshoot/references/release-pipeline.md.AGENTS.md
@@ -1,3 +1,3 @@
 # ci-troubleshoot/references/release-pipeline.md — index
 
-`publish.yml` deep dive. Gated 7-job graph: resolve → parallel CI checks and standalone smoke → optional tag-and-push → ordered npm publish → Electron matrix → GitHub Release. Pins `electron.needs: [resolve, publish]` and tag-push skip handling.
+`publish.yml` deep dive. Gated 7-job graph: resolve → parallel checks/smoke → tag → publish → Electron → GitHub Release. Records `_electron-build.yml` inputs, literal failure-to-fix rows, post-release site checks, rerun/cancel recovery, and the no-manual-publish boundary.

--- a/.pi/skills/ci-troubleshoot/references/release-pipeline.md.AGENTS.md
+++ b/.pi/skills/ci-troubleshoot/references/release-pipeline.md.AGENTS.md
@@ -1,3 +1,3 @@
 # ci-troubleshoot/references/release-pipeline.md — index
 
-`publish.yml` deep dive. 4-job flow (prepare→publish→electron→github-release) with per-job steps, outputs, and failure tables. Documents `needs: [prepare, publish]` electron-ordering lock, npm publish order (sub-packages first), `_electron-build.yml` delegation inputs, `sync-release-version.yml` + `deploy-site.yml` after-release flow.
+`publish.yml` deep dive. Gated 7-job graph: resolve → parallel CI checks and standalone smoke → optional tag-and-push → ordered npm publish → Electron matrix → GitHub Release. Pins `electron.needs: [resolve, publish]` and tag-push skip handling.

--- a/.pi/skills/ci-troubleshoot/references/workflow-taxonomy.md
+++ b/.pi/skills/ci-troubleshoot/references/workflow-taxonomy.md
@@ -1,151 +1,46 @@
 # Workflow Taxonomy
 
-All 6 GitHub Actions workflows in `.github/workflows/`, what each does, when it fires, and what it can't do.
+`.github/workflows/` contains 10 workflow files: 8 entry workflows and 2 reusable workflows.
 
-## Push-triggered
+## Entry workflows
 
-### `ci.yml` — main CI
+| Workflow | Trigger | Purpose | Mutates releases? |
+|---|---|---|---|
+| `ci.yml` | Push and pull request to `develop` | Node 22 lint, type checks, tests, and build | No |
+| `deploy-site.yml` | `site/**` push, release publication, manual | Build and deploy GitHub Pages | Site only |
+| `ci-e2e-electron.yml` | Path-filtered pull request, manual | Native Electron Playwright checks on Linux and Windows | No |
+| `ci-electron.yml` | Manual | Build selected Electron installer matrix legs | No |
+| `ci-smoke.yml` | Manual | Run the standalone installation smoke matrix | No |
+| `nightly.yml` | Manual; schedule currently disabled | Full-fidelity Verdaccio and Electron round-trip | No public release mutation |
+| `publish.yml` | `v*` tag or manual version dispatch | Gate, tag when dispatched, publish npm packages, build Electron, create GitHub Release | Yes |
+| `sync-release-version.yml` | Release published or edited, manual | Write release metadata to the site and push `develop` | Site metadata commit |
 
-| Field | Value |
-|-------|-------|
-| Triggers | `push` (any branch) |
-| Jobs | `ci`, `standalone-install-smoke-linux` (matrix), `standalone-install-smoke-windows` (matrix) |
-| Runs on | ubuntu-latest + matrix legs (Debian/Ubuntu/Alpine images for Linux, windows-latest) |
+## Reusable workflows
 
-`ci` runs tests + lint + type-check + repo-lint tests. The smoke matrix exercises `pi install npm:@blackbelt-technology/pi-agent-dashboard` from a clean container/VM.
+| Workflow | Called by | Purpose |
+|---|---|---|
+| `_smoke.yml` | `ci-smoke.yml`, `publish.yml` | Seven-leg standalone installation smoke matrix |
+| `_electron-build.yml` | `ci-electron.yml`, `nightly.yml`, `publish.yml` | Six-leg Electron build matrix |
 
-Smoke jobs verify:
-- npm install resolves cleanly with the freshly-published packages
-- Bridge starts, server bootstraps, `/api/health` responds
-- No platform-specific regressions (Alpine musl, Windows path quirks, etc.)
+## Dependency graph
 
-### `deploy-site.yml` — site deploy
-
-| Field | Value |
-|-------|-------|
-| Triggers | `push` on main, paths: `site/**` |
-| Job | Build + deploy the marketing/docs site |
-
-Lightweight. Only runs if site files changed. Failures here don't block code releases.
-
-## Release flow (publish.yml + helpers)
-
-### `publish.yml` — release orchestrator
-
-| Field | Value |
-|-------|-------|
-| Triggers | `push` of tag `v*` **OR** `workflow_dispatch` with `version` input |
-| Jobs | `prepare` → `publish` → `electron` → `github-release` |
-| Permissions | `contents: write` on prepare; OIDC for publish |
-
-Two entry paths:
-
-1. **Tag push** (`v0.4.1` → workflow). `prepare` resolves the version from the tag, skips bump steps, jumps straight to publish.
-2. **Dispatch** (operator types `0.4.1` in UI). `prepare` bumps every workspace package.json, runs `scripts/sync-versions.js`, regenerates lockfile, promotes `[Unreleased]` in CHANGELOG, commits + tags + pushes.
-
-After `prepare`, both paths converge: publish → electron → github-release.
-
-### `_electron-build.yml` — reusable Electron matrix
-
-| Field | Value |
-|-------|-------|
-| Triggers | `workflow_call` only (never directly) |
-| Jobs | 6-leg matrix: DMG (arm64+x64), AppImage, DEB, Windows ZIP, Windows portable .exe |
-| Consumed by | `publish.yml` (release flow, `source_only_bundle=false`) and `ci-electron.yml` (on-demand, `source_only_bundle=true`) |
-
-**Critical:** does NOT publish to npm or create a GitHub Release. Only produces artifacts via `actions/upload-artifact`. Publishing is the caller's job.
-
-Inputs:
-- `version`: SemVer string set via `npm version` on every workspace
-- `ref`: Git ref to check out
-- `legs`: Matrix subset (`all` / `darwin` / `linux` / `win32` / comma-list like `darwin-arm64,linux-x64`)
-- `source_only_bundle`: If true, `bundle-server.mjs --source-only` skips host-side `npm install` and resolves `@blackbelt-technology/*` from local workspace source. Required for CI dev builds where the dispatched version isn't on npm.
-- `artifact_retention_days`: 14 for CI, 90 for release.
-
-### `sync-release-version.yml` — site cache updater
-
-| Field | Value |
-|-------|-------|
-| Triggers | `release: { types: [published, edited] }` **OR** `workflow_dispatch` |
-| Job | Writes `site/src/data/latest-release.json` with the latest release metadata and commits to develop |
-
-After committing, `deploy-site.yml` picks up the change via its `paths: ["site/**"]` filter and redeploys.
-
-## Manual-dispatch only
-
-### `ci-electron.yml` — on-demand Electron smoke
-
-| Field | Value |
-|-------|-------|
-| Triggers | `workflow_dispatch` only |
-| Inputs | `legs` (matrix subset, default `all`) |
-| Uses | `_electron-build.yml` with `source_only_bundle=true` |
-
-**Purpose** — smoke-test that the full Electron matrix still builds green on a feature branch, WITHOUT publishing or creating a Release.
-
-Use cases:
-- Verify `bundle-server.mjs` / `forge.config.ts` changes without burning a SemVer slot
-- Hand a teammate a one-off installer to reproduce a packaging bug
-- Confirm matrix legs still green before cutting a release
-
-**Safety invariants** (locked by repo-lint tests):
-- No `npm publish`
-- No GitHub Release (drafts, prereleases, or full)
-- No tag push
-- Version slug is a SemVer prerelease ranked **below** the base stable, so an accidental Release publish wouldn't reach electron-updater clients with `allowPrerelease: false`
-
-Re-dispatching on the same branch cancels the prior run. Different branches run in parallel.
-
-## Workflow dependency graph
-
-```
-                  ┌────────────┐
-                  │  push tag  │
-                  │    v*      │
-                  └─────┬──────┘
-                        │
-              ┌─────────┴──────────┐
-              ▼                    ▼
-      ┌──────────────┐   ┌─────────────────┐
-      │  publish.yml │   │ ci.yml (always) │
-      └──────┬───────┘   └─────────────────┘
-             │
-       ┌─────┴──────┐
-       │ prepare    │
-       └─────┬──────┘
-             │
-       ┌─────┴──────┐
-       │ publish    │
-       └─────┬──────┘
-             │
-       ┌─────┴───────────────────┐
-       │ electron                │
-       │ (calls _electron-build) │
-       └─────┬───────────────────┘
-             │
-       ┌─────┴──────────┐
-       │ github-release │
-       └─────┬──────────┘
-             │
-             ▼ (release event)
-   ┌────────────────────────┐
-   │ sync-release-version.yml│
-   └─────┬──────────────────┘
-         │ (commits site/**)
-         ▼
-   ┌─────────────────┐
-   │ deploy-site.yml │
-   └─────────────────┘
+```mermaid
+flowchart LR
+  ci[ci.yml] --> checks[tests + lint + build]
+  deploy[deploy-site.yml] --> pages[GitHub Pages]
+  native[ci-e2e-electron.yml] --> nativeTests[native Electron E2E]
+  ciSmoke[ci-smoke.yml] --> smoke[_smoke.yml]
+  publish[publish.yml] --> smoke
+  ciElectron[ci-electron.yml] --> electron[_electron-build.yml]
+  nightly[nightly.yml] --> electron
+  publish --> electron
+  publish --> release[GitHub Release]
+  release --> sync[sync-release-version.yml]
 ```
 
-## Quick "where is X configured" cheatsheet
+## Safety boundaries
 
-| Question | Workflow |
-|----------|----------|
-| Which Node versions are tested? | `ci.yml` matrix.node-version |
-| Which Linux distros are smoked? | `ci.yml` matrix.image |
-| Which Windows is tested? | `ci.yml` standalone-install-smoke-windows |
-| What npm packages publish? | `publish.yml` publish job (sub-packages first, root last) |
-| Which Electron platforms build? | `_electron-build.yml` matrix (6 legs) |
-| How is the site updated after release? | `sync-release-version.yml` + `deploy-site.yml` |
-| Can I test the Electron matrix without releasing? | `ci-electron.yml` (workflow_dispatch) |
+- `_smoke.yml`, `_electron-build.yml`, `ci-smoke.yml`, `ci-electron.yml`, `ci-e2e-electron.yml`, and `nightly.yml` do not publish to public npm or create a GitHub Release.
+- `publish.yml` is the only public release orchestrator.
+- `deploy-site.yml` and `sync-release-version.yml` mutate only site deployment or release metadata.
+- Current per-file contracts live in `.github/workflows/AGENTS.md`; consult it when a workflow changes.

--- a/.pi/skills/ci-troubleshoot/references/workflow-taxonomy.md.AGENTS.md
+++ b/.pi/skills/ci-troubleshoot/references/workflow-taxonomy.md.AGENTS.md
@@ -1,3 +1,3 @@
 # ci-troubleshoot/references/workflow-taxonomy.md — index
 
-All 6 `.github/workflows/` files: triggers, jobs, permissions, what each cannot do. Covers `ci.yml` push flow, `publish.yml` release flow, `_electron-build.yml` reusable matrix (6 legs), `sync-release-version.yml` site cache, `deploy-site.yml`, `ci-electron.yml` manual-dispatch smoke. Workflow dependency graph + "where is X configured" cheatsheet.
+Current `.github/workflows/` inventory: 8 entry workflows and 2 reusable matrices. Records triggers, purposes, public-release mutation boundaries, and the shared smoke/Electron dependency graph.

--- a/.pi/skills/ci-troubleshoot/references/workflow-taxonomy.md.AGENTS.md
+++ b/.pi/skills/ci-troubleshoot/references/workflow-taxonomy.md.AGENTS.md
@@ -1,3 +1,3 @@
 # ci-troubleshoot/references/workflow-taxonomy.md — index
 
-Current `.github/workflows/` inventory: 8 entry workflows and 2 reusable matrices. Records triggers, purposes, public-release mutation boundaries, and the shared smoke/Electron dependency graph.
+Current `.github/workflows/` inventory: 8 entry workflows and 2 reusable workflows. Records triggers, purposes, public-release mutation boundaries, and the shared smoke/Electron dependency graph.

--- a/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/design.md
+++ b/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/design.md
@@ -51,7 +51,7 @@ Set `plugins.apple-tools.enabled` to `false` through the Dashboard plugin toggle
 
 ### Correct the OpenSpec worktree-recovery skill at its source
 
-Update `packages/openspec-workflow/.pi/skills/fix-worktree-opsx-skills-not-created/SKILL.md`. The repository hook runs `pnpm install && npx --no-install openspec init --tools pi --force`; manual recovery uses `pnpm exec openspec` so the lockfile-selected CLI cannot fall through to a registry fetch. Pin the scoped fallback to `@fission-ai/openspec@1.6.0`. The installed CLI generated six lifecycle skills, so validation must check required names and the CLI's own success output instead of a hard-coded count of eight.
+Update `packages/openspec-workflow/.pi/skills/fix-worktree-opsx-skills-not-created/SKILL.md`. The repository hook and manual recovery use `pnpm exec openspec` so the lockfile-selected CLI cannot fall through to a registry fetch. Pin the scoped fallback to `@fission-ai/openspec@1.6.0`. The installed CLI generated six lifecycle skills, so validation must check required names and the CLI's own success output instead of a hard-coded count of eight.
 
 Update the existing `packages/openspec-workflow/AGENTS.md` row because it repeats the stale command. Validate the skill frontmatter and re-run the smallest recovery checks against this worktree. The installed npm copy remains unchanged; the feature branch carries the canonical source correction for the next package release.
 
@@ -99,13 +99,17 @@ The `ci-troubleshoot` skill points to root `scripts/list-recent-runs.ts` and `sc
 
 Keep CI skill prose consistent with its `pnpm exec tsx` commands and update its workflow overview against `.github/workflows/AGENTS.md`. Make the OpenSpec recovery verification fail closed with strict shell mode and an exact before/after Git status comparison.
 
-Keep this completed change under `openspec/changes/archive/`. The repository ship skill requires archive plus spec-sync evidence before merge; the review request to move it back to the active change root is a false positive.
+Keep this completed change under `openspec/changes/archive/`. The root path prohibition applies only when creating a change; `ship-change` moves completed changes into this archive, so no policy exception is required. The review request to move it back to the active change root is a false positive.
 
 ### Treat project-owner feedback as a push gate
 
 Robert's PR 520 review is the acceptance contract. Restore all five requested diagnostic/documentation groups: recovery controls and no-bypass warning; `_electron-build.yml` input semantics; literal failure-to-fix rows; the post-release site symptom; and KB sidecar pointers plus `kb dox lint`. The repository-wide lint currently has 93 unrelated baseline findings; the verified run reported zero findings against the three restored CI skill pointers. Preserve that residual report rather than widening this PR into a repo-wide DOX cleanup. Also apply his post-merge review: pin the one-virtualizer invariant, restore the stack and `pool:"forks"` blame-rotation diagnostics in the AGENTS row, and clarify the root OpenSpec creation-versus-archive rule.
 
 Apply both valid CodeRabbit findings: use “reusable workflows” consistently; and make worktree recovery reject dirty starting state, capture final status in a checked assignment, and use the local scoped OpenSpec CLI in `.pi/settings.json`. Before any push, require multiple independent cautious reviewers and one synthesis reviewer to map every owner and CodeRabbit item to verified evidence. Do not merge or enable auto-merge.
+
+### One-time post-push branch maintenance after upstream overlap
+
+This is a one-time PR 520 refresh after its initial push, not the merge-based ship workflow. `origin/develop` advanced to `71ea6e59` and GitHub marked the PR dirty. Rebase onto that exact commit rather than merging. Resolve only the three overlapping documentation records. Keep the newer upstream virtualizer drain-scope invariant and lint gate, retain Robert's requested failure signature and bounded-cost guidance, and apply CodeRabbit's standard timer wording. The review found that `runConfigHarness.tsx` lacked its required row in the conflict-resolved test-support index; add that one missing purpose row and rerun the focused documentation gate. Repeat the independent review gate before a force-with-lease push. Leave the normal ship workflow and final PR merge to the project owner; never enable auto-merge.
 
 ### Ship and make future Pi sessions independent of the extension worktree link
 
@@ -154,6 +158,6 @@ A test replacement of the global Dashboard root link with published `@blackbelt-
 21. Force the KB stale-property test's second index and pass its targeted suite.
 22. Drain the TanStack Virtual scroll-reset callback after ChatView tests and pass the client plus full-suite gates.
 23. Correct and validate the CI troubleshooting skill's first-move commands.
-24. Integrate `origin/develop`, pass the full test and build gates, archive the change, open a PR, and merge only after CI and review pass.
+24. For PR 520's one-time post-push refresh only, rebase onto exact current `origin/develop`, pass full test and build gates, and update the open PR. This maintenance does not replace the merge-based ship workflow; leave final merge to the project owner.
 25. Keep the worktree while the Dashboard server link resolves inside it.
 26. If activation fails, restore `KillMode=control-group`, restore the prior package set where safe, and start the Dashboard service.

--- a/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/design.md
+++ b/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/design.md
@@ -101,9 +101,15 @@ Keep CI skill prose consistent with its `pnpm exec tsx` commands and update its 
 
 Keep this completed change under `openspec/changes/archive/`. The repository ship skill requires archive plus spec-sync evidence before merge; the review request to move it back to the active change root is a false positive.
 
+### Treat project-owner feedback as a push gate
+
+Robert's PR 520 review is the acceptance contract. Restore all five requested diagnostic/documentation groups: recovery controls and no-bypass warning; `_electron-build.yml` input semantics; literal failure-to-fix rows; the post-release site symptom; and KB sidecar pointers plus `kb dox lint`. The repository-wide lint currently has 93 unrelated baseline findings; the verified run reported zero findings against the three restored CI skill pointers. Preserve that residual report rather than widening this PR into a repo-wide DOX cleanup. Also apply his post-merge review: pin the one-virtualizer invariant, restore the stack and `pool:"forks"` blame-rotation diagnostics in the AGENTS row, and clarify the root OpenSpec creation-versus-archive rule.
+
+Apply both valid CodeRabbit findings: use “reusable workflows” consistently; and make worktree recovery reject dirty starting state, capture final status in a checked assignment, and use the local scoped OpenSpec CLI in `.pi/settings.json`. Before any push, require multiple independent cautious reviewers and one synthesis reviewer to map every owner and CodeRabbit item to verified evidence. Do not merge or enable auto-merge.
+
 ### Ship and make future Pi sessions independent of the extension worktree link
 
-Open a pull request from the fork branch to upstream `develop`. Run the integrated test and build gates, archive the OpenSpec change, wait for required CI and review, then squash-merge.
+Open or update the pull request from the fork branch to upstream `develop`. Run integrated tests/build and complete review gates. Leave the final merge action to the user or repository owner.
 
 Use Pi package commands to replace the linked `packages/extension` source with `npm:@blackbelt-technology/pi-dashboard-extension@0.7.0`, then pass the bounded fresh Pi startup gate.
 

--- a/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/design.md
+++ b/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/design.md
@@ -95,6 +95,12 @@ Track ChatView mounting through the existing scroll-container layout shim so man
 
 The `ci-troubleshoot` skill points to root `scripts/list-recent-runs.ts` and `scripts/show-failed-run.ts`, but the helpers live under `.pi/skills/ci-troubleshoot/scripts/`. Correct those four paths and run them through the repository-pinned `pnpm exec tsx`. Validate `show-failed-run.ts` against failed run `32286916122` and require its run summary plus failed annotation.
 
+### Apply second-round review hardening
+
+Keep CI skill prose consistent with its `pnpm exec tsx` commands and update its workflow overview against `.github/workflows/AGENTS.md`. Make the OpenSpec recovery verification fail closed with strict shell mode and an exact before/after Git status comparison.
+
+Keep this completed change under `openspec/changes/archive/`. The repository ship skill requires archive plus spec-sync evidence before merge; the review request to move it back to the active change root is a false positive.
+
 ### Ship and make future Pi sessions independent of the extension worktree link
 
 Open a pull request from the fork branch to upstream `develop`. Run the integrated test and build gates, archive the OpenSpec change, wait for required CI and review, then squash-merge.

--- a/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/proposal.md
+++ b/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/proposal.md
@@ -18,6 +18,10 @@ The enabled Subagent Inspector plugin reported `@blackbelt-technology/pi-dashboa
 - Make the KB stale-property test force its second reindex so it does not depend on two writes receiving different filesystem timestamps.
 - Drain TanStack Virtual's 150 ms scroll-reset callback after ChatView tests so it cannot update React after jsdom removes `window` under full-suite load.
 - Correct the CI troubleshooting skill after its deleted helper script blocks failure-log retrieval.
+- Preserve current recovery commands, Electron workflow inputs, literal failure diagnostics, and the post-release site symptom identified by the project owner.
+- Restore KB sidecar pointers, clarify the ChatView virtualizer invariant and diagnostics, and clarify that the root OpenSpec path rule governs change creation while `ship-change` archives completed work.
+- Make worktree recovery fail closed on dirty or unreadable Git status and use the repository-pinned OpenSpec CLI in `.pi/settings.json`.
+- Require a line-by-line owner-feedback audit plus independent cautious reviewers before any further push. Never merge the pull request from this agent session.
 - Ship the repository correction to `develop` through a reviewed pull request.
 - Replace the worktree-linked Pi extension with published `@blackbelt-technology/pi-dashboard-extension@0.7.0` and pass the fresh-start gate. Keep the Dashboard server worktree link because the published root package starts with zero discovered plugins.
 - Do not change application behavior, APIs, manifests, lockfiles, or application source code.
@@ -39,8 +43,8 @@ None. This change repairs one runtime installation and does not change product r
 - Global agent guidance: add the fresh Pi startup gate to `~/.pi/agent/AGENTS.md`.
 - Dashboard config: set `plugins.apple-tools.enabled` to `false`.
 - Runtime Dashboard installation: replace the linked Pi extension source with `npm:@blackbelt-technology/pi-dashboard-extension@0.7.0`. Retain the global Dashboard server worktree link after a published-root test discovered zero plugins.
-- Repository: OpenSpec artifacts; two corrected skills; checkout-independent auto-start seams; deterministic KB reindex and ChatView cleanup test support. Ship them to `develop`; no application source or dependency declaration changes.
-- Validation: `pi list`, package metadata, `GET /api/health`, `GET /api/plugins`, and a bounded fresh Pi process with normal extensions. `pi list` must not contain `npm:pi-hermes-memory` after removal.
+- Repository: OpenSpec artifacts; corrected CI and OpenSpec recovery skills; `.pi/settings.json`; root and KB-tree agent guidance; checkout-independent tests. No application runtime source or dependency declaration changes.
+- Validation: runtime requirement probes, bounded fresh Pi startup, skill validation, `kb dox lint`, repository tests/build, and independent owner-feedback completeness review before push.
 
 ## Discipline Skills
 

--- a/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/tasks.md
+++ b/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/tasks.md
@@ -60,3 +60,18 @@
 - [x] 8.10 Align the CI skill overview and reference taxonomy with the current workflow inventory.
 - [x] 8.11 Make the OpenSpec recovery verification fail closed and prove it preserves Git status.
 - [x] 8.12 Resolve the archive-location review as a false positive using the repository ship gate.
+
+## 9. Address project-owner and final CodeRabbit feedback
+
+- [x] 9.1 Restore release recovery commands and the no-manual-publish warning.
+- [x] 9.2 Restore `_electron-build.yml` input semantics, especially `legs` and `source_only_bundle`.
+- [x] 9.3 Restore literal failure-message-to-fix rows with current job names and the builder-debug drop-step guidance.
+- [x] 9.4 Restore the post-release site update symptom and workflow checks.
+- [x] 9.5 Restore all three KB sidecar pointers, run `kb dox lint`, and prove no lint finding targets those pointers; report unrelated baseline findings separately.
+- [x] 9.6 Use “reusable workflows” consistently in both index records.
+- [x] 9.7 Make worktree recovery reject dirty state, check final status retrieval, and update `.pi/settings.json` to the local scoped OpenSpec CLI.
+- [x] 9.8 Record the single-virtualizer invariant, stack trace, `pool:"forks"` blame rotation, and bounded test cost in the authoritative AGENTS row.
+- [x] 9.9 Clarify the root OpenSpec rule as creation-only; completed changes archive through `ship-change`.
+- [x] 9.10 Persist the global rule that this agent never merges or enables auto-merge, then pass a fresh Pi startup.
+- [x] 9.11 Obtain independent cautious review and synthesis proving every Robert and CodeRabbit item is addressed.
+- [x] 9.12 Push only after task 9.11 passes; leave PR 520 unmerged for the owner.

--- a/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/tasks.md
+++ b/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/tasks.md
@@ -75,3 +75,23 @@
 - [x] 9.10 Persist the global rule that this agent never merges or enables auto-merge, then pass a fresh Pi startup.
 - [x] 9.11 Obtain independent cautious review and synthesis proving every Robert and CodeRabbit item is addressed.
 - [x] 9.12 Push only after task 9.11 passes; leave PR 520 unmerged for the owner.
+
+## 10. Complete one-time post-push PR maintenance outside the ship workflow
+
+- [x] 10.1 Record CodeRabbit's timer-wording finding, exact `origin/develop` commit `71ea6e59`, and the three overlapping documentation records before mutation.
+- [x] 10.2 Rebase onto `origin/develop` without merging.
+- [x] 10.3 Resolve the documentation overlap by keeping the newer upstream drain-scope invariant and lint gate, Robert's requested diagnostics and bounded cost, and CodeRabbit's standard timer wording.
+- [x] 10.4 Run targeted documentation, convention, full test, and build validation.
+- [x] 10.5 Run the independent cautious review and record its missing `runConfigHarness.tsx` purpose-row finding.
+- [x] 10.6 Add the missing purpose row and rerun focused documentation validation.
+- [x] 10.7 Obtain a final focused reviewer and synthesis verdict for the exact amendment.
+- [x] 10.8 Force-push with lease only after task 10.7 passes; leave PR 520 unmerged for the owner. This one-time maintenance does not replace the merge-based ship workflow.
+
+## 11. Address the post-rebase CodeRabbit review
+
+- [x] 11.1 Triage all three findings: reject the archive-location false positive; accept the one-time-maintenance clarification and standard “test ID” wording.
+- [x] 11.2 Clarify archive policy and separate the one-time PR refresh from the merge-based ship workflow.
+- [x] 11.3 Replace “testid” with “test ID” in the virtualizer sidecar without changing behavior.
+- [x] 11.4 Run focused documentation and convention validation.
+- [x] 11.5 Obtain final independent review and synthesis before another push.
+- [x] 11.6 Force-push with lease only after task 11.5 passes; leave PR 520 unmerged for the owner.

--- a/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/tasks.md
+++ b/openspec/changes/archive/2026-08-20-restore-dashboard-subagents-dependency/tasks.md
@@ -57,3 +57,6 @@
 - [x] 8.7 Pass fresh review, validate archive readiness, and hand the completed change to the repository ship pipeline.
 - [x] 8.8 Track ChatView mounting across manual unmounts and retain the scoped 160 ms cleanup drain.
 - [x] 8.9 Replace unpinned skill commands with repository-local `pnpm exec` calls and pin the registry fallback.
+- [x] 8.10 Align the CI skill overview and reference taxonomy with the current workflow inventory.
+- [x] 8.11 Make the OpenSpec recovery verification fail closed and prove it preserves Git status.
+- [x] 8.12 Resolve the archive-location review as a false positive using the repository ship gate.

--- a/packages/client/src/test-support/AGENTS.md
+++ b/packages/client/src/test-support/AGENTS.md
@@ -4,4 +4,4 @@ Files in this directory. One row per source file.
 
 | File | Purpose |
 |------|---------|
-| `virtualizer-jsdom.ts` | Vitest `setupFiles` shim (wired in `packages/client/vitest.config.ts`). → see `virtualizer-jsdom.ts.AGENTS.md` |
+| `virtualizer-jsdom.ts` | Vitest `setupFiles` layout shim + scoped 160 ms TanStack callback drain. Enforced call-site invariant and flake triage → see `virtualizer-jsdom.ts.AGENTS.md` |

--- a/packages/client/src/test-support/AGENTS.md
+++ b/packages/client/src/test-support/AGENTS.md
@@ -4,4 +4,5 @@ Files in this directory. One row per source file.
 
 | File | Purpose |
 |------|---------|
+| `runConfigHarness.tsx` | `ModelConfigProvider` test harness. Exports `makeModels`, `makeRunConfig`, `RunConfigHarness`. See change: openspec-dialog-model-effort-selector. |
 | `virtualizer-jsdom.ts` | Vitest `setupFiles` layout shim + scoped 160 ms TanStack callback drain. Enforced call-site invariant and flake triage → see `virtualizer-jsdom.ts.AGENTS.md` |

--- a/packages/client/src/test-support/virtualizer-jsdom.ts.AGENTS.md
+++ b/packages/client/src/test-support/virtualizer-jsdom.ts.AGENTS.md
@@ -21,7 +21,7 @@ Same class, earlier cause: React concurrent scheduler flushing after fork teardo
 
 ## Drain scope invariant
 
-`DRAINED_TESTIDS` in the shim lists the drained scroll containers. List MUST cover every `useVirtualizer` call site in `packages/client/src`. At this change, `ChatView.tsx` is the only production call site. A site rendering another testid leaves its own callback scheduled — drain skips it, flake returns, no failing test points at it.
+`DRAINED_TESTIDS` in the shim lists the drained scroll containers. List MUST cover every `useVirtualizer` call site in `packages/client/src`. At this change, `ChatView.tsx` is the only production call site. A site rendering another test ID leaves its own callback scheduled — drain skips it, flake returns, no failing test points at it.
 
 Enforced by `packages/shared/src/__tests__/virtualizer-drain-scope.test.ts`. If another virtualized list is added, widen `DRAINED_TESTIDS` + the drain predicate in the same change; do not just bump the lint's expected list.
 

--- a/packages/client/src/test-support/virtualizer-jsdom.ts.AGENTS.md
+++ b/packages/client/src/test-support/virtualizer-jsdom.ts.AGENTS.md
@@ -1,6 +1,6 @@
 # virtualizer-jsdom.ts — index
 
-Vitest `setupFiles` shim (wired in `packages/client/vitest.config.ts`). jsdom lacks layout + `ResizeObserver`, so TanStack Virtual reads `offsetHeight`=0 and renders ZERO rows. Provides no-op `ResizeObserver` + reports tall `offsetHeight`/wide `offsetWidth` for ONLY the ChatView scroll container (`data-testid="chat-scroll-container"`), so ALL windowed rows mount for per-row content assertions (rows still measure 0). Global RTL `cleanup()` unmounts every tree. The layout shim records any ChatView scroller access, including a later manual unmount. Real-timer ChatView tests then wait 160 ms for TanStack Virtual's 150 ms scroll-reset callback; fake-timer and non-ChatView tests skip the wait. This prevents the callback from reaching React after jsdom removes `window`, which otherwise exits the run on `Errors 1` after all assertions pass. NOT a global `setTimeout` wrapper cancelling pending ids: that also intercepts `user-event`'s scheduling and broke the clipboard-fallback spec. See change: fix-tmux-session-shutdown-leak. `configure({ asyncUtilTimeout: 5_000 })` raises `waitFor`/`findBy*` poll ceiling under parallel-suite CPU oversubscription. Scroll/windowing BEHAVIOUR is Playwright-gated, not asserted here. See change: virtualize-chat-transcript-tanstack.
+Vitest `setupFiles` shim (wired in `packages/client/vitest.config.ts`). jsdom lacks layout + `ResizeObserver`, so TanStack Virtual reads `offsetHeight`=0 and renders ZERO rows. Provides no-op `ResizeObserver` + reports tall `offsetHeight`/wide `offsetWidth` for ONLY the ChatView scroll container (`data-testid="chat-scroll-container"`), so ALL windowed rows mount for per-row content assertions (rows still measure 0). Global RTL `cleanup()` unmounts every tree. The layout shim records any ChatView scroller access, including a later manual unmount. ChatView tests that use real timers then wait 160 ms for TanStack Virtual's 150 ms scroll-reset callback; tests that use fake timers and non-ChatView tests skip the wait. This prevents the callback from reaching React after jsdom removes `window`, which otherwise exits the run on `Errors 1` after all assertions pass. NOT a global `setTimeout` wrapper cancelling pending ids: that also intercepts `user-event`'s scheduling and broke the clipboard-fallback spec. See change: fix-tmux-session-shutdown-leak. `configure({ asyncUtilTimeout: 5_000 })` raises `waitFor`/`findBy*` poll ceiling under parallel-suite CPU oversubscription. Scroll/windowing BEHAVIOUR is Playwright-gated, not asserted here. See change: virtualize-chat-transcript-tanstack.
 
 ## Triage — leaked-callback flake
 
@@ -21,8 +21,12 @@ Same class, earlier cause: React concurrent scheduler flushing after fork teardo
 
 ## Drain scope invariant
 
-`DRAINED_TESTIDS` in the shim lists the drained scroll containers. List MUST cover every `useVirtualizer` call site in `packages/client/src`. A site rendering another testid leaves its own callback scheduled — drain skips it, flake returns, no failing test points at it.
+`DRAINED_TESTIDS` in the shim lists the drained scroll containers. List MUST cover every `useVirtualizer` call site in `packages/client/src`. At this change, `ChatView.tsx` is the only production call site. A site rendering another testid leaves its own callback scheduled — drain skips it, flake returns, no failing test points at it.
 
-Enforced by `packages/shared/src/__tests__/virtualizer-drain-scope.test.ts`. Lint fails on a new call site. Widen `DRAINED_TESTIDS` + the drain predicate; do not just bump the lint's expected list.
+Enforced by `packages/shared/src/__tests__/virtualizer-drain-scope.test.ts`. If another virtualized list is added, widen `DRAINED_TESTIDS` + the drain predicate in the same change; do not just bump the lint's expected list.
+
+## Cost and scope
+
+The 160 ms wait is a bounded but real wall-clock cost for each matching ChatView `afterEach`. Unrelated client tests skip it. Scroll and windowing behavior remain Playwright concerns; this shim supports rendered-output assertions only.
 
 `noteScrollerAccess` named for effect — answers layout question AND arms the drain. Getter access is the only available hook. Pure predicate is `isDrainedScroller`.

--- a/packages/openspec-workflow/.pi/skills/fix-worktree-opsx-skills-not-created/SKILL.md
+++ b/packages/openspec-workflow/.pi/skills/fix-worktree-opsx-skills-not-created/SKILL.md
@@ -11,7 +11,7 @@ Use when a git worktree lacks the OpenSpec lifecycle skills (`.pi/skills/openspe
 ## Procedure
 1. Confirm the skills are generated, not committed. `.pi/.gitignore` contains `skills/openspec-*/**`; each fresh worktree must run `openspec init`.
 2. Confirm the repository declares `@fission-ai/openspec` and identify its package-manager install command. The unscoped npm package `openspec` is a `0.0.0` stub.
-3. Install repository dependencies before initialization. For this repository, run `pnpm install --frozen-lockfile`.
+3. Require a clean `git status --porcelain=v1`, then install repository dependencies. For this repository, run `pnpm install --frozen-lockfile`.
 4. Use the repository-pinned binary when it exists:
    ```bash
    pnpm exec openspec init --tools pi --force
@@ -35,13 +35,18 @@ Bare `npx openspec init ...` can fetch `openspec@0.0.0` when `node_modules/.bin/
 ```bash
 set -euo pipefail
 before_status="$(git status --porcelain=v1)"
+if [ -n "$before_status" ]; then
+  printf '%s\n' "Refusing recovery in a dirty worktree" >&2
+  exit 1
+fi
 pnpm install --frozen-lockfile
 pnpm exec openspec --version
 pnpm exec openspec init --tools pi --force
 for skill in openspec-explore openspec-propose openspec-apply-change openspec-update-change openspec-archive-change; do
   test -d ".pi/skills/$skill" || exit 1
 done
-test "$(git status --porcelain=v1)" = "$before_status"
+after_status="$(git status --porcelain=v1)"
+test -z "$after_status"
 ```
 
-Completion requires setup success, every named directory, and no unexplained tracked change.
+Completion requires setup success, every named directory, and empty Git status before and after recovery.

--- a/packages/openspec-workflow/.pi/skills/fix-worktree-opsx-skills-not-created/SKILL.md
+++ b/packages/openspec-workflow/.pi/skills/fix-worktree-opsx-skills-not-created/SKILL.md
@@ -33,13 +33,15 @@ Bare `npx openspec init ...` can fetch `openspec@0.0.0` when `node_modules/.bin/
 ## Verification
 
 ```bash
+set -euo pipefail
+before_status="$(git status --porcelain=v1)"
 pnpm install --frozen-lockfile
 pnpm exec openspec --version
 pnpm exec openspec init --tools pi --force
 for skill in openspec-explore openspec-propose openspec-apply-change openspec-update-change openspec-archive-change; do
   test -d ".pi/skills/$skill" || exit 1
 done
-git status --short
+test "$(git status --porcelain=v1)" = "$before_status"
 ```
 
 Completion requires setup success, every named directory, and no unexplained tracked change.


### PR DESCRIPTION
## Summary

Follow-up to #519 after its automatic merge occurred before the final review round completed.

- align the CI troubleshooting skill and references with the current 10 workflow files
- use repository-local `pnpm exec tsx` for CI helper scripts
- make OpenSpec recovery verification fail closed and pin the only registry fallback
- retain the completed OpenSpec change under `archive/` as required by the ship gate

## Validation

- merged current `origin/develop`, including #518 and #519
- merge conflicts resolved by keeping the reviewed follow-up skill and archive content
- `npm run lint`: passed
- full unit suite: 14,786 passed; 40 skipped; 0 failed
- `npm run build`: passed
- skill frontmatter: 68 checked, no errors or warnings
- OpenSpec recovery command preserved Git status before and after initialization
- CI troubleshooting helper returned the expected annotation for run 32286916122

## Scope

Documentation, Agent Skills, and archived OpenSpec evidence only. No runtime or application behavior changes.
