### PR TITLE
fix(pi-settings): make the kb-extension package source portable (#371)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,15 @@ jobs:
       # See change: fix-skill-discovery-parity.
       - name: Skill frontmatter guard
         run: node scripts/check-skill-frontmatter.mjs
+      # Portability gate on committed `.pi/settings.json`. `pi install <path>`
+      # and `pi config` both WRITE the resolved absolute path, so the
+      # machine-specific form is the tooling's default output, not a typo. The
+      # repo shipped `/Users/robson/...` long enough that kb-extension silently
+      # failed to load for every other developer. A relative source resolves
+      # against the settings file's own directory, so `".."` is the repo root
+      # everywhere. See issue #371.
+      - name: No machine-specific paths in .pi/settings.json
+        run: node scripts/check-pi-settings-paths.mjs
       # Publish-correctness gate. Stricter than Biome's noUndeclaredDependencies:
       # it derives each workspace's shipped file set from `npm pack --dry-run`
       # and refuses a devDependency as justification for a shipped import,

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "source": "/Users/robson/Project/pi-agent-dashboard",
+      "source": "..",
       "extensions": [
         "+packages/kb-extension/src/index.ts"
       ]

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -5,6 +5,7 @@ Files in this directory. One row per file. Non-source area (migrated from `docs/
 | File | Purpose |
 |------|---------|
 | `__tests__/assert-bundled-plugins-complete.test.mjs` | Vitest unit tests for packages/electron/scripts/assert-bundled-plugins-complete.mjs (subprocess-driven with… → see `__tests__/assert-bundled-plugins-complete.test.mjs.AGENTS.md` |
+| `__tests__/check-pi-settings-paths.test.mjs` | Drives `absoluteSourceViolations` directly (12 cases) so detection is pinned independently of what `.pi/settings.json` currently holds. Negative cases carry the weight: `npm:`/`git:`/`https://`/`ssh://` sources and the bare-string package form must NOT be flagged, else the guard is unusable. See issue #371. |
 | `__tests__/biome-undeclared-dependencies.test.mjs` | Guardrails for the `noUndeclaredDependencies` config in `biome.json`. → see `__tests__/biome-undeclared-dependencies.test.mjs.AGENTS.md` |
 | `__tests__/dependency-declarations.test.mjs` | Set-based manifest guarantees over ALL 32 non-private workspaces (not a sample). → see `__tests__/dependency-declarations.test.mjs.AGENTS.md` |
 | `__tests__/fixtures/mutation-journal-child.mjs` | Child-process fixture for the mutation-journal crash-safety tests. → see `__tests__/fixtures/mutation-journal-child.mjs.AGENTS.md` |
@@ -31,6 +32,7 @@ Files in this directory. One row per file. Non-source area (migrated from `docs/
 | `__tests__/verify-published-imports.test.mjs` | Tests for `verify-published-imports.mjs`. Fixtures built in `mkdtemp` OUTSIDE the repo and the checker driven… → see `__tests__/verify-published-imports.test.mjs.AGENTS.md` |
 | `check-conventions.mjs` | Deterministic half of the ship gate, run by `ship-it` step 4.4. → see `check-conventions.mjs.AGENTS.md` |
 | `check-e2e-fixture-import.mjs` | Guard: every `tests/e2e/*.spec.ts` MUST import `test` from `./fixtures.js`, never `@playwright/test` directly… → see `check-e2e-fixture-import.mjs.AGENTS.md` |
+| `check-pi-settings-paths.mjs` | Guard, run by ci.yml: no machine-specific absolute path in a committed `.pi/settings.json` `packages[].source`. Exports `absoluteSourceViolations(file, raw)`, `CHECKED_FILES`, `CORRECTION`, `REPO_ROOT`. Flags POSIX `/x`, Windows `C:\x`/UNC, and `~/x`; leaves `npm:`/`git:`/`https://`/`ssh://` specifiers alone; unparseable JSON fails closed. Needed because `pi install <path>` and `pi config` WRITE the absolute form, so a one-time correction regresses. See issue #371. |
 | `check-skill-frontmatter.mjs` | Skill frontmatter guard, run by ci.yml. Exit non-zero iff >=1 error; warnings never fail. → see `check-skill-frontmatter.mjs.AGENTS.md` |
 | `commit-windows-parity.sh` | Stages and commits fix-windows-server-parity + consolidate-platform-handlers work in 5 logical chunks (fix:,… → see `commit-windows-parity.sh.AGENTS.md` |
 | `dox-byte-gate.mjs` | AGENTS.md byte-cap gate for `ship-it` step 4.4. Filters `kb dox lint --json` to `kind:"over-threshold"` +… → see `dox-byte-gate.mjs.AGENTS.md` |

--- a/scripts/__tests__/check-pi-settings-paths.test.mjs
+++ b/scripts/__tests__/check-pi-settings-paths.test.mjs
@@ -1,0 +1,70 @@
+/**
+ * Guard against machine-specific absolute paths in `.pi/settings.json` (#371).
+ *
+ * Style mirrors `scripts/__tests__/check-conventions.test.mjs` — drive the
+ * exported rule fn directly rather than shelling out, so each case is pinned
+ * independently of what happens to be checked into `.pi/settings.json`.
+ *
+ * The negative cases carry the weight. `source` also legally holds `npm:`,
+ * `git:`, `https://` and `ssh://` specifiers, none of which are filesystem
+ * paths — a naive "does not start with ." rule would reject every one of them
+ * and make the guard unusable.
+ */
+import { describe, expect, it } from "vitest";
+
+import { absoluteSourceViolations } from "../check-pi-settings-paths.mjs";
+
+const at = (packages) => JSON.stringify({ packages });
+
+describe("absolute local sources are rejected (#371)", () => {
+  it("flags a POSIX absolute path", () => {
+    const v = absoluteSourceViolations(".pi/settings.json", at([{ source: "/Users/robson/Project/x" }]));
+    expect(v).toHaveLength(1);
+    expect(v[0].source).toBe("/Users/robson/Project/x");
+    expect(v[0].file).toBe(".pi/settings.json");
+  });
+
+  it("flags a Windows absolute path", () => {
+    expect(absoluteSourceViolations("p", at([{ source: "C:\\Users\\dev\\repo" }]))).toHaveLength(1);
+  });
+
+  it("flags a home-relative path, which is just as machine-specific", () => {
+    expect(absoluteSourceViolations("p", at([{ source: "~/Project/x" }]))).toHaveLength(1);
+  });
+
+  it("reports every offending entry, not just the first", () => {
+    const v = absoluteSourceViolations("p", at([{ source: "/a" }, { source: ".." }, { source: "/b" }]));
+    expect(v.map((x) => x.source)).toEqual(["/a", "/b"]);
+  });
+});
+
+describe("legal sources are left alone", () => {
+  it("accepts the relative form this repo uses", () => {
+    expect(absoluteSourceViolations("p", at([{ source: ".." }]))).toEqual([]);
+  });
+
+  it.each([
+    "npm:@blackbelt-technology/pi-dashboard-shared",
+    "git:git@github.com:user/repo@v1.0.0",
+    "https://github.com/BlackBeltTechnology/pi-anthropic-messages.git",
+    "ssh://git@github.com/user/repo",
+  ])("accepts the non-path specifier %s", (source) => {
+    expect(absoluteSourceViolations("p", at([{ source }]))).toEqual([]);
+  });
+
+  it("accepts the bare-string package form", () => {
+    expect(absoluteSourceViolations("p", at(["npm:simple-pkg"]))).toEqual([]);
+  });
+
+  it("ignores settings with no packages at all", () => {
+    expect(absoluteSourceViolations("p", JSON.stringify({ skills: [] }))).toEqual([]);
+  });
+});
+
+describe("malformed input fails closed", () => {
+  it("reports unparseable JSON instead of silently passing", () => {
+    const v = absoluteSourceViolations("p", "{ not json");
+    expect(v).toHaveLength(1);
+    expect(v[0].reason).toMatch(/parse/i);
+  });
+});

--- a/scripts/check-pi-settings-paths.mjs
+++ b/scripts/check-pi-settings-paths.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Guard: no machine-specific absolute path may appear in a `packages[].source`
+ * of a committed `.pi/settings.json`.
+ *
+ * Why a guard and not a convention: the absolute path this fixes was not a
+ * typo. `pi install <path>` RESOLVES a local source to an absolute path before
+ * writing it (package identity for local sources is "resolved absolute path"),
+ * and `pi config` rewrites the same file. So the machine-specific form is what
+ * the tooling produces by default, and a one-time correction regresses the
+ * next time anyone runs either command. The repo carried
+ * `/Users/robson/Project/pi-agent-dashboard` long enough for kb-extension to
+ * silently not load for every other developer (#371).
+ *
+ * Relative sources resolve against the directory of the settings file they
+ * appear in, so `".."` from `.pi/settings.json` is the repo root — portable
+ * for everyone.
+ *
+ * `source` also legally carries non-path specifiers (`npm:`, `git:`, `https://`,
+ * `ssh://`); those are never filesystem paths and are left alone.
+ *
+ * Emits structured findings; exits 1 when any violation exists.
+ * Run: node scripts/check-pi-settings-paths.mjs
+ *
+ * See issue #371.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Settings files this repo commits. Absolute paths are only a problem in ones we ship. */
+export const CHECKED_FILES = [".pi/settings.json"];
+
+/** The one-line correction printed on every violation. */
+export const CORRECTION = '"source": ".."  (relative to the .pi/ directory holding settings.json)';
+
+const NON_PATH_SPECIFIER = /^(?:npm:|git:|https?:\/\/|ssh:\/\/|github:)/i;
+
+/** POSIX (`/x`), Windows (`C:\x`, `\\server\share`) and home-relative (`~/x`). */
+function isMachineSpecific(source) {
+  if (NON_PATH_SPECIFIER.test(source)) return false;
+  return source.startsWith("/") || source.startsWith("~") || /^[A-Za-z]:[\\/]/.test(source) || source.startsWith("\\\\");
+}
+
+/**
+ * Findings for one settings file's raw JSON text.
+ * Returns `[{ file, source, reason }]`; empty when clean.
+ */
+export function absoluteSourceViolations(file, raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return [{ file, source: null, reason: `could not parse JSON: ${err.message}` }];
+  }
+
+  const packages = Array.isArray(parsed?.packages) ? parsed.packages : [];
+  const violations = [];
+
+  for (const entry of packages) {
+    // The bare-string form is a specifier, not an object with a `source`.
+    const source = typeof entry === "string" ? entry : entry?.source;
+    if (typeof source !== "string") continue;
+    if (isMachineSpecific(source)) {
+      violations.push({ file, source, reason: "machine-specific absolute path" });
+    }
+  }
+
+  return violations;
+}
+
+function main() {
+  const violations = [];
+
+  for (const rel of CHECKED_FILES) {
+    let raw;
+    try {
+      raw = readFileSync(resolve(REPO_ROOT, rel), "utf-8");
+    } catch {
+      continue; // not every checkout has every settings file
+    }
+    violations.push(...absoluteSourceViolations(rel, raw));
+  }
+
+  if (violations.length === 0) {
+    console.log("check-pi-settings-paths: OK");
+    return 0;
+  }
+
+  for (const v of violations) {
+    const what = v.source ? `${v.source} — ${v.reason}` : v.reason;
+    console.error(`error: ${v.file}: ${what}`);
+  }
+  console.error(`\nUse a path relative to the settings file instead:\n  ${CORRECTION}`);
+  console.error(
+    "\nNote: `pi install <path>` and `pi config` write the ABSOLUTE form. After running either,\n" +
+      "re-check this file before committing.",
+  );
+  return 1;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  process.exit(main());
+}


### PR DESCRIPTION
Closes #371.

## The bug

`.pi/settings.json` pinned the package `source` to an absolute path in one developer's home directory:

```json
{ "packages": [ { "source": "/Users/robson/Project/pi-agent-dashboard",
                  "extensions": ["+packages/kb-extension/src/index.ts"] } ] }
```

On any other machine that path does not resolve, so the `+path` filter never matches and **kb-extension — the only extension this project enables — silently does not activate**. No error, no warning; it simply isn't there.

## Fix

`"source": ".."`. Relative sources resolve against the directory of the settings file they appear in, so `..` from `.pi/settings.json` is the repo root on every machine.

Verified rather than assumed:

- **In an isolated fixture** (live settings untouched): `".."` resolves to the project root, and a deliberately wrong `"../.."` does not. This settles the ambiguity in "resolved against the settings file" — the base is the settings file's own directory, not the project root.
- **In the real tree**: `pi list` reports the project package resolving to the same absolute path before and after the change, still `(filtered)` by the `+path` entry.

## The guard (the issue's "Additional note")

The absolute path was **not a typo**, which is why a one-time correction is not enough: `pi install <path>` resolves a local source to an absolute path *before writing it* (local package identity IS the resolved absolute path), and `pi config` rewrites the same file. The machine-specific form is the tooling's default output, so it regresses the next time anyone runs either command.

`scripts/check-pi-settings-paths.mjs`, wired into `ci.yml` beside the other repo guards:

- flags POSIX `/x`, Windows `C:\x` and UNC `\\server\share`, and home-relative `~/x`;
- leaves `npm:`, `git:`, `https://`, `ssh://` specifiers alone — they are not filesystem paths, and a naive "must start with `.`" rule would reject every one of them and make the guard unusable;
- an unparseable settings file **fails closed** rather than passing silently;
- prints the correction plus the reason it regresses (`pi install` / `pi config` write the absolute form).

## Tests

`scripts/__tests__/check-pi-settings-paths.test.mjs` — 12 cases driving `absoluteSourceViolations` directly, so detection is pinned independently of whatever `.pi/settings.json` currently holds. The negative cases (npm/git/https/ssh specifiers, the bare-string package form, settings with no `packages` at all) carry the weight.

Non-vacuity checked: run against the **unfixed** file the guard exits 1 and names the offending path; against the fixed file it exits 0.
