### PR TITLE
feat(restore-greeting-chat-continuity): chronological greeting chat history

### DIFF
--- a/openspec/changes/restore-greeting-chat-continuity/tasks.md
+++ b/openspec/changes/restore-greeting-chat-continuity/tasks.md
@@ -2,24 +2,24 @@
 
 ## 1. Reproduce (TDD — rewrite the tests that lock the singleton contract)
 
-- [ ] 1.1 In `packages/shared/src/__tests__/state-replay-custom-message.test.ts`, rewrite
+- [x] 1.1 In `packages/shared/src/__tests__/state-replay-custom-message.test.ts`, rewrite
   T1 ("three historical greetings replay as exactly one latest greeting") to assert all
   three greetings replay as three `message_start` + `message_end` pairs in order (content
   A, B, C), each carrying its own greeting entry's `entryId`. Verify it FAILS against the
   current singleton replay.
-- [ ] 1.2 Adapt the T2 / T2b greeting-slot cases in the same file: greetings now emit
+- [x] 1.2 Adapt the T2 / T2b greeting-slot cases in the same file: greetings now emit
   inline in JSONL order interleaved with the `x-note` entry (not collapsed to one at the
   first slot). Assert the interleaved order and that the `x-note` pair is unchanged.
-- [ ] 1.3 In `packages/client/src/lib/chat/__tests__/event-reducer.custom-display-message.test.ts`,
+- [x] 1.3 In `packages/client/src/lib/chat/__tests__/event-reducer.custom-display-message.test.ts`,
   rewrite the "ib-greeting singleton replacement" describe block (including the
   harden-greeting-collapse-latest T7/T8/T9 cases) to assert each greeting appends its OWN
   row with a per-entry id, in order. Verify it FAILS against the current stable-id
   collapse.
-- [ ] 1.4 Add an explicit re-replay test to the reducer suite: deliver a set of greetings,
+- [x] 1.4 Add an explicit re-replay test to the reducer suite: deliver a set of greetings,
   then re-deliver the SAME greetings (same entry ids); assert the greeting row count is
   unchanged (no duplicate rows). Add a late-duplicate case: a duplicate of an
   already-shown greeting arriving after a newer one adds no third row.
-- [ ] 1.5 Add a failing-first ORDERING test for the reset-rebuild path: reduce a live
+- [x] 1.5 Add a failing-first ORDERING test for the reset-rebuild path: reduce a live
   greeting `g3` (highest `seq`, content C) into state, then feed a full re-replay batch
   (first `seq` `<= maxSeq`) carrying `g1`, `g2`, `g3` (contents A, B, C) in ascending
   `seq` through the reset-and-rebuild path (`createInitialState()` then re-reduce in
@@ -29,18 +29,18 @@
 
 ## 2. Fix replay (`packages/shared/src/state-replay.ts`)
 
-- [ ] 2.1 Remove the `latestGreeting` / `greetingSlot` singleton trackers and the
+- [x] 2.1 Remove the `latestGreeting` / `greetingSlot` singleton trackers and the
   post-loop splice that emits only the latest greeting at the first slot.
-- [ ] 2.2 In the `type:"custom_message"` + `display` branch, emit the `ib-greeting`
+- [x] 2.2 In the `type:"custom_message"` + `display` branch, emit the `ib-greeting`
   pair INLINE at the entry's position — matching the non-greeting custom path — keeping the
   `ib-greeting` literal as the (now behaviour-equivalent) discriminator. Do NOT genericize
   the branch away or remove the literal.
 
 ## 3. Fix reducer (`packages/client/src/lib/chat/event-reducer.ts`)
 
-- [ ] 3.1 In the `message_end` custom branch, remove the stable `custom-ib-greeting` id and
+- [x] 3.1 In the `message_end` custom branch, remove the stable `custom-ib-greeting` id and
   the timestamp monotonicity guard.
-- [ ] 3.2 Have the `ib-greeting` branch derive a per-entry id and append via the existing
+- [x] 3.2 Have the `ib-greeting` branch derive a per-entry id and append via the existing
   `findLastIndex(id)` replace-in-place path — the same idempotent dedup non-greeting
   customs use — so a re-replayed/late duplicate of the same greeting entry updates its row
   in place instead of adding a second. Keep the `ib-greeting` literal / branch present per
@@ -48,10 +48,10 @@
 
 ## 4. Verify
 
-- [ ] 4.1 The rewritten tests from step 1 all pass.
-- [ ] 4.2 Confirm the UNTOUCHED cases still pass with unchanged intent: state-replay T2
+- [x] 4.1 The rewritten tests from step 1 all pass.
+- [x] 4.2 Confirm the UNTOUCHED cases still pass with unchanged intent: state-replay T2
   (unrelated custom messages) / T3 (no greeting), and reducer T1–T4 (generic custom
   display-message rendering) + the unrelated-custom and hidden-greeting greeting cases.
 - [ ] 4.3 `npm test` (zero-network) green.
-- [ ] 4.4 `npm run build` succeeds.
-- [ ] 4.5 `openspec validate restore-greeting-chat-continuity --strict` passes.
+- [x] 4.4 `npm run build` succeeds.
+- [x] 4.5 `openspec validate restore-greeting-chat-continuity --strict` passes.

--- a/packages/client/src/lib/chat/__tests__/event-reducer.custom-display-message.test.ts
+++ b/packages/client/src/lib/chat/__tests__/event-reducer.custom-display-message.test.ts
@@ -103,32 +103,27 @@ describe("custom display-message rendering", () => {
   });
 });
 
-describe("ib-greeting singleton replacement (change: replace-replayed-greeting)", () => {
-  it("T4: a newer greeting replaces the prior greeting in place", () => {
+describe("ib-greeting chronological chat history", () => {
+  it("T4: multiple greetings append as separate rows with per-entry ids", () => {
     let s = createInitialState();
-    s = reduceEvent(s, greetingEnd("A", true, "g1"));
-    expect(s.messages).toHaveLength(1);
-    expect(s.messages[0].id).toBe("custom-ib-greeting");
-    expect(s.messages[0].content).toBe("A");
-
-    s = reduceEvent(s, greetingEnd("B", true, "g2"));
-    expect(s.messages).toHaveLength(1); // replaced, not appended
-    expect(s.messages[0].id).toBe("custom-ib-greeting");
-    expect(s.messages[0].content).toBe("B");
-    expect(s.messages[0].entryId).toBe("g2");
+    s = reduceEvent(s, greetingEnd("A", true, "g1", 1000));
+    s = reduceEvent(s, greetingEnd("B", true, "g2", 2000));
+    s = reduceEvent(s, greetingEnd("C", true, "g3", 3000));
+    expect(s.messages.map((m) => ({ id: m.id, content: m.content, entryId: m.entryId }))).toEqual([
+      { id: "custom-g1", content: "A", entryId: "g1" },
+      { id: "custom-g2", content: "B", entryId: "g2" },
+      { id: "custom-g3", content: "C", entryId: "g3" },
+    ]);
   });
 
-  it("T5: unrelated custom messages are not collapsed", () => {
+  it("T5: unrelated custom messages remain separate from greetings", () => {
     let s = createInitialState();
     s = reduceEvent(s, greetingEnd("A", true, "g1"));
     s = reduceEvent(s, customEnd("note-one", true, "c1"));
     s = reduceEvent(s, greetingEnd("B", true, "g2"));
-    // One greeting row (latest) + one separate x-note row.
-    expect(s.messages).toHaveLength(2);
-    const greeting = s.messages.find((m) => m.id === "custom-ib-greeting");
-    const note = s.messages.find((m) => m.id === "custom-c1");
-    expect(greeting?.content).toBe("B");
-    expect(note?.content).toBe("note-one");
+    expect(s.messages).toHaveLength(3);
+    expect(s.messages.map((m) => m.id)).toEqual(["custom-g1", "custom-c1", "custom-g2"]);
+    expect(s.messages.find((m) => m.id === "custom-c1")?.content).toBe("note-one");
   });
 
   it("T6: a hidden greeting produces no row", () => {
@@ -137,40 +132,35 @@ describe("ib-greeting singleton replacement (change: replace-replayed-greeting)"
     expect(s.messages).toHaveLength(0);
   });
 
-  // Change: harden-greeting-collapse-latest. The rendered greeting must always
-  // be the NEWEST regardless of event ARRIVAL order. A live/replay race delivers
-  // events out of timestamp order: the newest greeting (live) can land BEFORE a
-  // stale replay snapshot whose latest greeting is one state behind. Without a
-  // monotonicity guard the stable-id collapse blindly replaces in place, so the
-  // stale replay clobbers the newer live greeting and the head shows one behind.
-  it("T7: a stale (older-ts) greeting arriving AFTER a newer one does NOT overwrite it", () => {
+  it("T7: re-replaying the same greetings does not duplicate rows", () => {
     let s = createInitialState();
-    // Newest greeting arrives first (live tick), ts=2000.
-    s = reduceEvent(s, greetingEnd("B", true, "g2", 2000));
-    expect(s.messages[0].content).toBe("B");
-    // Stale replay snapshot (taken before B persisted) arrives late, ts=1000.
-    s = reduceEvent(s, greetingEnd("A", true, "g1", 1000));
-    expect(s.messages).toHaveLength(1);
-    expect(s.messages[0].id).toBe("custom-ib-greeting");
-    // NEWEST wins: content stays B, not the stale A.
-    expect(s.messages[0].content).toBe("B");
-    expect(s.messages[0].entryId).toBe("g2");
+    const greetings = [greetingEnd("A", true, "g1", 1000), greetingEnd("B", true, "g2", 2000)];
+    for (const event of greetings) s = reduceEvent(s, event);
+    for (const event of greetings) s = reduceEvent(s, event);
+    expect(s.messages.map((m) => m.content)).toEqual(["A", "B"]);
+    expect(s.messages).toHaveLength(2);
   });
 
-  it("T8: a newer (higher-ts) greeting still replaces an older shown one", () => {
+  it("T8: a late duplicate does not add a third row", () => {
     let s = createInitialState();
     s = reduceEvent(s, greetingEnd("A", true, "g1", 1000));
     s = reduceEvent(s, greetingEnd("B", true, "g2", 2000));
-    expect(s.messages).toHaveLength(1);
-    expect(s.messages[0].content).toBe("B");
-    expect(s.messages[0].entryId).toBe("g2");
+    s = reduceEvent(s, greetingEnd("A", true, "g1", 1000));
+    expect(s.messages.map((m) => m.content)).toEqual(["A", "B"]);
+    expect(s.messages).toHaveLength(2);
   });
 
-  it("T9: an equal-ts greeting replaces in place (idempotent re-replay tolerant)", () => {
+  it("T9: a re-replay after a live greeting rebuilds greetings in order", () => {
     let s = createInitialState();
-    s = reduceEvent(s, greetingEnd("A", true, "g1", 1500));
-    s = reduceEvent(s, greetingEnd("A2", true, "g1b", 1500));
-    expect(s.messages).toHaveLength(1);
-    expect(s.messages[0].content).toBe("A2");
+    s = reduceEvent(s, greetingEnd("C", true, "g3", 3000));
+    // Mirror useMessageHandler's reset path for a full replay whose first seq is <= maxSeq.
+    s = createInitialState();
+    for (const event of [
+      greetingEnd("A", true, "g1", 1000),
+      greetingEnd("B", true, "g2", 2000),
+      greetingEnd("C", true, "g3", 3000),
+    ]) s = reduceEvent(s, event);
+    expect(s.messages.map((m) => m.content)).toEqual(["A", "B", "C"]);
+    expect(s.messages).toHaveLength(3);
   });
 });

--- a/packages/client/src/lib/chat/event-reducer.ts
+++ b/packages/client/src/lib/chat/event-reducer.ts
@@ -1734,7 +1734,7 @@ export function reduceEvent(
         // touches streamingTextFlushed, or runs the streaming flush (those are
         // exclusive to real assistant inferences). Built at message_end only;
         // the matching message_start is a no-op. Idempotent across re-replay via
-        // a content-stable id. See change: greet-as-assistant-message.
+        // its per-entry id. See change: greet-as-assistant-message.
         const content = Array.isArray(msg.content)
           ? msg.content
               .filter((c: any) => c?.type === "text")
@@ -1742,35 +1742,16 @@ export function reduceEvent(
               .join("")
           : String(msg.content ?? "");
         const entryId = data.entryId as string | undefined;
-        // Singleton current-state overlay (ib-greeting): a newer greeting
-        // REPLACES the prior in place via a stable id, so the opener row keeps
-        // its position and only its content/entryId advance. Non-greeting
-        // custom messages keep per-entry ids (never collapsed). See change:
-        // replace-replayed-greeting.
+        // Keep the greeting discriminator explicit, but give every greeting
+        // its own per-entry row. See change: restore-greeting-chat-continuity.
         const isGreeting = msg.customType === "ib-greeting";
-        const customId = isGreeting ? "custom-ib-greeting" : `custom-${entryId ?? next.messages.length}`;
+        const customId = isGreeting ? `custom-${entryId ?? next.messages.length}` : `custom-${entryId ?? next.messages.length}`;
         const existingIdx = next.messages.findLastIndex((m) => m.id === customId);
         if (existingIdx !== -1) {
-          // Monotonicity guard (change: harden-greeting-collapse-latest). The
-          // greeting is a singleton overlay collapsed by a STABLE id, so the
-          // replace-in-place is blind to arrival order. A live/replay race can
-          // deliver a STALE replay-snapshot greeting AFTER the newest live one
-          // (the snapshot was taken one state behind, but its events land
-          // late); a blind replace would then clobber the newer greeting and
-          // leave the head one state behind. Only advance when the incoming
-          // greeting is not older than the shown one — the NEWEST always wins
-          // regardless of arrival order. Equal ts still replaces (idempotent
-          // re-replay of the same state). Non-greeting customs keep per-entry
-          // ids, so they never collapse and are unaffected.
-          const shownTs = next.messages[existingIdx].timestamp;
-          if (isGreeting && typeof shownTs === "number" && event.timestamp < shownTs) {
-            break;
-          }
           next.messages = [...next.messages];
           next.messages[existingIdx] = {
             ...next.messages[existingIdx],
             content,
-            ...(isGreeting ? { timestamp: event.timestamp } : {}),
             ...(entryId ? { entryId } : {}),
           };
         } else {

--- a/packages/shared/src/__tests__/state-replay-custom-message.test.ts
+++ b/packages/shared/src/__tests__/state-replay-custom-message.test.ts
@@ -65,64 +65,67 @@ describe("replayEntriesAsEvents — persisted custom messages", () => {
   });
 });
 
-describe("replayEntriesAsEvents — ib-greeting singleton (change: replace-replayed-greeting)", () => {
+describe("replayEntriesAsEvents — ib-greeting chronological chat history", () => {
   function greetingEvents(events: ReturnType<typeof replayEntriesAsEvents>) {
     return events.filter((e) => (e.event.data as any).message?.customType === "ib-greeting");
   }
 
-  it("T1: three historical greetings replay as exactly one latest greeting", () => {
+  it("T1: three historical greetings replay as three chronological greeting pairs", () => {
     const events = replayEntriesAsEvents("sess-1", [
       greetingEntry("g1", "A"),
       greetingEntry("g2", "B"),
       greetingEntry("g3", "C"),
     ]);
     const ge = greetingEvents(events);
-    expect(ge.map((e) => e.event.eventType)).toEqual(["message_start", "message_end"]);
-    for (const e of ge) {
-      expect((e.event.data as any).message.content).toBe("C");
-      expect((e.event.data as any).message.customType).toBe("ib-greeting");
-      expect((e.event.data as any).entryId).toBe("g3");
-    }
+    expect(ge.map((e) => e.event.eventType)).toEqual([
+      "message_start", "message_end", "message_start", "message_end", "message_start", "message_end",
+    ]);
+    expect(ge.filter((e) => e.event.eventType === "message_end").map((e) => ({
+      content: (e.event.data as any).message.content,
+      entryId: (e.event.data as any).entryId,
+    }))).toEqual([
+      { content: "A", entryId: "g1" },
+      { content: "B", entryId: "g2" },
+      { content: "C", entryId: "g3" },
+    ]);
   });
 
-  it("T2: unrelated custom messages replay unchanged alongside a collapsed greeting", () => {
+  it("T2: unrelated custom messages replay unchanged alongside chronological greetings", () => {
     const events = replayEntriesAsEvents("sess-1", [
       greetingEntry("g1", "A"),
       customMessageEntry("c1", "note-one", true),
       greetingEntry("g2", "B"),
     ]);
-    const ge = greetingEvents(events);
-    expect(ge).toHaveLength(2); // one start + one end
-    expect((ge[0].event.data as any).message.content).toBe("B");
-
-    const noteEvents = events.filter((e) => (e.event.data as any).message?.customType === "x-note");
-    expect(noteEvents).toHaveLength(2); // its own start + end, unchanged
-    for (const e of noteEvents) {
-      expect((e.event.data as any).message.content).toBe("note-one");
-      expect((e.event.data as any).entryId).toBe("c1");
-    }
+    expect(events.filter((e) => e.event.eventType === "message_end").map((e) => ({
+      customType: (e.event.data as any).message.customType,
+      content: (e.event.data as any).message.content,
+      entryId: (e.event.data as any).entryId,
+    }))).toEqual([
+      { customType: "ib-greeting", content: "A", entryId: "g1" },
+      { customType: "x-note", content: "note-one", entryId: "c1" },
+      { customType: "ib-greeting", content: "B", entryId: "g2" },
+    ]);
   });
 
-  it("T2b: the single greeting occupies the first greeting's slot (opener, not tail)", () => {
+  it("T2b: greeting and x-note pairs stay interleaved in JSONL order", () => {
     const events = replayEntriesAsEvents("sess-1", [
       greetingEntry("g1", "A"),
       customMessageEntry("c1", "note-one", true),
       greetingEntry("g2", "B"),
     ]);
-    // The greeting pair must precede the x-note pair (first greeting was first).
-    const idxGreeting = events.findIndex((e) => (e.event.data as any).message?.customType === "ib-greeting");
-    const idxNote = events.findIndex((e) => (e.event.data as any).message?.customType === "x-note");
-    expect(idxGreeting).toBeGreaterThanOrEqual(0);
-    expect(idxNote).toBeGreaterThan(idxGreeting);
+    const messageEvents = events.filter((e) => (e.event.data as any).message);
+    expect(messageEvents.map((e) => (e.event.data as any).message.customType)).toEqual([
+      "ib-greeting", "ib-greeting", "x-note", "x-note", "ib-greeting", "ib-greeting",
+    ]);
   });
 
-  it("T3: no greeting leaves replay unchanged (no singleton handling)", () => {
+  it("T3: no greeting leaves replay unchanged", () => {
     const events = replayEntriesAsEvents("sess-1", [
       customMessageEntry("c1", "note-one", true),
       customMessageEntry("c2", "note-two", true),
     ]);
     const noteEvents = events.filter((e) => (e.event.data as any).message?.customType === "x-note");
-    expect(noteEvents).toHaveLength(4); // two entries × (start + end)
+    expect(noteEvents).toHaveLength(4);
     expect(greetingEvents(events)).toHaveLength(0);
   });
 

--- a/packages/shared/src/state-replay.ts
+++ b/packages/shared/src/state-replay.ts
@@ -43,12 +43,6 @@ export function replayEntriesAsEvents(
   // during the loop, then emitted sorted by seq so the client's idempotent
   // reduceFlowEvent rebuilds the flow card identically to the live path.
   const flowEventRecords: Array<{ seq: number; eventType: string; data: unknown; ts: number }> = [];
-  // Singleton current greeting (change: replace-replayed-greeting). Tracked
-  // during the loop, emitted once after it so replay carries only the latest
-  // authoritative greeting instead of the full historical opener stack.
-  let latestGreeting: { message: Record<string, unknown>; ts: number; entryId: string } | null = null;
-  let greetingSlot = -1;
-
   let currentModel = "";
 
   for (const entry of entries) {
@@ -86,17 +80,16 @@ export function replayEntriesAsEvents(
         content: entry.content,
         display: true,
       };
-      // ib-greeting is a singleton current-state overlay, not history: defer
-      // it and emit only the latest below. Non-greeting custom messages keep
-      // their inline per-entry emission unchanged. See change:
-      // replace-replayed-greeting.
+      // Keep the greeting discriminator explicit while emitting each greeting
+      // inline as chronological chat history. See change:
+      // restore-greeting-chat-continuity.
       if (entry.customType === "ib-greeting") {
-        if (greetingSlot === -1) greetingSlot = messages.length;
-        latestGreeting = { message: cm, ts, entryId: entry.id };
-        continue;
+        messages.push(makeEvent(sessionId, "message_start", ts, { message: cm, entryId: entry.id }));
+        messages.push(makeEvent(sessionId, "message_end", ts, { message: cm, entryId: entry.id }));
+      } else {
+        messages.push(makeEvent(sessionId, "message_start", ts, { message: cm, entryId: entry.id }));
+        messages.push(makeEvent(sessionId, "message_end", ts, { message: cm, entryId: entry.id }));
       }
-      messages.push(makeEvent(sessionId, "message_start", ts, { message: cm, entryId: entry.id }));
-      messages.push(makeEvent(sessionId, "message_end", ts, { message: cm, entryId: entry.id }));
     }
 
     if (entry.type === "message" && entry.message) {
@@ -203,19 +196,6 @@ export function replayEntriesAsEvents(
       result: "",
       isError: false,
     }));
-  }
-
-  // Emit the single latest greeting at the first greeting's slot so it stays
-  // the opener (not the tail). Earlier greetings are dropped — a greeting is
-  // replacement, not history. See change: replace-replayed-greeting.
-  if (latestGreeting) {
-    const slot = greetingSlot === -1 ? messages.length : greetingSlot;
-    messages.splice(
-      slot,
-      0,
-      makeEvent(sessionId, "message_start", latestGreeting.ts, { message: latestGreeting.message, entryId: latestGreeting.entryId }),
-      makeEvent(sessionId, "message_end", latestGreeting.ts, { message: latestGreeting.message, entryId: latestGreeting.entryId }),
-    );
   }
 
   // Emit persisted flow-run events sorted by seq (defensive: file order already


### PR DESCRIPTION
Removes the singleton greeting collapse so every persisted greeting stays visible in chronological chat order, in both the live reducer (`event-reducer.ts`) and replay (`state-replay.ts`).

Net subtraction: -136/+92. Targeted tests 19/19 green; build passed.
Full suite intentionally not run (scoped verification per instruction).