### PR TITLE
fix(restore-greeting-chat-continuity): carry custom-message details through replay

### DIFF
--- a/packages/shared/src/__tests__/state-replay-custom-message.test.ts
+++ b/packages/shared/src/__tests__/state-replay-custom-message.test.ts
@@ -135,4 +135,26 @@ describe("replayEntriesAsEvents — ib-greeting chronological chat history", () 
     expect(greetingEvents(events)).toHaveLength(0);
     expect(events).toHaveLength(0);
   });
+
+  it("T5: a persisted greeting WITH details replays carrying its details intact", () => {
+    const withDetails = { ...greetingEntry("g1", "A"), details: { state: "awaiting-approval", glyph: "clock" } };
+    const events = replayEntriesAsEvents("sess-1", [withDetails]);
+    const ge = greetingEvents(events);
+    expect(ge.map((e) => e.event.eventType)).toEqual(["message_start", "message_end"]);
+    for (const e of ge) {
+      const m = (e.event.data as any).message;
+      expect(m.customType).toBe("ib-greeting");
+      expect(m.details).toEqual({ state: "awaiting-approval", glyph: "clock" });
+    }
+  });
+
+  it("T6: a greeting WITHOUT details injects no `details` key", () => {
+    const events = replayEntriesAsEvents("sess-1", [greetingEntry("g1", "A")]);
+    const ge = greetingEvents(events);
+    expect(ge).toHaveLength(2);
+    for (const e of ge) {
+      const m = (e.event.data as any).message;
+      expect("details" in m).toBe(false);
+    }
+  });
 });

--- a/packages/shared/src/state-replay.ts
+++ b/packages/shared/src/state-replay.ts
@@ -74,12 +74,20 @@ export function replayEntriesAsEvents(
     // context-only and not shown. Distinct from type:"custom" (CustomEntry).
     // See change: greet-as-assistant-message.
     if (entry.type === "custom_message" && entry.display) {
-      const cm = {
+      const cm: Record<string, unknown> = {
         role: "custom",
         customType: entry.customType,
         content: entry.content,
         display: true,
       };
+      // Include custom-message details (e.g. the greeting's state) if present,
+      // matching the tool-details precedent below. Live delivery carries
+      // entry.details; replay must not drop it or consumers cannot render a
+      // state-derived glyph. Only added when present, so a detail-less message
+      // gains no undefined key. See change: restore-greeting-chat-continuity.
+      if (entry.details && typeof entry.details === "object") {
+        cm.details = entry.details;
+      }
       // Keep the greeting discriminator explicit while emitting each greeting
       // inline as chronological chat history. See change:
       // restore-greeting-chat-continuity.


### PR DESCRIPTION
Replay rebuilt the display `custom_message` without `entry.details`, so greetings delivered via replay lost their state and consumers could not render a state-derived glyph.

## Change
- `packages/shared/src/state-replay.ts`: add `details` to the rebuilt custom message when present, mirroring the existing tool-details precedent in the same file. Conditional, so a detail-less message gains no `undefined` key.
- Tests: greeting **with** details replays carrying them intact; greeting **without** details injects no `details` key.

## Verification
- Scoped tests: 21/21 pass.
- `pnpm run build`: green.

Scope limited to the greeting/custom-message replay path + its test — no genericization, no literal removed, no plugin move.