### PR TITLE
fix(extension): deflake the inbound-drop hot-path overhead test (median of paired ratios)

### DIFF
--- a/openspec/changes/fix-connection-inbound-drop-flake/design.md
+++ b/openspec/changes/fix-connection-inbound-drop-flake/design.md
@@ -1,21 +1,22 @@
 # Design — fix-connection-inbound-drop-flake
 
-## D1 — Median-of-interleaved-rounds (chosen)
+## D1 — Median-of-interleaved-rounds with paired per-round ratios (chosen)
 
 Run K=7 rounds; each round measures one baseline flood and one with-report
-flood back-to-back. Collect the baseline samples and with-report samples into
-separate arrays; assert `median(withReports) < max(median(baseline)*1.1,
-median(baseline)+5)`.
+flood **back-to-back**. Assert `median(withReport_i / baseline_i) < 1.1`
+OR `median(withReports) − median(baselines) < 5` (absolute floor, same OR
+shape as the original `max` bound).
 
-Why medians: a scheduler preemption inserts a one-off spike into exactly one
-sample; the median of 7 is immune to up to 3 corrupted samples. Why
-interleaved: sequential A-then-B lets slow drift (JIT tier-up, GC heap growth,
-thermal throttle) systematically penalize B; alternating A/B/A/B distributes
-drift evenly across both series.
-
-Why K=7: 3 corruptable samples per series ≈ observed CI jitter rate; K=7 keeps
-the test under ~2 s (7 × 2 × ~20 ms + connect overhead ≈ 0.6 s measured, ×5
-safety) while dominating any plausible spike pattern.
+Why paired ratios: a sustained slow window (GC phase, runner throttle)
+inflates **both** samples of a back-to-back pair equally, so the per-round
+ratio cancels window-level load entirely — cross-series medians were tried
+first and still failed 1/3 under 64-spinner contention (a slow window shifts
+the with-report series as a whole) — paired ratios passed 5/5 under the
+identical load. Why K=7: the median tolerates up to 3 corrupted rounds,
+matched to the observed CI spike rate, while keeping the test under ~1 s.
+Why the absolute floor: preserves the original bound's protection at tiny
+baselines where ratios are noisy; it is an OR fallback, so a slow window
+cannot produce a false-green (it inflates the difference too).
 
 ## D2 — Keep the budget, not a wider one
 

--- a/packages/extension/src/__tests__/connection-inbound-drop-report.test.ts
+++ b/packages/extension/src/__tests__/connection-inbound-drop-report.test.ts
@@ -246,11 +246,42 @@ describe("inbound drop reporting — hot-path overhead", () => {
     flood(2_000, () => undefined);
     flood(2_000, () => "S_self");
 
-    const baseline = flood(10_000, () => undefined);
-    const withReports = flood(10_000, () => "S_self");
+    // Median-of-interleaved-rounds with paired per-round ratios. A single
+    // sequential A/B pair is decided by whichever sample catches a scheduler
+    // preemption: CI runners failed this assertion 3/4 runs (PR #586) and on
+    // develop (run 33371420416) with the code content-invariant — the
+    // estimator, not the overhead, was the defect. Each round measures one
+    // baseline and one with-report flood back-to-back so both share the same
+    // load window; the median of the per-round ratios then cancels any
+    // window-level slowdown entirely (sustained throttling shifts baseline
+    // and with-report alike) and survives up to 3 corrupted rounds at K=7.
+    // See change: fix-connection-inbound-drop-flake.
+    const K = 7;
+    const baselines: number[] = [];
+    const withReports: number[] = [];
+    const ratios: number[] = [];
+    for (let round = 0; round < K; round++) {
+      const baseline = flood(10_000, () => undefined);
+      const withReport = flood(10_000, () => "S_self");
+      baselines.push(baseline);
+      withReports.push(withReport);
+      ratios.push(withReport / baseline);
+    }
+    const medianRatio = median(ratios);
+    const absoluteOverhead = median(withReports) - median(baselines);
 
     // The per-window bound caps reporting at 10 sends; the rest is one clock
-    // read and a counter bump.
-    expect(withReports).toBeLessThan(Math.max(baseline * 1.1, baseline + 5));
+    // read and a counter bump. Budget unchanged from the single-sample era:
+    // under 10 % relative overhead, or under +5 ms absolute (protects the
+    // assertion at tiny baselines where ratios are noisy).
+    const budgetOk = medianRatio < 1.1 || absoluteOverhead < 5;
+    expect(budgetOk, `medianRatio=${medianRatio.toFixed(3)} absoluteOverhead=${absoluteOverhead.toFixed(2)}ms`).toBe(true);
   });
 });
+
+/** Middle element of a sorted numeric copy — the robust central estimator. */
+function median(samples: number[]): number {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}


### PR DESCRIPTION
Implements OpenSpec change `fix-connection-inbound-drop-flake`.

Test-only robustness fix: the inbound-drop hot-path overhead assertion now uses the median of K=7 paired (baseline, with-report) flood rounds — 10% relative / +5 ms absolute budget unchanged. Single-sample sequential A/B failed 3/4 on CI and once on develop, content-invariantly.

Evidence: old methodology 2/3 red under 64-spinner CPU contention; new methodology 5/5 green under identical load, 10/10 clean soak, full suite 17534 passed / 0 failed.
