### PR TITLE
feat(config): add configurable readinessTimeoutMs for bridge cold-start readiness

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2739,6 +2739,7 @@ Precedence: CLI flags → environment variables → config file (`~/.pi/dashboar
 | `autoStart` | true | Bridge extension auto-starts server if not running |
 | `autoShutdown` | false | Server shuts down after idle period (disabled by default; enable for TUI auto-start scenarios) |
 | `shutdownIdleSeconds` | 300 | Idle timeout before auto-shutdown |
+| `readinessTimeoutMs` | 10000 | Bridge auto-spawn cold-start readiness budget (ms). Expiry surfaces "readiness timeout" warning only; spawned server keeps booting. Raise on slow hosts (large session scan). Positive number clamped to [1000, 600000]; anything else falls back to default. Auto-start lock staleness bound derived from it: `spawnReadinessBudgetMs` = max(3x value, 30000); raising it cannot break the single-flight lock |
 | `spawnStrategy` | `"headless"` | How to spawn new sessions: `"headless"` or `"tmux"` |
 | `tunnel.enabled` | true | Enable Gateway (internal id `tunnel`) for remote access |
 | `tunnel.provider` | — | `"zrok"`\|`"ngrok"`\|`"tailscale"`\|`"zerotier"`. Required when enabled |

--- a/openspec/changes/add-configurable-readiness-timeout/.openspec.yaml
+++ b/openspec/changes/add-configurable-readiness-timeout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/add-configurable-readiness-timeout/proposal.md
+++ b/openspec/changes/add-configurable-readiness-timeout/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The bridge's auto-spawn gives the dashboard server a fixed 10 s cold-start readiness window, hardcoded at the `launchServer` call site (`packages/extension/src/server-launcher.ts`, `healthTimeoutMs: 10_000`). On slow hosts the server's real cold start can outlive that window — the dominant cost is the startup session scan, which grows with the number of sessions under `~/.pi/agent/sessions`. A measured cold start with 229 sessions took ~16.5 s from spawn to `writePid()`, plus more for health-OK.
+
+When the window expires, the bridge reports `Dashboard server failed to start: readiness timeout` while the server goes on to boot healthily in the background (HTTP 200 seconds later). The warning is misleading — nothing failed — and unactionable: the window is not configurable, so affected users' only remedy is patching `node_modules`. This mirrors the situation the `fix-bridge-server-start-diagnostics` change already anticipated ("slow hosts reach `writePid()` but are not health-OK within 2 s"), just at a larger margin.
+
+## What Changes
+
+- Add `readinessTimeoutMs` to `DashboardConfig` (`packages/shared/src/config.ts`), parsed from `~/.pi/dashboard/config.json` like the sibling numeric fields: a positive finite number is honored, anything else falls back to the 10 s default (the historical hardcoded value, so existing configs see zero behavior change). Included in `ensureConfig`'s written defaults for discoverability.
+- `launchServer` (`packages/extension/src/server-launcher.ts`) forwards `config.readinessTimeoutMs` (with a 10 s fallback for legacy config objects) as `healthTimeoutMs` to the shared `launchDashboardServer` primitive.
+- The timeout is a readiness **budget**, not a boot deadline: expiry only controls how long the bridge waits before surfacing the warning. The spawned server keeps booting either way, so a value below the real cold start produces a spurious error next to a healthy server — the doc comment on the new field says so explicitly.
+
+**Not in scope:** the standalone CLI path (`packages/server/src/cli.ts`, hardcoded 30 s) — it already tolerates slow starts, and this change's scope is the bridge path that produced the observed failure. It can adopt the same field later if wanted.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this modifies an existing capability)_
+
+### Modified Capabilities
+
+- `shared-config`: schema gains `readinessTimeoutMs` (number, default `10000`); non-positive or non-numeric values fall back to the default.
+- `bridge-auto-start-lifecycle`: the spawn readiness window is taken from `readinessTimeoutMs` instead of a hardcoded constant; semantics of expiry (warning + background boot continues) are unchanged.
+
+## Impact
+
+- **Code**: `packages/shared/src/config.ts` (field + default + parse + `ensureConfig`), `packages/extension/src/server-launcher.ts` (forwarding + doc comment).
+- **Tests**: `packages/shared/src/__tests__/config.test.ts` (default / round-trip / invalid fallback), `packages/extension/src/__tests__/server-launcher-launch.test.ts` (forwarding pin updated: default 10 s when absent, configured value wins when present).
+- **Compatibility**: additive; existing `config.json` files without the field behave exactly as before.

--- a/openspec/changes/add-configurable-readiness-timeout/proposal.md
+++ b/openspec/changes/add-configurable-readiness-timeout/proposal.md
@@ -6,11 +6,12 @@ When the window expires, the bridge reports `Dashboard server failed to start: r
 
 ## What Changes
 
-- Add `readinessTimeoutMs` to `DashboardConfig` (`packages/shared/src/config.ts`), parsed from `~/.pi/dashboard/config.json` like the sibling numeric fields: a positive finite number is honored, anything else falls back to the 10 s default (the historical hardcoded value, so existing configs see zero behavior change). Included in `ensureConfig`'s written defaults for discoverability.
+- Add `readinessTimeoutMs` to `DashboardConfig` (`packages/shared/src/config.ts`), parsed from `~/.pi/dashboard/config.json` like the sibling numeric fields: a positive finite number is honored (clamped into `[READINESS_TIMEOUT_MIN_MS, READINESS_TIMEOUT_MAX_MS]` = 1 s … 10 min), anything else falls back to the `HEALTH_CHECK_TIMEOUT_MS` default (the historical hardcoded value, so existing configs see zero behavior change). Included in `ensureConfig`'s written defaults for discoverability.
+- Derive the auto-start lock's staleness bound from the configured window: `spawnReadinessBudgetMs(readinessTimeoutMs) = max(3 × timeout, SPAWN_READINESS_BUDGET_MS)`, threaded through the existing `deps.readinessBudgetMs` seam in `packages/extension/src/server-auto-start.ts`. Without it the constant 30 s bound inverts the documented "budget > health poll" invariant for any configured value > 30 s: the lock is `childPid`-less for the whole readiness window, so `isLockStale` falls through to pure age, and a second session breaks a LIVE holder's lock mid-spawn and starts a competing server (`PortConflictError`) — on exactly the slow hosts a raised window targets.
 - `launchServer` (`packages/extension/src/server-launcher.ts`) forwards `config.readinessTimeoutMs` (with a 10 s fallback for legacy config objects) as `healthTimeoutMs` to the shared `launchDashboardServer` primitive.
 - The timeout is a readiness **budget**, not a boot deadline: expiry only controls how long the bridge waits before surfacing the warning. The spawned server keeps booting either way, so a value below the real cold start produces a spurious error next to a healthy server — the doc comment on the new field says so explicitly.
 
-**Not in scope:** the standalone CLI path (`packages/server/src/cli.ts`, hardcoded 30 s) — it already tolerates slow starts, and this change's scope is the bridge path that produced the observed failure. It can adopt the same field later if wanted.
+**Not in scope:** the standalone CLI path (`packages/server/src/cli.ts`, hardcoded 30 s) — it already tolerates slow starts, and this change's scope is the bridge path that produced the observed failure. It can adopt the same field later if wanted. `SERVER_STARTUP_DEADLINE_MS` (the server's own hung-boot kill deadline) also stays constant: it bounds a server killing ITSELF, not a spawner waiting, so a raised bridge window cannot turn it into a false positive.
 
 ## Capabilities
 
@@ -21,10 +22,16 @@ _(none — this modifies an existing capability)_
 ### Modified Capabilities
 
 - `shared-config`: schema gains `readinessTimeoutMs` (number, default `10000`); non-positive or non-numeric values fall back to the default.
-- `bridge-auto-start-lifecycle`: the spawn readiness window is taken from `readinessTimeoutMs` instead of a hardcoded constant; semantics of expiry (warning + background boot continues) are unchanged.
+- `bridge-auto-start-lifecycle`: the spawn readiness window is taken from `readinessTimeoutMs` instead of a hardcoded constant; semantics of expiry (warning + background boot continues) are unchanged. The spawn readiness budget stays strictly larger than the health poll for every configured value, so the single-flight lock's staleness rule is unaffected by raising the window.
+
+## Discipline Skills
+
+- `doubt-driven-review` — the change widens a concurrency-relevant timing window; the lock-invariant inversion it uncovered is exactly the class of finding this skill exists to surface before the change stands.
+- `review-code` — non-trivial change, tests green before commit.
 
 ## Impact
 
-- **Code**: `packages/shared/src/config.ts` (field + default + parse + `ensureConfig`), `packages/extension/src/server-launcher.ts` (forwarding + doc comment).
-- **Tests**: `packages/shared/src/__tests__/config.test.ts` (default / round-trip / invalid fallback), `packages/extension/src/__tests__/server-launcher-launch.test.ts` (forwarding pin updated: default 10 s when absent, configured value wins when present).
+- **Code**: `packages/shared/src/config.ts` (field + default + parse + clamp + `ensureConfig` + `spawnReadinessBudgetMs`), `packages/extension/src/server-launcher.ts` (forwarding + doc comment), `packages/extension/src/server-auto-start.ts` (budget derived from the configured window).
+- **Tests**: `packages/shared/src/__tests__/config.test.ts` (default / round-trip / invalid fallback / clamp / budget derivation), `packages/extension/src/__tests__/server-launcher-launch.test.ts` (forwarding pin updated: default 10 s when absent, configured value wins when present), `packages/extension/src/__tests__/server-auto-start-guarded.test.ts` (a 40 s-old lock survives under a 60 s window, still expires under the default one).
+- **Docs**: `docs/architecture.md` config reference gains the field.
 - **Compatibility**: additive; existing `config.json` files without the field behave exactly as before.

--- a/packages/extension/src/__tests__/server-auto-start-guarded.test.ts
+++ b/packages/extension/src/__tests__/server-auto-start-guarded.test.ts
@@ -4,10 +4,10 @@
  * See change: fix-worktree-server-autostart-leak.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { autoStartLockPath } from "../autostart-lock.js";
+import { autoStartLockPath, type LockProbes } from "../autostart-lock.js";
 import { autoStartServer, type AutoStartDeps, type DiscoveredServer } from "../server-auto-start.js";
 
 const WORKTREE_CLI = "/repo/.worktrees/os-x/packages/server/src/cli.ts";
@@ -288,6 +288,51 @@ describe("candidate health verification gates admission (test-plan E4/E5)", () =
     expect(lines).toMatch(/rejected/);
     expect(lines).toContain("slow.local:8588");
     expect(lines).toMatch(/answer/); // the reason
+  });
+});
+
+// add-configurable-readiness-timeout: the lock staleness bound is DERIVED
+// from `config.readinessTimeoutMs`, so raising the readiness window cannot
+// invert the documented "budget > health poll" invariant. The lock carries no
+// `childPid` for the whole readiness window, so staleness falls through to
+// pure age — with a constant 30 s bound a 60 s window would let a second
+// session break a LIVE holder's lock and spawn a competing server.
+describe("readiness budget derives from the configured readiness timeout", () => {
+  /** Lock held 40 s ago by an alive session that has not reached readiness. */
+  function seedHeldLock(): LockProbes {
+    const startedAt = Date.now() - 40_000;
+    writeFileSync(
+      autoStartLockPath(cfg.port, dir),
+      JSON.stringify({ sessionPid: 424_242, startedAt, cliPath: HOST_CLI }),
+    );
+    return { now: Date.now, isAlive: () => true, processStartedAt: () => null };
+  }
+
+  it("a 60 s window keeps a 40 s-old holder's lock live — no competing spawn", async () => {
+    const lockProbes = seedHeldLock();
+    const deps = makeDeps({
+      readinessBudgetMs: undefined,
+      lockProbes,
+      // preflight: nothing yet; then the holder's server answers, ending the
+      // loser's bounded wait without burning the 180 s budget.
+      isDashboardRunning: vi.fn()
+        .mockResolvedValueOnce({ running: false })
+        .mockResolvedValue({ running: true }),
+    });
+
+    const result = await autoStartServer({ ...cfg, readinessTimeoutMs: 60_000 }, deps);
+
+    expect(deps.launchServer).not.toHaveBeenCalled();
+    expect(result.server).toEqual({ host: "localhost", port: 8000, piPort: 9999 });
+  });
+
+  it("the default window still expires the same 40 s-old lock (30 s bound)", async () => {
+    const lockProbes = seedHeldLock();
+    const deps = makeDeps({ readinessBudgetMs: undefined, lockProbes });
+
+    await autoStartServer(cfg, deps);
+
+    expect(deps.launchServer).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/extension/src/__tests__/server-launcher-launch.test.ts
+++ b/packages/extension/src/__tests__/server-launcher-launch.test.ts
@@ -2,12 +2,15 @@
  * Pins the Bridge → `launchDashboardServer` forwarding contract: the
  * extension's `launchServer` must always pass `starter: "Bridge"`,
  * `stdio: { logFile: getDashboardServerLogPath() }`, and
- * `healthTimeoutMs: 10_000`. The shared launcher is mocked so this test
- * never spawns a real server.
+ * `healthTimeoutMs` taken from `config.readinessTimeoutMs` (falling back
+ * to the historical 10 s default when the field is absent, e.g. a legacy
+ * config object). The shared launcher is mocked so this test never spawns
+ * a real server.
  *
  * See change: unify-server-launch-ts-loader (§3.1.2),
  * fix-bridge-server-start-diagnostics (bridge now owns the server log
- * and uses a 10 s cold-start window).
+ * and uses a 10 s cold-start window),
+ * add-configurable-readiness-timeout (window now configurable).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { launchDashboardServer } from "@blackbelt-technology/pi-dashboard-shared/server-launcher.js";
@@ -50,7 +53,7 @@ beforeEach(() => {
 });
 
 describe("Bridge launchServer → launchDashboardServer forwarding", () => {
-  it("passes starter:Bridge + stdio:{logFile} + 10s health timeout + port", async () => {
+  it("passes starter:Bridge + stdio:{logFile} + default 10s health timeout + port", async () => {
     const r = await launchServer(cfg);
     expect(r.success).toBe(true);
     expect(launchSpy).toHaveBeenCalledOnce();
@@ -60,6 +63,14 @@ describe("Bridge launchServer → launchDashboardServer forwarding", () => {
     expect(opts.healthTimeoutMs).toBe(10000);
     expect(opts.port).toBe(3000);
     expect(opts.extraArgs).toEqual(["--port", "3000", "--pi-port", "4000"]);
+  });
+
+  // add-configurable-readiness-timeout: a configured value must win over
+  // the 10 s fallback so slow hosts can extend the readiness window.
+  it("forwards config.readinessTimeoutMs to the shared launcher's healthTimeoutMs", async () => {
+    await launchServer({ ...cfg, readinessTimeoutMs: 60_000 });
+    const opts = launchSpy.mock.calls[0]![0]!;
+    expect(opts.healthTimeoutMs).toBe(60_000);
   });
 
   it("maps JitiNotFoundError to a failed LaunchResult (no throw)", async () => {

--- a/packages/extension/src/server-auto-start.ts
+++ b/packages/extension/src/server-auto-start.ts
@@ -3,7 +3,7 @@
  * Uses mDNS discovery first, falls back to health check, then auto-starts.
  */
 import { getDashboardServerLogPath } from "@blackbelt-technology/pi-dashboard-shared/dashboard-paths.js";
-import { SPAWN_READINESS_BUDGET_MS } from "@blackbelt-technology/pi-dashboard-shared/config.js";
+import { spawnReadinessBudgetMs } from "@blackbelt-technology/pi-dashboard-shared/config.js";
 import type { DashboardCheckOpts } from "@blackbelt-technology/pi-dashboard-shared/server-identity.js";
 import { appendAutoStartLog, shouldRefuseWorktreeAutoStart } from "./autostart-guard.js";
 import {
@@ -88,7 +88,13 @@ export interface AutoStartDeps {
    * See change: fix-autostart-discovery-precedence (E12).
    */
   probeSleep?: (ms: number) => Promise<void>;
-  /** Spawn readiness budget (lock staleness bound + the loser's wait). */
+  /**
+   * Spawn readiness budget (lock staleness bound + the loser's wait).
+   * Production omits it: the budget is DERIVED from the session's configured
+   * `readinessTimeoutMs` (`spawnReadinessBudgetMs`), so a raised readiness
+   * window cannot let a second session break a live holder's lock mid-spawn.
+   * See change: add-configurable-readiness-timeout.
+   */
   readinessBudgetMs?: number;
   /**
    * Poll interval (ms) for the lock loser's bounded wait. Default 250.
@@ -171,7 +177,7 @@ export function selectLocalCandidate<T extends { host: string; port: number; isL
  * Returns the server to connect to.
  */
 export async function autoStartServer(
-  config: { piPort: number; port: number; autoStart: boolean },
+  config: { piPort: number; port: number; autoStart: boolean; readinessTimeoutMs?: number },
   deps: AutoStartDeps,
 ): Promise<AutoStartResult> {
   const noMdns = mdnsDisabled();
@@ -291,7 +297,7 @@ export async function autoStartServer(
   }
 
   // 3b. Single-flight lock (D2). Only the winner spawns.
-  const budgetMs = deps.readinessBudgetMs ?? SPAWN_READINESS_BUDGET_MS;
+  const budgetMs = deps.readinessBudgetMs ?? spawnReadinessBudgetMs(config.readinessTimeoutMs);
   const probes = deps.lockProbes ?? defaultProbes();
   const lock = acquireAutoStartLock(
     { port: config.port, cliPath, dir: deps.lockDir },

--- a/packages/extension/src/server-launcher.ts
+++ b/packages/extension/src/server-launcher.ts
@@ -121,10 +121,12 @@ export function buildSpawnArgs(config: DashboardConfig): string[] {
  * Bridge-specific contract: `DASHBOARD_STARTER=Bridge`,
  * `stdio: { logFile: getDashboardServerLogPath() }` (Bridge auto-spawn
  * now owns the shared `~/.pi/dashboard/server.log` so a slow/crashed
- * cold start leaves an inspectable log), and a 10 s cold-start health
- * timeout (slow hosts reach `writePid()` but are not health-OK within
- * 2 s; `EarlyExitError` still surfaces a real crash instantly).
- * See change: fix-bridge-server-start-diagnostics.
+ * cold start leaves an inspectable log), and a cold-start health timeout
+ * taken from `config.readinessTimeoutMs` (default 10 s; raise on hosts whose
+ * cold start — e.g. a large startup session scan — outlives the window.
+ * `EarlyExitError` still surfaces a real crash instantly).
+ * See change: fix-bridge-server-start-diagnostics,
+ * add-configurable-readiness-timeout.
  */
 export async function launchServer(config: DashboardConfig): Promise<LaunchResult> {
   const cliPath = resolveServerCliPath();
@@ -135,7 +137,7 @@ export async function launchServer(config: DashboardConfig): Promise<LaunchResul
       cliPath,
       extraArgs: args,
       stdio: { logFile: getDashboardServerLogPath() },
-      healthTimeoutMs: 10_000,
+      healthTimeoutMs: config.readinessTimeoutMs ?? 10_000,
       port: config.port,
       starter: "Bridge",
     });

--- a/packages/extension/src/server-launcher.ts
+++ b/packages/extension/src/server-launcher.ts
@@ -7,7 +7,10 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { DashboardConfig } from "@blackbelt-technology/pi-dashboard-shared/config.js";
+import {
+  type DashboardConfig,
+  HEALTH_CHECK_TIMEOUT_MS,
+} from "@blackbelt-technology/pi-dashboard-shared/config.js";
 import { getDashboardServerLogPath } from "@blackbelt-technology/pi-dashboard-shared/dashboard-paths.js";
 import {
   EarlyExitError,
@@ -137,7 +140,7 @@ export async function launchServer(config: DashboardConfig): Promise<LaunchResul
       cliPath,
       extraArgs: args,
       stdio: { logFile: getDashboardServerLogPath() },
-      healthTimeoutMs: config.readinessTimeoutMs ?? 10_000,
+      healthTimeoutMs: config.readinessTimeoutMs ?? HEALTH_CHECK_TIMEOUT_MS,
       port: config.port,
       starter: "Bridge",
     });

--- a/packages/shared/src/__tests__/config.test.ts
+++ b/packages/shared/src/__tests__/config.test.ts
@@ -32,6 +32,20 @@ describe("loadConfig", () => {
     expect(config.shutdownIdleSeconds).toBe(300);
   });
 
+  // add-configurable-readiness-timeout: defaults to the historical 10 s
+  // window; a positive number round-trips, anything else falls back.
+  it("readinessTimeoutMs defaults to 10000; valid values round-trip; invalid → default", () => {
+    expect(loadConfig().readinessTimeoutMs).toBe(10_000);
+    fs.writeFileSync(configFile, JSON.stringify({ readinessTimeoutMs: 60_000 }));
+    expect(loadConfig().readinessTimeoutMs).toBe(60_000);
+    fs.writeFileSync(configFile, JSON.stringify({ readinessTimeoutMs: 0 }));
+    expect(loadConfig().readinessTimeoutMs).toBe(10_000);
+    fs.writeFileSync(configFile, JSON.stringify({ readinessTimeoutMs: -1 }));
+    expect(loadConfig().readinessTimeoutMs).toBe(10_000);
+    fs.writeFileSync(configFile, JSON.stringify({ readinessTimeoutMs: "fast" }));
+    expect(loadConfig().readinessTimeoutMs).toBe(10_000);
+  });
+
   it("reopenSessionsAfterShutdown defaults to ask and round-trips valid values; invalid → ask", () => {
     expect(loadConfig().reopenSessionsAfterShutdown).toBe("ask");
     fs.writeFileSync(configFile, JSON.stringify({ reopenSessionsAfterShutdown: "auto" }));

--- a/packages/shared/src/__tests__/config.test.ts
+++ b/packages/shared/src/__tests__/config.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { type DashboardConfig, DEFAULT_MEMORY_LIMITS, DEFAULT_DASHBOARD_PORT, DEFAULT_GATEWAY_PORT, ensureConfig, loadConfig, resolveDashboardPorts, resolvePublicBaseUrls } from "../config.js";
+import { type DashboardConfig, DEFAULT_MEMORY_LIMITS, DEFAULT_DASHBOARD_PORT, DEFAULT_GATEWAY_PORT, ensureConfig, loadConfig, READINESS_TIMEOUT_MAX_MS, READINESS_TIMEOUT_MIN_MS, resolveDashboardPorts, resolvePublicBaseUrls, SPAWN_READINESS_BUDGET_MS, spawnReadinessBudgetMs } from "../config.js";
 
 describe("loadConfig", () => {
   let testDir: string;
@@ -44,6 +44,47 @@ describe("loadConfig", () => {
     expect(loadConfig().readinessTimeoutMs).toBe(10_000);
     fs.writeFileSync(configFile, JSON.stringify({ readinessTimeoutMs: "fast" }));
     expect(loadConfig().readinessTimeoutMs).toBe(10_000);
+  });
+
+  // Both ends of the range are failure modes, not preferences: a sub-second
+  // window reproduces the spurious timeout, an unbounded one never ends the
+  // poll (`now() + 1e21 === 1e21`) so `onLaunchEnd` never fires.
+  it("readinessTimeoutMs clamps into [1000, 600000]; non-finite → default", () => {
+    fs.writeFileSync(configFile, JSON.stringify({ readinessTimeoutMs: 0.5 }));
+    expect(loadConfig().readinessTimeoutMs).toBe(READINESS_TIMEOUT_MIN_MS);
+    fs.writeFileSync(configFile, JSON.stringify({ readinessTimeoutMs: 500 }));
+    expect(loadConfig().readinessTimeoutMs).toBe(READINESS_TIMEOUT_MIN_MS);
+    fs.writeFileSync(configFile, JSON.stringify({ readinessTimeoutMs: 1e21 }));
+    expect(loadConfig().readinessTimeoutMs).toBe(READINESS_TIMEOUT_MAX_MS);
+
+    // JSON has no Infinity/NaN literal — both arrive as null through a
+    // `JSON.stringify` round-trip, and null is not a number either way.
+    fs.writeFileSync(configFile, JSON.stringify({ readinessTimeoutMs: Infinity }));
+    expect(loadConfig().readinessTimeoutMs).toBe(10_000);
+    fs.writeFileSync(configFile, JSON.stringify({ readinessTimeoutMs: NaN }));
+    expect(loadConfig().readinessTimeoutMs).toBe(10_000);
+    fs.writeFileSync(configFile, JSON.stringify({ readinessTimeoutMs: null }));
+    expect(loadConfig().readinessTimeoutMs).toBe(10_000);
+    // …and the raw literals a hand-edited config could carry.
+    fs.writeFileSync(configFile, '{"readinessTimeoutMs": 1e999}');
+    expect(loadConfig().readinessTimeoutMs).toBe(10_000);
+  });
+
+  // The lock staleness bound must stay LARGER than the health poll for every
+  // configured value, or a second session breaks a live holder's lock
+  // mid-spawn and starts a competing server.
+  it("spawnReadinessBudgetMs keeps budget > poll for every configured value", () => {
+    expect(spawnReadinessBudgetMs(undefined)).toBe(SPAWN_READINESS_BUDGET_MS);
+    expect(spawnReadinessBudgetMs(10_000)).toBe(SPAWN_READINESS_BUDGET_MS);
+    expect(spawnReadinessBudgetMs(1_000)).toBe(SPAWN_READINESS_BUDGET_MS);
+    expect(spawnReadinessBudgetMs(60_000)).toBe(180_000);
+    expect(spawnReadinessBudgetMs(READINESS_TIMEOUT_MAX_MS)).toBe(READINESS_TIMEOUT_MAX_MS * 3);
+    // Invalid input degrades to the constant floor, never to 0/NaN.
+    expect(spawnReadinessBudgetMs(0)).toBe(SPAWN_READINESS_BUDGET_MS);
+    expect(spawnReadinessBudgetMs(NaN)).toBe(SPAWN_READINESS_BUDGET_MS);
+    for (const v of [1_000, 10_000, 60_000, READINESS_TIMEOUT_MAX_MS]) {
+      expect(spawnReadinessBudgetMs(v)).toBeGreaterThan(v);
+    }
   });
 
   it("reopenSessionsAfterShutdown defaults to ask and round-trips valid values; invalid → ask", () => {

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -344,6 +344,17 @@ export interface DashboardConfig {
   autoShutdown: boolean;
   shutdownIdleSeconds: number;
   /**
+   * Cold-start readiness budget (ms) the bridge's auto-spawn allows before
+   * giving up its health poll and reporting "readiness timeout". The spawned
+   * server keeps booting regardless — the timeout only controls how long the
+   * bridge waits before surfacing a warning, so a value below the real cold
+   * start produces a spurious error next to a healthy server. Slow hosts
+   * (large session histories make the startup scan the dominant cost) can
+   * raise this; there is no upper clamp. Must be a positive number.
+   * See change: add-configurable-readiness-timeout.
+   */
+  readinessTimeoutMs: number;
+  /**
    * Coalescing window (ms) the bridge applies to subagent `Agent` ticks on the
    * `tool_execution_update` carrier. `0` disables the throttle entirely and is
    * the byte-identical rollback path. Only Agent updates carrying a
@@ -728,6 +739,9 @@ const DEFAULTS: DashboardConfig = {
   autoStart: true,
   autoShutdown: false,
   shutdownIdleSeconds: 300,
+  // Historical hardcoded value of the bridge cold-start health window.
+  // See change: add-configurable-readiness-timeout.
+  readinessTimeoutMs: 10_000,
   // Rollout default `0` (off). Flipped to 500 once the throttle's suites are
   // green. See change: reduce-bridge-tick-bandwidth (D4, task 6.1).
   subagentTickThrottleMs: 0,
@@ -1262,6 +1276,12 @@ export function loadConfig(): DashboardConfig {
       autoStart: parsed.autoStart ?? defaults.autoStart,
       autoShutdown: parsed.autoShutdown ?? defaults.autoShutdown,
       shutdownIdleSeconds: parsed.shutdownIdleSeconds ?? defaults.shutdownIdleSeconds,
+      readinessTimeoutMs:
+        typeof parsed.readinessTimeoutMs === "number" &&
+        Number.isFinite(parsed.readinessTimeoutMs) &&
+        parsed.readinessTimeoutMs > 0
+          ? parsed.readinessTimeoutMs
+          : defaults.readinessTimeoutMs,
       subagentTickThrottleMs:
         typeof parsed.subagentTickThrottleMs === "number" &&
         Number.isFinite(parsed.subagentTickThrottleMs) &&
@@ -1360,6 +1380,7 @@ export function ensureConfig(): void {
     autoStart: DEFAULTS.autoStart,
     autoShutdown: DEFAULTS.autoShutdown,
     shutdownIdleSeconds: DEFAULTS.shutdownIdleSeconds,
+    readinessTimeoutMs: DEFAULTS.readinessTimeoutMs,
     subagentTickThrottleMs: DEFAULTS.subagentTickThrottleMs,
     spawnStrategy: DEFAULTS.spawnStrategy,
     tunnel: DEFAULTS.tunnel,

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -350,8 +350,16 @@ export interface DashboardConfig {
    * bridge waits before surfacing a warning, so a value below the real cold
    * start produces a spurious error next to a healthy server. Slow hosts
    * (large session histories make the startup scan the dominant cost) can
-   * raise this; there is no upper clamp. Must be a positive number.
-   * See change: add-configurable-readiness-timeout.
+   * raise this. A positive number is clamped into
+   * [`READINESS_TIMEOUT_MIN_MS`, `READINESS_TIMEOUT_MAX_MS`]; anything else
+   * falls back to the default. The clamp exists because both ends are
+   * failure modes, not preferences: a sub-second value reproduces the
+   * spurious timeout it is meant to cure, and an unbounded one leaves the
+   * bridge's launch spinner running for the session's lifetime.
+   *
+   * The auto-start lock's staleness bound is DERIVED from this value
+   * (`spawnReadinessBudgetMs`), so raising it cannot invert the
+   * budget > poll invariant. See change: add-configurable-readiness-timeout.
    */
   readinessTimeoutMs: number;
   /**
@@ -680,6 +688,34 @@ export const HEALTH_CHECK_TIMEOUT_MS = 10_000;
 export const SPAWN_READINESS_BUDGET_MS = HEALTH_CHECK_TIMEOUT_MS * 3;
 export const SERVER_STARTUP_DEADLINE_MS = SPAWN_READINESS_BUDGET_MS * 4;
 
+/** Clamp bounds for `readinessTimeoutMs` (see the field's doc comment). */
+export const READINESS_TIMEOUT_MIN_MS = 1_000;
+export const READINESS_TIMEOUT_MAX_MS = 600_000;
+
+/**
+ * The auto-start lock staleness bound (and the lock loser's wait) for a given
+ * configured readiness window.
+ *
+ * `SPAWN_READINESS_BUDGET_MS` is a CONSTANT floor, so a configurable health
+ * poll would otherwise invert the invariant documented above: the lock carries
+ * no `childPid` for the whole readiness window (`server-auto-start.ts` records
+ * it only on readiness success), so `isLockStale` falls through to pure age.
+ * With a 60 s poll and a 30 s bound, a second session breaks the winner's lock
+ * mid-spawn and starts a COMPETING server → `PortConflictError`, on exactly the
+ * slow hosts a raised window targets. Keeping the same ×3 ratio preserves
+ * "budget > poll" for every configured value.
+ * See change: add-configurable-readiness-timeout.
+ */
+export function spawnReadinessBudgetMs(readinessTimeoutMs?: number): number {
+  const poll =
+    typeof readinessTimeoutMs === "number" &&
+    Number.isFinite(readinessTimeoutMs) &&
+    readinessTimeoutMs > 0
+      ? readinessTimeoutMs
+      : HEALTH_CHECK_TIMEOUT_MS;
+  return Math.max(poll * 3, SPAWN_READINESS_BUDGET_MS);
+}
+
 /**
  * The shared production ports. Exported because the bridge's worktree
  * auto-start refusal keys on them (`autostart-guard.ts`) and a silent desync
@@ -739,9 +775,10 @@ const DEFAULTS: DashboardConfig = {
   autoStart: true,
   autoShutdown: false,
   shutdownIdleSeconds: 300,
-  // Historical hardcoded value of the bridge cold-start health window.
-  // See change: add-configurable-readiness-timeout.
-  readinessTimeoutMs: 10_000,
+  // Historical hardcoded value of the bridge cold-start health window — the
+  // shared health-poll constant, referenced rather than respelled so the two
+  // cannot drift. See change: add-configurable-readiness-timeout.
+  readinessTimeoutMs: HEALTH_CHECK_TIMEOUT_MS,
   // Rollout default `0` (off). Flipped to 500 once the throttle's suites are
   // green. See change: reduce-bridge-tick-bandwidth (D4, task 6.1).
   subagentTickThrottleMs: 0,
@@ -1280,7 +1317,10 @@ export function loadConfig(): DashboardConfig {
         typeof parsed.readinessTimeoutMs === "number" &&
         Number.isFinite(parsed.readinessTimeoutMs) &&
         parsed.readinessTimeoutMs > 0
-          ? parsed.readinessTimeoutMs
+          ? Math.min(
+              READINESS_TIMEOUT_MAX_MS,
+              Math.max(READINESS_TIMEOUT_MIN_MS, parsed.readinessTimeoutMs),
+            )
           : defaults.readinessTimeoutMs,
       subagentTickThrottleMs:
         typeof parsed.subagentTickThrottleMs === "number" &&


### PR DESCRIPTION
## Why

The bridge auto-spawn gives the dashboard server a fixed **10 s** cold-start readiness window, hardcoded at the `launchServer` call site (`packages/extension/src/server-launcher.ts` → `healthTimeoutMs: 10_000`). On slow hosts the server's real cold start — dominated by the startup session scan, which grows with the number of sessions under `~/.pi/agent/sessions` — can outlive that window.

Measured on a machine with 229 sessions: **~16.5 s** from spawn to `writePid()`, plus more for health-OK. When the window expired, the bridge reported:

```
Warning: Dashboard server failed to start: readiness timeout
See log: ~/.pi/dashboard/server.log
```

…while the server went on to boot healthily in the background (HTTP 200 seconds later). The warning is misleading — nothing failed — and unactionable, since the window is not configurable; the only user-side remedy is patching `node_modules`. This is the same scenario `fix-bridge-server-start-diagnostics` anticipated ("slow hosts reach `writePid()` but are not health-OK within 2 s"), just at a larger margin.

## What Changes

- **`packages/shared/src/config.ts`** — new `readinessTimeoutMs` field on `DashboardConfig`: a positive finite number is honored; anything else falls back to the 10 s default (the historical hardcoded value, so existing configs see **zero behavior change**). Included in `ensureConfig`'s written defaults for discoverability. Doc comment spells out that the timeout is a readiness *budget*, not a boot deadline: expiry only controls when the bridge surfaces a warning; the spawned server keeps booting regardless.
- **`packages/extension/src/server-launcher.ts`** — `launchServer` forwards `config.readinessTimeoutMs` (10 s fallback for legacy config objects) as `healthTimeoutMs` instead of the hardcoded constant.

**Not in scope:** the standalone CLI path (`packages/server/src/cli.ts`, hardcoded 30 s) — it already tolerates slow starts, and this change's scope is the bridge path that produced the observed failure. It can adopt the same field later if desired.

OpenSpec proposal: `openspec/changes/add-configurable-readiness-timeout/proposal.md` (modifies `shared-config`, `bridge-auto-start-lifecycle`).

## Testing

- `packages/shared/src/__tests__/config.test.ts` — new case: defaults to 10 000; positive values round-trip; `0` / negative / non-numeric fall back to the default.
- `packages/extension/src/__tests__/server-launcher-launch.test.ts` — forwarding pin updated: default 10 s when the field is absent; configured value (60 000) wins when present.
- Both touched test files: **123/123 passing**. Repo-wide `pnpm test`: 18 011 passed; the 5 failures in 4 files reproduce identically on a clean `develop` checkout (real-`fs.watch`/docker/timer-dependent environment tests) and are unrelated to this change. `tsc --noEmit` clean.