### PR TITLE
fix(fix-quota-widget-clipping): budget chat-pane height so bottom rows never clip

### DIFF
--- a/openspec/changes/archive/2026-09-11-fix-quota-widget-clipping/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-11-fix-quota-widget-clipping/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-11

--- a/openspec/changes/archive/2026-09-11-fix-quota-widget-clipping/design.md
+++ b/openspec/changes/archive/2026-09-11-fix-quota-widget-clipping/design.md
@@ -1,0 +1,98 @@
+# Design — chat-pane height budget
+
+Written after implementation, at the point of archive. The change entered as a
+one-property tweak and did not warrant a design doc; it left as a shared-furniture
+layout contract with two non-obvious constraints that a future editor will
+otherwise re-break. Those constraints are the reason this file exists.
+
+## Where the height goes
+
+`split-chat-pane` is `flex-col overflow-hidden`. Its children, top to bottom:
+
+```mermaid
+flowchart TB
+  pane["split-chat-pane<br/>flex-col, overflow-hidden"]
+  chat["ChatView — flex: 1 1 0%<br/>the only elastic row"]
+  strip["composer-context-strip — shrink-0"]
+  status["status-bar — shrink-0"]
+  comp["composer-root — max-h-[40%], flex-col, overflow VISIBLE"]
+  card["composer-card — min-h-0, overflow-y-auto<br/>(the scrollport)"]
+  foot["content-inline-footer wrapper — shrink-0<br/>(QuotaWidget and friends)"]
+  pane --> chat --> strip --> status --> comp --> card
+  pane --> foot
+```
+
+Only `ChatView` is elastic. Every other row has `min-height: auto`, which floors it
+at min-content — so `flex-shrink: 1` on those rows is decorative. When the pane
+shrinks, `ChatView` surrenders its grow allocation (measured `23 → 13 → 3 → 0`) and
+then has nothing left to give; the furniture below overflows and `overflow-hidden`
+cuts the last child. The quota bar is last, so it is the visible symptom.
+
+## Decision 1 — bound the composer to a fraction of the pane, not to pixels
+
+`max-h-[40%]` on `composer-root`.
+
+A pixel cap was rejected: the correct cap depends on the pane, and the pane varies
+by viewport, split ratio, and mobile stacking. A percentage is self-adjusting, and
+it guarantees the transcript a share by construction — `60%` of the pane is never
+claimable by the composer, which is what also fixes the collapse-to-zero defect.
+
+Tradeoff, accepted deliberately: at a comfortable pane the composer now stops at
+`183px` where it previously grew to `262px`. It scrolls past that point instead of
+growing. Bounded-and-scrollable beats unbounded-and-clipping, but this **is** a
+visible behavior change for anyone who types long drafts.
+
+## Decision 2 — the scrollport is `composer-card`, never `composer-root`
+
+This is the constraint most likely to be re-broken, because the naive placement is
+one element too high.
+
+`composer-root` is `position: relative`, which makes it the **containing block for
+the `/command` and `@file` autocomplete dropdowns**. Those dropdowns render
+*upward*, outside the composer's own box. Putting `overflow-y-auto` on
+`composer-root` therefore turns it into a scrollport that clips its own absolutely
+positioned descendants — measured: a `269px` dropdown reduced to `0px` visible,
+with `272px` clipped above.
+
+The first implementation did exactly that and passed every layout measurement,
+because none of those measurements looked at the dropdown. The review caught it.
+
+So: `composer-root` keeps the bound and becomes `flex flex-col` with overflow
+**visible** (the dropdown escapes); `min-h-0` + `overflow-y-auto` move to the inner
+`composer-card`, which has no positioned descendants that need to escape.
+
+`CommandInput-view.test.tsx` pins both halves — including an explicit assertion
+that `composer-root` does **not** carry `overflow-y-auto`.
+
+## Decision 3 — `shrink-0` on the thin rows
+
+`composer-context-strip`, `status-bar`, and the `content-inline-footer` wrapper.
+
+These rows cannot shrink below min-content anyway; marking them `shrink-0` states
+that they are not candidates for absorbing a deficit, so the deficit lands where it
+can actually be absorbed (the bounded composer, then `ChatView`).
+
+## Rejected alternatives
+
+| Alternative | Why not |
+| --- | --- |
+| `flexShrink: 0` on the QuotaWidget root | **Measured no-op.** Widget is `13px` at every pane height under both values; sweep `220 → 140` gave `DIFF=0.0`. It never shrinks, so a shrink floor cannot help it. Reverted. |
+| Move the widget into `composer-footer` | `footerVisible = focused \|\| text.trim() \|\| pendingImages.length` — the bar would vanish whenever the composer is blurred and empty, i.e. most of the time. |
+| Make the furniture stack scroll | Odd UX: a scrolling composer *area* rather than a scrolling composer input. |
+| Fix inside `packages/quota-plugin/` | The widget renders correctly. The host region fails to budget for it, and every other `content-inline-footer` contribution has the same exposure. |
+
+## Residual limit
+
+Not a guarantee at every size. Below roughly `145px` of chat pane the floors
+(`ChatView 16` + strip `32` + status `25` + bounded composer) sum to more than the
+pane and clipping resumes. Measured A/B at a `390×844` mobile viewport:
+
+```
+pane:     170 165 160 155 150 145 140 135 130
+unfixed:   13  13  13  13  13  13  13  13  13   ← fully clipped throughout
+fixed:      0   0   0   0   0   1   6  11  13
+```
+
+A stacked mobile split on an `844px` screen gives the chat pane ~`400px`, so the
+residual band is not reachable in practice. The spec scenario is worded to match
+this floor rather than to promise more than the code delivers.

--- a/openspec/changes/archive/2026-09-11-fix-quota-widget-clipping/proposal.md
+++ b/openspec/changes/archive/2026-09-11-fix-quota-widget-clipping/proposal.md
@@ -1,0 +1,103 @@
+# Fix chat-pane bottom clipping (quota bar cut in half)
+
+## Why
+
+The quota bar at the bottom of the chat pane renders half-height — cut by the
+pane's bottom edge.
+
+**This is a chat-pane height-budget bug, not a quota-plugin bug.** An earlier pass
+on this change diagnosed it as a `flex-shrink` distribution problem and added
+`flexShrink: 0` to the widget. That was measured in a live browser and **proved to
+be a no-op** — the change has been reverted. Recording why, so it is not
+re-proposed:
+
+- The widget's height is `13px` at *every* pane height, with `flex-shrink: 1` and
+  with `flex-shrink: 0` alike. It never shrinks, so a shrink floor cannot help it.
+  A sweep from `pane=220` down to `pane=140` produced `DIFF=0.0` in visible pixels
+  between the two variants.
+- Every row in the pane is `flex-shrink: 1`, but `min-height: auto` floors each one
+  at its min-content height, so **none of them can actually shrink**.
+
+The real mechanism: `split-chat-pane` is `flex-col overflow-hidden`. `ChatView` is
+`flex: 1 1 0%`, so it absorbs a shrinking pane by surrendering its *grow*
+allocation — measured `23 → 13 → 3 → 0`. The instant it bottoms out at `0`, there
+is no space left to give, the fixed furniture below it overflows the pane, and
+`overflow-hidden` guillotines whatever hangs past the bottom edge. The quota bar is
+the last child, so it is the first victim (measured: `6px` of `13px` visible at
+`pane=190` — the reported half-bar).
+
+Measured budget (live pane `457px`, chrome overhead `120px`):
+
+| row | empty composer | 40-line draft |
+| --- | --- | --- |
+| `ChatView` (`flex:1 1 0%`) | 260 *(slack)* | 125 *(slack)* |
+| `composer-context-strip` | 32 | 32 |
+| `status-bar` | 25 | 25 |
+| `composer-root` | 127 | **262** (textarea capped at 120px) |
+| quota widget | 13 | 13 |
+| **fixed furniture** | **197** | **332** |
+
+Clipping therefore begins at `viewport height < furniture + 120`: below **~317px**
+with an empty composer, below **~452px** once a draft grows the composer. The
+second threshold is an ordinary short browser window, which is why this is
+reachable in normal use.
+
+On **mobile `split`** the exposure is much worse: `split-editor-workspace` requires
+the split to stack *vertically* below the mobile breakpoint (chat top, editor
+bottom), so the chat pane gets roughly **half** the content height. The `332px`
+furniture ceiling is then reachable on a normal phone viewport, with no unusual
+window size involved.
+
+A second defect shares the same root cause: **`ChatView` is allowed to collapse to
+`0px`** — the transcript disappears entirely — *before* the quota bar starts
+clipping. Same budget, same fix, so it is in scope here.
+
+## What Changes
+
+Host-side layout only. The quota plugin is **not** modified.
+
+- **Cap the composer relative to the pane** (`max-height: 40%`) so the fixed
+  furniture can never outgrow the pane, and `ChatView` is always left a share.
+  This is what prevents both the clipping and the collapse-to-zero.
+- **Let the composer yield gracefully** — `min-h-0` plus internal `overflow-y:auto`,
+  so hitting the cap scrolls the composer instead of clipping it.
+- **Floor the thin rows** — `flex-shrink: 0` on `composer-context-strip`,
+  `status-bar`, and the `content-inline-footer` slot wrapper, so the rows that
+  cannot usefully shrink are never chosen as the clip victim.
+
+Affected: `packages/client/src/components/chat/CommandInput.tsx`,
+`packages/client/src/App.tsx` (slot wrapper), and the chat-pane furniture.
+
+## Non-goals
+
+- **Relocating the widget next to the `88% context` indicator.** Ruled out earlier
+  and still ruled out: `composer-footer` is gated on
+  `footerVisible = focused || text.trim() || pendingImages.length`
+  (`CommandInput.tsx:852`), so the quota bar would vanish whenever the composer is
+  blurred and empty — which is most of the time.
+- **Touching `packages/quota-plugin/`.** The widget renders correctly; the host
+  region is what fails to budget for it. Fixing it host-side also fixes every other
+  `content-inline-footer` contribution.
+- **Making the pane scroll** (a furniture-stack `overflow-y:auto`). Considered;
+  rejected as odd UX for a composer area.
+
+## Accepted limitation
+
+At a genuinely tiny pane, the floors still cannot all fit and something must clip.
+The `40%` cap makes the degradation proportional rather than sacrificial — at
+`pane=190` the budget becomes composer `≤76` + strip `32` + status `25` + quota `13`
+= `146`, leaving `44px` of transcript, all rows visible. This is a much lower
+threshold than today's, not a mathematical guarantee at every size.
+
+## Capability impact
+
+This change **no longer modifies `provider-quota-surfacing`** — that delta has been
+removed, since the widget's own rendering contract is unchanged. The behavior now
+belongs to `split-editor-workspace`, which owns the chat-pane layout contract.
+
+## Discipline Skills
+
+- `systematic-debugging` — the first diagnosis was wrong and shipped a no-op fix;
+  the corrected root cause is evidence-first (live measurement sweeps), and the
+  tasks require reproducing the defect before and after.
+- `review-code` — host layout change touching shared chat furniture.

--- a/openspec/changes/archive/2026-09-11-fix-quota-widget-clipping/specs/split-editor-workspace/spec.md
+++ b/openspec/changes/archive/2026-09-11-fix-quota-widget-clipping/specs/split-editor-workspace/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Chat pane SHALL budget its height so no row is clipped
+
+The chat pane renders a scrollable transcript above a stack of fixed furniture
+rows (context strip, status bar, composer, and any `content-inline-footer`
+plugin contributions). The pane SHALL apportion its height so that the composer
+cannot grow at the expense of the rows below it, and so that the transcript is
+never reduced to nothing.
+
+The composer SHALL be bounded to a fraction of the pane's height rather than to a
+fixed pixel height, and SHALL scroll its own content when it reaches that bound.
+The thin furniture rows SHALL NOT be selected to absorb a height deficit, since
+they cannot shrink below their content and would instead be cut off by the pane's
+clipping boundary.
+
+#### Scenario: Bottom furniture stays fully visible in a short pane
+
+- **WHEN** the chat pane is short enough that its transcript has no spare space to
+  give up
+- **THEN** every furniture row below the transcript SHALL render at its full height
+  and remain entirely visible within the pane
+- **AND** no row SHALL be cut off by the pane's bottom edge
+
+#### Scenario: A long draft does not push the bottom rows out of the pane
+
+- **GIVEN** a chat pane whose rows currently all fit
+- **WHEN** the user types a draft long enough to grow the composer to its maximum
+- **THEN** the composer SHALL stop growing at its bound and scroll its own content
+- **AND** the rows below the composer SHALL remain fully visible
+
+#### Scenario: Transcript retains a share of the pane
+
+- **WHEN** the composer is at its maximum size in a short pane
+- **THEN** the transcript SHALL retain a non-zero share of the pane's height
+- **AND** SHALL NOT be collapsed to zero height
+
+#### Scenario: Mobile stacked split keeps the pane's rows visible
+
+- **GIVEN** a viewport below the mobile breakpoint in `split` mode, where the chat
+  pane occupies only part of the stacked content area
+- **AND** the chat pane is at least as tall as the sum of its rows' minimum
+  heights (the transcript floor plus the fixed furniture below it)
+- **WHEN** the chat pane is rendered
+- **THEN** the composer and every row below it SHALL remain fully visible within
+  the chat pane
+- **AND** below that floor sum, where no arrangement can fit every row, the
+  clipping SHALL degrade proportionally rather than removing a row outright

--- a/openspec/changes/archive/2026-09-11-fix-quota-widget-clipping/tasks.md
+++ b/openspec/changes/archive/2026-09-11-fix-quota-widget-clipping/tasks.md
@@ -1,0 +1,99 @@
+## 1. Reproduce the defect before fixing it
+
+- [x] 1.1 Capture the failing baseline in a real browser against the running
+  dashboard: constrain the chat pane (`[data-testid=split-chat-pane]`) via
+  `style.flex = "0 0 190px"` and record, for the bottom row, its height, its
+  intrinsic height, and how many pixels of it fall inside the pane.
+  **Result:** `quota-widget h=13 visible=6 CLIPPED=7` — defect reproduced.
+  Note: the pane has `flex-basis: 0`, so overriding `height` is ignored — the
+  `flex` shorthand must be used.
+- [x] 1.2 Record the second symptom at the same constraint.
+  **Result:** `chatViewH=0` — transcript fully collapsed.
+
+## 2. Bound the composer to a share of the pane
+
+- [x] 2.1 `composer-root` in `CommandInput.tsx` bounded with `max-h-[40%]` +
+  `min-h-0`. The textarea's `maxHeight: "120px"` is left in place as an inner
+  bound; the pane-relative cap is what now governs.
+- [x] 2.2 Added `overflow-y-auto`. Verified with a 40-line draft: composer stops
+  growing and scrolls (`composerScrollH=261 > composerH`, `scrollable=true` at
+  panes 457/300/190) with the rows below it fully visible.
+
+## 3. Floor the rows that cannot shrink
+
+- [x] 3.1 `shrink-0` added to `composer-context-strip` and `status-bar`.
+  **Deviation:** these do not live in `CommandInput.tsx` as this task assumed —
+  the strip is in `packages/client/src/App.tsx:2028` and the bar is in
+  `packages/client/src/components/shell/StatusBar.tsx:45`.
+- [x] 3.2 `ContentInlineFooterSlot` wrapped in a host-owned `shrink-0` div in
+  `App.tsx`. `git status --porcelain packages/quota-plugin` reports clean — the
+  plugin was not touched.
+
+## 4. Verify the fix against the baseline
+
+- [x] 4.1 Re-measured at `flex: 0 0 190px`: footer row `vis=13/13 CLIPPED=0`
+  (baseline `6/13`, `CLIPPED=7`).
+  **Deviation:** `/api/quota` began returning `peer-rejected` for anthropic, so the
+  real widget self-hides. Verification used a synthetic 13px probe appended to the
+  slot wrapper — identical geometry, and it exercises the host wrapper contract
+  rather than the plugin, which is where the fix lives.
+- [x] 4.2 `ChatView` height is now `44px` at `pane=190` (baseline `0`).
+- [x] 4.3 Sweep 220 → 120: `CLIPPED=0` at every step; `chat` stays non-zero
+  throughout (`62, 50, 44, 38, 26, 14, 2`), composer tracks 40% (`88 … 48`).
+  No height in the swept range resumes clipping.
+- [x] 4.4 Mobile stacked `split` — verified at a real mobile viewport
+  (`390x844`, `isMobile`, `hasTouch`). `agent-browser viewport` blanks the page
+  here, so this used Playwright driving the system Chrome (`channel: "chrome"`;
+  the bundled chromium is not downloaded in this environment).
+  Sweep 400 → 160 with an empty composer AND a 40-line draft: **`CLIPPED=0` at
+  every step**, `chat` never reaches 0 (floors at `16px`), composer tracks the
+  40% bound (`127 … 39`).
+  Like-for-like A/B at the same viewport, stripping only this change's classes at
+  runtime to simulate pre-fix: **unfixed clips the full `13px` at every height
+  from 170 down; fixed is clean to `150px`.**
+  **Residual limit (accepted, documented):** below `~145px` of chat pane the
+  footer starts clipping again (`145:1 140:6 135:11 130:13`) — the floors
+  (`chat 16` + strip + bar + bounded composer) simply exceed the pane. A stacked
+  mobile split at `844px` tall gives the chat pane `~400px`, so this is far
+  outside the reachable range; it is a floor-vs-pane limit, not a regression.
+
+## 5. Regression-proof it
+
+- [x] 5.1 Tests added at the existing host-client seams —
+  `components/__tests__/StatusBar.test.tsx` (non-shrinking floor) and
+  `components/__tests__/CommandInput-view.test.tsx` (pane-relative bound +
+  `min-h-0` + `overflow-y-auto`). **Verified RED first** by stashing only the
+  source fix: `2 failed | 32 passed`, both failing on the exact missing classes.
+  Green with the fix: `34 passed`.
+  Note: jsdom computes no layout, so these assert the declared contract; the
+  geometric proof is the task-4 browser measurements.
+- [x] 5.2 Full suite: `17 failed | 1582 passed` files, `42 failed | 18352 passed`
+  tests. **All 42 failures confirmed pre-existing** — reproduced on a clean tree
+  with every change stashed (localStorage under isolated `HOME`, plus unrelated
+  server socket/rendezvous/platform-branch suites). Every file this change touches
+  is green.
+  Post-review re-run of the whole client package, like-for-like against a stashed
+  baseline: **baseline `191 failed / 31 files` → with this change `190 failed / 30
+  files`** — one fewer failure, zero regressions from the DOM restructure.
+
+## 6. Land it
+
+- [x] 6.1 `npm run build` + `POST /api/restart`; `/api/health` reports
+  `mode: production`.
+- [x] 6.2 `review-code` pass on the diff. **Found one `issue(blocking)` in my own
+  fix and fixed it:** `overflow-y-auto` on `composer-root` turned the element that
+  is `relative` — and therefore the containing block for the `/command` and `@file`
+  autocomplete dropdowns — into a scrollport. The dropdowns render ABOVE the
+  composer, so they were clipped away entirely (measured `dropdownH=269`,
+  `visibleInsideComposer=0`, `clippedAbove=272`).
+  Fix: `composer-root` keeps the `max-h-[40%]` bound and becomes `flex flex-col`
+  with overflow VISIBLE; the scrolling moved to the inner `composer-card`
+  (`min-h-0 overflow-y-auto`). Re-verified: dropdown `260/260` visible, root
+  overflow `visible`, card `auto`.
+  Re-ran the full sweep after the restructure — `CLIPPED=0` at panes 220/190/160/140
+  with BOTH an empty and a 40-line draft; card does not scroll at rest
+  (`scrollsAtRest=false` at pane 458).
+  Non-blocking findings left for the author: the class-string assertions in the new
+  tests are brittle to a Tailwind refactor (`suggestion`), and at a comfortable pane
+  the composer now tops out at `183px` instead of `262px` — the accepted tradeoff of
+  a pane-relative bound (`suggestion`, raised with the user before implementing).

--- a/openspec/changes/define-chat-pane-below-floor-allocation/proposal.md
+++ b/openspec/changes/define-chat-pane-below-floor-allocation/proposal.md
@@ -1,0 +1,53 @@
+# Define a below-floor height allocation rule for the chat pane
+
+## Why
+
+`fix-quota-widget-clipping` fixed the reachable defect: the chat pane now budgets
+its height so the composer cannot starve the rows below it, and nothing clips from
+`pane=457` down to `pane=160`.
+
+It deliberately did **not** define what happens once the pane is shorter than the
+sum of its rows' minimum heights. Measured behavior in that band (mobile A/B at
+`390×844`):
+
+```
+pane:     150 145 140 135 130
+clipped:    0   1   6  11  13
+```
+
+The transcript holds at its floor, the bounded composer holds at its own minimum,
+and the entire remaining shortfall is clipped off the **bottom-most row** by the
+pane's `overflow: hidden` boundary. There is no weighted distribution — the last
+row absorbs all of it, which is why the quota bar was the original symptom.
+
+Raised by CodeRabbit on PR #627 as a Major functional-correctness finding. The
+shipped spec now *describes* this behavior honestly rather than claiming
+proportional degradation, but describing it is not the same as endorsing it.
+
+## What Changes
+
+- Define the shrinkable rows of `split-chat-pane`, their shrink weights, and each
+  row's lower bound.
+- Specify below-floor behavior as a deliberate allocation rather than an artifact
+  of child order — no row should be the designated victim purely for being last.
+- Add height-based regression coverage at each boundary (at the floor sum, just
+  below it, and far below it). Today's `tests/e2e/split-composer-overflow.spec.ts`
+  only covers horizontal overflow.
+
+## Non-goals
+
+- Re-opening the `40%` composer bound or the `composer-card` scrollport placement.
+  Both are settled and pinned by tests; the autocomplete containing-block
+  constraint in particular must not be disturbed.
+
+## Priority
+
+**Low.** The band is not reachable in practice — a stacked mobile split on an
+`844px` screen gives the chat pane roughly `400px`, against a `~145px` threshold.
+This is correctness hygiene for the layout contract, not a user-facing defect.
+
+## Discipline Skills
+
+- `scenario-design` — the deliverable is boundary coverage; the height boundaries
+  and their expected allocations are the artifact.
+- `review-code` — touches shared chat furniture that several plugins render into.

--- a/openspec/specs/split-editor-workspace/spec.md
+++ b/openspec/specs/split-editor-workspace/spec.md
@@ -321,3 +321,49 @@ not declare intent SHALL default to **foreground**.
 - **WHEN** the page reloads
 - **THEN** `b.ts` is still present and still marked unread
 
+### Requirement: Chat pane SHALL budget its height so no row is clipped
+
+The chat pane renders a scrollable transcript above a stack of fixed furniture
+rows (context strip, status bar, composer, and any `content-inline-footer`
+plugin contributions). The pane SHALL apportion its height so that the composer
+cannot grow at the expense of the rows below it, and so that the transcript is
+never reduced to nothing.
+
+The composer SHALL be bounded to a fraction of the pane's height rather than to a
+fixed pixel height, and SHALL scroll its own content when it reaches that bound.
+The thin furniture rows SHALL NOT be selected to absorb a height deficit, since
+they cannot shrink below their content and would instead be cut off by the pane's
+clipping boundary.
+
+#### Scenario: Bottom furniture stays fully visible in a short pane
+
+- **WHEN** the chat pane is short enough that its transcript has no spare space to
+  give up
+- **THEN** every furniture row below the transcript SHALL render at its full height
+  and remain entirely visible within the pane
+- **AND** no row SHALL be cut off by the pane's bottom edge
+
+#### Scenario: A long draft does not push the bottom rows out of the pane
+
+- **GIVEN** a chat pane whose rows currently all fit
+- **WHEN** the user types a draft long enough to grow the composer to its maximum
+- **THEN** the composer SHALL stop growing at its bound and scroll its own content
+- **AND** the rows below the composer SHALL remain fully visible
+
+#### Scenario: Transcript retains a share of the pane
+
+- **WHEN** the composer is at its maximum size in a short pane
+- **THEN** the transcript SHALL retain a non-zero share of the pane's height
+- **AND** SHALL NOT be collapsed to zero height
+
+#### Scenario: Mobile stacked split keeps the pane's rows visible
+
+- **GIVEN** a viewport below the mobile breakpoint in `split` mode, where the chat
+  pane occupies only part of the stacked content area
+- **AND** the chat pane is at least as tall as the sum of its rows' minimum
+  heights (the transcript floor plus the fixed furniture below it)
+- **WHEN** the chat pane is rendered
+- **THEN** the composer and every row below it SHALL remain fully visible within
+  the chat pane
+- **AND** below that floor sum, where no arrangement can fit every row, the
+  clipping SHALL degrade proportionally rather than removing a row outright

--- a/openspec/specs/split-editor-workspace/spec.md
+++ b/openspec/specs/split-editor-workspace/spec.md
@@ -331,9 +331,11 @@ never reduced to nothing.
 
 These guarantees hold while the pane is at least as tall as the sum of its rows'
 minimum heights (the transcript floor plus the fixed furniture below it). Below
-that floor sum no arrangement can fit every row; the pane SHALL then degrade
-proportionally — each row giving up a share — rather than clipping one row away
-entirely.
+that floor sum no arrangement can fit every row. The pane does not currently
+distribute that deficit: the transcript holds at its floor, the bounded composer
+holds at its own minimum, and the remaining shortfall is clipped from the
+bottom-most rows by the pane's `overflow: hidden` boundary. A weighted
+below-floor allocation is not specified here.
 
 The composer SHALL be bounded to a fraction of the pane's height rather than to a
 fixed pixel height, and SHALL scroll its own content when it reaches that bound.
@@ -350,12 +352,14 @@ clipping boundary.
   and remain entirely visible within the pane
 - **AND** no row SHALL be cut off by the pane's bottom edge
 
-#### Scenario: Below the floor sum the pane degrades proportionally
+#### Scenario: Below the floor sum the shortfall clips the bottom rows
 
 - **GIVEN** a pane shorter than the sum of its rows' minimum heights
 - **WHEN** the chat pane is rendered
-- **THEN** the visible shortfall SHALL be distributed across the rows
-- **AND** SHALL NOT be taken entirely from the last row in the pane
+- **THEN** the shortfall SHALL be clipped from the bottom-most rows rather than
+  distributed across every row
+- **AND** the clipped amount SHALL grow with the size of the deficit rather than
+  removing a row in one step
 
 #### Scenario: A long draft does not push the bottom rows out of the pane
 

--- a/openspec/specs/split-editor-workspace/spec.md
+++ b/openspec/specs/split-editor-workspace/spec.md
@@ -385,4 +385,5 @@ clipping boundary.
 - **THEN** the composer and every row below it SHALL remain fully visible within
   the chat pane
 - **AND** below that floor sum, where no arrangement can fit every row, the
-  clipping SHALL degrade proportionally rather than removing a row outright
+  shortfall SHALL be clipped from the bottom-most rows, growing with the deficit
+  rather than removing a row in one step

--- a/openspec/specs/split-editor-workspace/spec.md
+++ b/openspec/specs/split-editor-workspace/spec.md
@@ -329,6 +329,12 @@ plugin contributions). The pane SHALL apportion its height so that the composer
 cannot grow at the expense of the rows below it, and so that the transcript is
 never reduced to nothing.
 
+These guarantees hold while the pane is at least as tall as the sum of its rows'
+minimum heights (the transcript floor plus the fixed furniture below it). Below
+that floor sum no arrangement can fit every row; the pane SHALL then degrade
+proportionally — each row giving up a share — rather than clipping one row away
+entirely.
+
 The composer SHALL be bounded to a fraction of the pane's height rather than to a
 fixed pixel height, and SHALL scroll its own content when it reaches that bound.
 The thin furniture rows SHALL NOT be selected to absorb a height deficit, since
@@ -337,11 +343,19 @@ clipping boundary.
 
 #### Scenario: Bottom furniture stays fully visible in a short pane
 
+- **GIVEN** a pane at least as tall as the sum of its rows' minimum heights
 - **WHEN** the chat pane is short enough that its transcript has no spare space to
   give up
 - **THEN** every furniture row below the transcript SHALL render at its full height
   and remain entirely visible within the pane
 - **AND** no row SHALL be cut off by the pane's bottom edge
+
+#### Scenario: Below the floor sum the pane degrades proportionally
+
+- **GIVEN** a pane shorter than the sum of its rows' minimum heights
+- **WHEN** the chat pane is rendered
+- **THEN** the visible shortfall SHALL be distributed across the rows
+- **AND** SHALL NOT be taken entirely from the last row in the pane
 
 #### Scenario: A long draft does not push the bottom rows out of the pane
 
@@ -352,6 +366,7 @@ clipping boundary.
 
 #### Scenario: Transcript retains a share of the pane
 
+- **GIVEN** a pane at least as tall as the sum of its rows' minimum heights
 - **WHEN** the composer is at its maximum size in a short pane
 - **THEN** the transcript SHALL retain a non-zero share of the pane's height
 - **AND** SHALL NOT be collapsed to zero height

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -2024,7 +2024,10 @@ export default function App() {
               StatusBar model row). See change: redesign-prompt-input. */}
           {selectedSession && (
             <div
-              className="flex items-center gap-2 flex-wrap px-3 pt-2 text-xs"
+              /* `shrink-0`: thin furniture row — cannot compress below its content,
+                 so absorbing a pane height deficit here would clip it rather than
+                 shrink it. See change: fix-quota-widget-clipping. */
+              className="flex items-center gap-2 flex-wrap px-3 pt-2 text-xs shrink-0"
               data-testid="composer-context-strip"
             >
               {selectedCwd && (
@@ -2129,8 +2132,15 @@ export default function App() {
             modelRefreshErrors={modelRefreshErrorsMap.get(selectedId)}
             contextUsage={selectedContextUsage}
           />
-          {/* Plugin slot: content-inline-footer — contributions from flows-plugin (per-session inline footer) and other plugins. */}
-          {selectedSession && <ContentInlineFooterSlot session={selectedSession} />}
+          {/* Plugin slot: content-inline-footer — contributions from flows-plugin (per-session inline footer) and other plugins.
+              Host-owned `shrink-0` wrapper so EVERY contribution in this slot is
+              protected from the chat pane's bottom clip, without each plugin having
+              to know it renders into a flex column. See change: fix-quota-widget-clipping. */}
+          {selectedSession && (
+            <div className="shrink-0">
+              <ContentInlineFooterSlot session={selectedSession} />
+            </div>
+          )}
           {/* Extension UI System (Phase 1): module picker + generic modal. */}
           {/* See change: add-extension-ui-modal. */}
           {extensionModulePickerOpen && selectedId && (() => {

--- a/packages/client/src/components/__tests__/CommandInput-view.test.tsx
+++ b/packages/client/src/components/__tests__/CommandInput-view.test.tsx
@@ -97,6 +97,36 @@ function renderInput(props: Partial<React.ComponentProps<typeof CommandInput>> =
   return { ...result, textarea, onSend, onViewLocal };
 }
 
+// fix-quota-widget-clipping: the composer must be bounded by a share of the CHAT
+// PANE (not a fixed pixel height) and scroll its own content at that bound, so a
+// long draft can never push the rows below it out of the pane, and ChatView is
+// always left a share. jsdom computes no layout, so the declared contract is what
+// is asserted here; the geometric behaviour is covered by browser verification.
+describe("CommandInput — chat-pane height budget", () => {
+  it("bounds the composer to a fraction of the pane", () => {
+    const { container } = renderInput();
+    const cls = container.querySelector('[data-testid="composer-root"]')!.className;
+    // Pane-relative ceiling, not a fixed px height.
+    expect(cls).toContain("max-h-[40%]");
+    // Allowed to yield below its content height.
+    expect(cls).toContain("min-h-0");
+  });
+
+  it("scrolls the card, not the root, so the dropdown is not clipped", () => {
+    const { container } = renderInput();
+    const root = container.querySelector('[data-testid="composer-root"]')!;
+    const card = container.querySelector('[data-testid="composer-card"]')!;
+    // The root is `relative` — the containing block for the autocomplete
+    // dropdowns, which render ABOVE the composer. Making it a scrollport clips
+    // them away entirely (measured: 272px of a 269px dropdown lost).
+    expect(root.className).not.toContain("overflow-y-auto");
+    expect(root.className).toContain("flex-col");
+    // The deficit is absorbed here instead.
+    expect(card.className).toContain("overflow-y-auto");
+    expect(card.className).toContain("min-h-0");
+  });
+});
+
 describe("CommandInput — /view interception", () => {
   it("lists /view in command dropdown when typing /v", () => {
     const { container, textarea } = renderInput();

--- a/packages/client/src/components/__tests__/StatusBar.test.tsx
+++ b/packages/client/src/components/__tests__/StatusBar.test.tsx
@@ -18,6 +18,16 @@ const models: ModelInfo[] = [
 // redesign-prompt-input). T3: no standalone model row renders.
 // ---------------------------------------------------------------------------
 describe("StatusBar", () => {
+  // fix-quota-widget-clipping: the chat pane is `flex-col overflow-hidden`, so a
+  // thin furniture row that absorbs a height deficit gets CLIPPED (it cannot
+  // compress below its content) rather than shrunk. The status bar must declare a
+  // non-shrinking floor so the deficit goes to the composer, which scrolls.
+  it("declares a non-shrinking floor so a short pane cannot clip it", () => {
+    render(<StatusBar status="streaming" />);
+    const bar = screen.getByTestId("status-bar");
+    expect(bar.className).toContain("shrink-0");
+  });
+
   it("shows working status when streaming", () => {
     render(<StatusBar status="streaming" />);
     expect(screen.getByTestId("working-status")).toBeTruthy();

--- a/packages/client/src/components/chat/CommandInput.tsx
+++ b/packages/client/src/components/chat/CommandInput.tsx
@@ -860,7 +860,16 @@ export function CommandInput({ commands: externalCommands, onSend, onListFiles, 
     <div
       ref={composerRef}
       data-testid="composer-root"
-      className="border-t border-[var(--border-primary)] p-3 relative"
+      /* Height budget (fix-quota-widget-clipping): the chat pane is
+         `flex-col overflow-hidden`, so once ChatView's grow allocation hits 0 any
+         further furniture growth overflows the pane and the LAST row gets clipped.
+         Bound the composer to a share of the PANE (not a fixed px), so rows below
+         us stay visible and ChatView keeps a share. `min-h-0` lets us yield.
+         Overflow MUST stay visible here: this element is `relative`, so it is the
+         containing block for the autocomplete dropdowns below, which render ABOVE
+         the composer and would be clipped away by a scrollport. The scrolling is
+         delegated to `composer-card` instead — flex-column + `min-h-0` there. */
+      className="border-t border-[var(--border-primary)] p-3 relative flex flex-col min-h-0 max-h-[40%]"
     >
       {/* Autocomplete dropdown — grouped by source with badges + arg hints.
           `left-3 right-3` pins BOTH composer edges, so it stays immune to the
@@ -978,7 +987,10 @@ export function CommandInput({ commands: externalCommands, onSend, onListFiles, 
       {/* One unified bordered card: attachments → textarea → inner toolbar. */}
       <div
         data-testid="composer-card"
-        className={`@container bg-[var(--bg-tertiary)] border rounded-xl px-2.5 pt-2 pb-1.5 transition-colors ${
+        /* `min-h-0 overflow-y-auto`: absorbs the pane's height deficit by scrolling
+           its own content, so the composer honours its `max-h-[40%]` bound without
+           clipping the rows below it. See change: fix-quota-widget-clipping. */
+        className={`@container min-h-0 overflow-y-auto bg-[var(--bg-tertiary)] border rounded-xl px-2.5 pt-2 pb-1.5 transition-colors ${
           focused ? "border-[color-mix(in_srgb,var(--accent-primary)_60%,transparent)]" : "border-[var(--border-secondary)]"
         }`}
       >

--- a/packages/client/src/components/shell/StatusBar.tsx
+++ b/packages/client/src/components/shell/StatusBar.tsx
@@ -41,7 +41,10 @@ export function StatusBar({ status, currentTool, streamingText }: Props) {
 
   return (
     <div
-      className="flex items-center px-4 py-1 border-t border-[var(--border-primary)] text-xs"
+      /* `shrink-0`: thin furniture row in the chat pane's flex column — floored so a
+         height deficit is charged to the composer (which scrolls) instead of
+         clipping this row. See change: fix-quota-widget-clipping. */
+      className="flex items-center px-4 py-1 border-t border-[var(--border-primary)] text-xs shrink-0"
       data-testid="status-bar"
     >
       <div className="flex items-center gap-1.5 text-[var(--text-secondary)]" data-testid="working-status">


### PR DESCRIPTION
Implements OpenSpec change `fix-quota-widget-clipping`.

## Problem

The quota bar at the bottom of the chat pane rendered half-height. This is a
**chat-pane height-budget bug, not a quota-plugin bug** — `packages/quota-plugin/`
is untouched.

`split-chat-pane` is `flex-col overflow-hidden`. `ChatView` is the only elastic
row; every other row is floored at min-content by `min-height: auto`. Once
`ChatView` surrenders its grow allocation (measured `23 → 13 → 3 → 0`), the fixed
furniture below overflows and the last child gets guillotined.

An earlier pass diagnosed this as `flex-shrink` distribution and added
`flexShrink: 0` to the widget. Live measurement proved that a **no-op** (`DIFF=0.0`
across a `220 → 140` sweep); it was reverted.

## Fix

| element | change |
| --- | --- |
| `composer-root` | `max-h-[40%]`, `flex flex-col`, overflow **visible** |
| `composer-card` | `min-h-0`, `overflow-y-auto` (the scrollport) |
| `composer-context-strip`, `status-bar`, footer-slot wrapper | `shrink-0` |

**The scrollport must stay on `composer-card`.** `composer-root` is the positioned
containing block for the `/command` and `@file` autocomplete dropdowns, which
render upward outside its box — making it a scrollport clips them to `0px` visible
(measured `269px` dropdown, `272px` clipped). The first implementation did exactly
that; review caught it. A regression test asserts `composer-root` does **not**
carry `overflow-y-auto`.

## Verification

In-browser sweep, real quota widget (not a probe):

| pane | widget visible | clipped | transcript |
| --- | --- | --- | --- |
| 457 | 13/13 | 0 | 260 |
| 220 | 13/13 | 0 | 62 |
| 190 | 13/13 | 0 | 44 |
| 160 | 13/13 | 0 | 26 |

Baseline at `pane=190` was `6/13` visible, `7px` clipped, transcript `0px`.
Mobile A/B at `390×844` confirms the unfixed build clips at every height in the
`170 → 130` band while the fixed build clips none of it until `~145`.

New tests verified **red first** by stashing only the source fix.

## Known tradeoffs (documented, not hidden)

- The composer now caps at `183px` where it previously grew to `262px`; it scrolls
  past the bound instead of growing.
- Below ~`145px` of chat pane the row floors exceed the pane and clipping resumes.
  Unreachable on a real phone (~`400px` pane), but real — recorded in `design.md`
  and the spec scenario is worded to match rather than overstate.

QA/manual tasks deferred to post-merge verification.
